### PR TITLE
Auto-archive ArduPilot BIN logs to USB after each dive

### DIFF
--- a/extension/backend/src/doris/models/dive_history.py
+++ b/extension/backend/src/doris/models/dive_history.py
@@ -22,3 +22,8 @@ class DiveHistoryEntry(BaseModel):
     image_count: int = 0
     video_count: int = 0
     configuration: str = ""
+    # ArduPilot BIN log archive results (populated by services.binlog).
+    # ``bin_log_files`` is a list of media-download ids (relative to USB or
+    # DATA_ROOT) that the frontend can pass to ``/api/v1/media/download``.
+    bin_log_files: list[str] = []
+    bin_log_status: str | None = None

--- a/extension/backend/src/doris/routes/dive.py
+++ b/extension/backend/src/doris/routes/dive.py
@@ -10,6 +10,7 @@ triggering. A dive record (dive_NNNN.json) is persisted under
 DATA_ROOT/dives/.
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -18,9 +19,10 @@ from pathlib import Path
 
 from robyn import Response, Robyn
 
+from ..services import binlog
+from ..services import ip_camera_recorder as iprec
 from ..services.camera import CameraService
 from ..services.dive import DiveService
-from ..services import ip_camera_recorder as iprec
 from ..services.storage import DATA_ROOT, StorageService, media_download_id_from_abs_path
 
 logger = logging.getLogger(__name__)
@@ -72,9 +74,12 @@ def _sync_mission_state_from_vehicle(status_dict: dict) -> None:
         ms[f"{new_status}_at"] = datetime.now(tz=timezone.utc).isoformat()
         changed = True
         try:
-            _update_active_dive_record(new_status)
+            updated = _update_active_dive_record(new_status)
         except Exception as e:
             logger.warning("Failed to mark dive record %s: %s", new_status, e)
+            updated = None
+        if updated is not None:
+            _schedule_binlog_archive(updated)
     if changed:
         try:
             MISSION_STATE_PATH.write_text(json.dumps(ms, indent=2, default=str))
@@ -117,8 +122,13 @@ def _next_dive_filename() -> Path:
     return DIVES_DIR / f"dive_{highest + 1:04d}.json"
 
 
-def _update_active_dive_record(new_status: str) -> None:
-    """Find the most recent active dive record and update its status."""
+def _update_active_dive_record(new_status: str) -> Path | None:
+    """Find the most recent active dive record and update its status.
+
+    Returns the path of the dive record that was updated, or ``None`` if
+    no active dive was found.  The caller uses the returned path to
+    schedule downstream finalize work (e.g. BIN log archive).
+    """
     DIVES_DIR.mkdir(parents=True, exist_ok=True)
     pattern = re.compile(r"^dive_(\d{4})\.json$")
     dive_files = []
@@ -136,9 +146,34 @@ def _update_active_dive_record(new_status: str) -> None:
                 record["ended_at"] = datetime.now(tz=timezone.utc).isoformat()
                 dive_file.write_text(json.dumps(record, indent=2, default=str))
                 logger.info(f"Dive record updated: {dive_file.name} -> {new_status}")
-                return
+                return dive_file
         except Exception as e:
             logger.warning(f"Error reading {dive_file.name}: {e}")
+    return None
+
+
+def _schedule_binlog_archive(dive_file: Path) -> None:
+    """Fire-and-forget background BIN log archive for a finalized dive.
+
+    Picks up the dive's BIN log(s) from the firmware logs dir and copies
+    them to USB (where they'll surface in the Data tab).  Failures are
+    logged but never bubble up to the caller — finalization happens on
+    the request path and must not block on a slow USB write.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("No running loop; skipping BIN archive for %s", dive_file)
+        return
+
+    async def _runner() -> None:
+        try:
+            result = await binlog.archive_dive_bin_logs(dive_file)
+            logger.info("BIN archive (%s): %s", dive_file.name, result)
+        except Exception:
+            logger.exception("BIN archive failed for %s", dive_file)
+
+    loop.create_task(_runner())
 
 
 def _close_all_active_dive_records(new_status: str = "completed") -> int:
@@ -229,6 +264,14 @@ def register_dive_routes(app: Robyn) -> None:
             logger.info(f"Closed {stale} stale active dive record(s) before new dive")
 
         dive_file = _next_dive_filename()
+        # Snapshot the most recent ArduPilot BIN log number so that on
+        # dive end we can copy *only* the BINs created during this dive.
+        try:
+            bin_log_start_num = binlog.read_lastlog_num()
+        except Exception as e:
+            logger.warning("Failed to read ArduPilot LASTLOG.TXT at dive start: %s", e)
+            bin_log_start_num = None
+
         dive_record = {
             "dive_name": body.get("dive_name", ""),
             "username": body.get("username", ""),
@@ -239,6 +282,7 @@ def register_dive_routes(app: Robyn) -> None:
             "started_at": loaded_at.isoformat(),
             "status": "active",
             "profile_id": profile_id,
+            "bin_log_start_num": bin_log_start_num,
         }
         lat, lon = body.get("latitude"), body.get("longitude")
         if lat is not None and lon is not None:
@@ -294,10 +338,14 @@ def register_dive_routes(app: Robyn) -> None:
             logger.warning(f"Failed to stop IP camera recorder: {e}")
 
         # Update the most recent active dive record
+        updated_dive_file: Path | None = None
         try:
-            _update_active_dive_record("cancelled")
+            updated_dive_file = _update_active_dive_record("cancelled")
         except Exception as e:
             logger.warning(f"Failed to update dive record: {e}")
+
+        if updated_dive_file is not None:
+            _schedule_binlog_archive(updated_dive_file)
 
         try:
             _set_mission_terminal_status("cancelled")
@@ -435,3 +483,40 @@ def register_dive_routes(app: Robyn) -> None:
                 headers={"Content-Type": "application/json"},
             )
         return json.dumps({"success": True})
+
+    @app.post("/api/v1/dive/history/:dive_id/archive_binlogs")
+    async def dive_history_archive_binlogs(request):
+        """Re-run the BIN log archive for a past dive.
+
+        Useful when the USB drive was missing at dive end, or when the
+        operator wants a fresh copy.  Returns the same status dict the
+        background archiver writes into the dive record.
+        """
+        dive_id = request.path_params.get("dive_id", "").strip()
+        if not re.fullmatch(r"dive_\d{4}", dive_id):
+            return Response(
+                status_code=400,
+                description=json.dumps({"error": "Invalid dive id"}),
+                headers={"Content-Type": "application/json"},
+            )
+        path = DIVES_DIR / f"{dive_id}.json"
+        if not path.is_file():
+            return Response(
+                status_code=404,
+                description=json.dumps({"error": "Dive record not found"}),
+                headers={"Content-Type": "application/json"},
+            )
+        try:
+            result = await binlog.archive_dive_bin_logs(path)
+        except Exception as e:
+            logger.exception("Manual BIN archive failed for %s", dive_id)
+            return Response(
+                status_code=500,
+                description=json.dumps({"error": str(e)}),
+                headers={"Content-Type": "application/json"},
+            )
+        return Response(
+            status_code=200,
+            description=json.dumps(result, default=str),
+            headers={"Content-Type": "application/json"},
+        )

--- a/extension/backend/src/doris/services/binlog.py
+++ b/extension/backend/src/doris/services/binlog.py
@@ -1,0 +1,393 @@
+"""ArduPilot BIN log archiver.
+
+After a dive ends (completed or cancelled), copy the matching ArduPilot
+``.BIN`` log(s) from the firmware logs directory to the external USB
+drive under a dive-named filename, so they show up in the DORIS Data tab.
+
+ArduPilot writes a new ``00000NNN.BIN`` file every arm/disarm cycle and
+keeps the latest log number in ``LASTLOG.TXT``.  The Dockerfile bind-mounts
+the host's ``/root/.config/blueos/ardupilot-manager/firmware`` directory
+into the container at ``/tmp/storage/firmware``, so the BIN files are
+visible at :data:`BINLOG_DIR` ``/tmp/storage/firmware/logs``.
+
+Selection rules (see :func:`select_bin_logs_for_dive`):
+
+1. Primary: every BIN whose log number is in
+   ``[bin_log_start_num + 1, current_LASTLOG]`` (range captured at dive
+   start).  ``bin_log_start_num + 1`` because the LASTLOG read at dive
+   start is the *previous* completed log; the dive's own arm cycle bumps
+   the counter by at least one.
+2. Fallback (no ``bin_log_start_num`` recorded, e.g. a legacy dive or
+   the LASTLOG file was unreadable): every BIN whose mtime overlaps
+   ``started_at - 30s`` to ``ended_at + 60s``.
+3. Skip empty / zero-byte files in either case.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import re
+import shutil
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from . import usb_storage
+
+logger = logging.getLogger(__name__)
+
+
+BINLOG_DIR = Path(os.environ.get("DORIS_BINLOG_DIR", "/tmp/storage/firmware/logs"))
+LASTLOG_NAME = "LASTLOG.TXT"
+USB_SUBDIR = "binlogs"
+
+_BIN_RE = re.compile(r"^(\d+)\.BIN$", re.IGNORECASE)
+
+_FALLBACK_PRE_S = 30
+_FALLBACK_POST_S = 60
+
+
+# ── LASTLOG / BIN discovery ─────────────────────────────────────────
+
+
+def read_lastlog_num(logs_dir: Path | None = None) -> int | None:
+    """Return the integer in ``LASTLOG.TXT`` or ``None`` if unavailable.
+
+    ArduPilot increments this counter every arm cycle, so reading it at
+    dive start gives a stable lower bound for the dive's BIN logs.
+    """
+    base = logs_dir or BINLOG_DIR
+    p = base / LASTLOG_NAME
+    try:
+        text = p.read_text(errors="replace").strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def iter_bin_logs(
+    min_num: int | None = None,
+    max_num: int | None = None,
+    *,
+    logs_dir: Path | None = None,
+) -> Iterator[tuple[int, Path]]:
+    """Yield ``(log_num, path)`` for every numbered ``.BIN`` in the logs dir.
+
+    Filters by inclusive ``min_num`` / ``max_num`` when provided.  Skips
+    entries with non-numeric names (e.g. ``LASTLOG.TXT``).
+    """
+    base = logs_dir or BINLOG_DIR
+    try:
+        entries = list(base.iterdir())
+    except OSError:
+        return
+    for path in entries:
+        if not path.is_file():
+            continue
+        m = _BIN_RE.match(path.name)
+        if not m:
+            continue
+        try:
+            num = int(m.group(1))
+        except ValueError:
+            continue
+        if min_num is not None and num < min_num:
+            continue
+        if max_num is not None and num > max_num:
+            continue
+        yield num, path
+
+
+# ── selection ───────────────────────────────────────────────────────
+
+
+def _parse_iso_to_utc(value: object) -> datetime | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    s = s.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _bin_log_start_num(record: dict) -> int | None:
+    raw = record.get("bin_log_start_num")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def select_bin_logs_for_dive(
+    dive_record: dict,
+    *,
+    logs_dir: Path | None = None,
+) -> list[Path]:
+    """Return the ``.BIN`` files that belong to this dive, newest-first.
+
+    See module docstring for rules.  Always sorted by log number ascending.
+    Empty / unreadable files are skipped.
+    """
+    base = logs_dir or BINLOG_DIR
+
+    def _nonempty(path: Path) -> bool:
+        try:
+            return path.stat().st_size > 0
+        except OSError:
+            return False
+
+    start_num = _bin_log_start_num(dive_record)
+    current = read_lastlog_num(base)
+
+    primary: list[tuple[int, Path]] = []
+    if start_num is not None and current is not None and current > start_num:
+        primary = [
+            (n, p)
+            for n, p in iter_bin_logs(
+                min_num=start_num + 1, max_num=current, logs_dir=base
+            )
+            if _nonempty(p)
+        ]
+    if primary:
+        primary.sort(key=lambda x: x[0])
+        return [p for _, p in primary]
+
+    # Fallback: time window
+    started = _parse_iso_to_utc(dive_record.get("started_at"))
+    ended = _parse_iso_to_utc(dive_record.get("ended_at"))
+    if started is None:
+        return []
+    if ended is None or ended < started:
+        ended = datetime.now(tz=timezone.utc)
+
+    lo = started - timedelta(seconds=_FALLBACK_PRE_S)
+    hi = ended + timedelta(seconds=_FALLBACK_POST_S)
+
+    matches: list[tuple[int, Path]] = []
+    for num, path in iter_bin_logs(logs_dir=base):
+        if not _nonempty(path):
+            continue
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            continue
+        if lo <= mtime <= hi:
+            matches.append((num, path))
+    matches.sort(key=lambda x: x[0])
+    return [p for _, p in matches]
+
+
+# ── quiescence ──────────────────────────────────────────────────────
+
+
+async def wait_until_quiescent(
+    path: Path,
+    *,
+    idle_s: float = 2.0,
+    max_wait_s: float = 10.0,
+    poll_s: float = 0.5,
+) -> bool:
+    """Wait until ``path`` mtime+size stop changing for ``idle_s`` seconds.
+
+    Returns ``True`` when the file went idle, ``False`` if the budget
+    expired.  Used to avoid copying a BIN file the autopilot is still
+    writing to (the ``RECOVERY`` state is reached just before disarm).
+    """
+    deadline = asyncio.get_event_loop().time() + max_wait_s
+    last: tuple[float, int] | None = None
+    last_change = asyncio.get_event_loop().time()
+    while True:
+        try:
+            st = path.stat()
+            cur = (st.st_mtime, st.st_size)
+        except OSError:
+            return False
+        now = asyncio.get_event_loop().time()
+        if last is None or cur != last:
+            last = cur
+            last_change = now
+        elif now - last_change >= idle_s:
+            return True
+        if now >= deadline:
+            return False
+        await asyncio.sleep(poll_s)
+
+
+# ── naming ──────────────────────────────────────────────────────────
+
+
+_SLUG_BAD = re.compile(r"[^\w\s-]")
+_SLUG_SPACE = re.compile(r"[\s-]+")
+
+
+def _slug(value: str) -> str:
+    """Filename-safe lowercase slug (mirrors StorageService._slug)."""
+    s = _SLUG_BAD.sub("", value.strip().lower())
+    s = _SLUG_SPACE.sub("_", s)
+    return s
+
+
+def slug_for_dive(dive_record: dict, dive_file: Path) -> str:
+    """Slug to use as the BIN destination prefix.
+
+    Prefers ``dive_name``; falls back to the dive id stem (e.g. ``dive_0066``)
+    so the filename is never empty / ambiguous.
+    """
+    raw = str(dive_record.get("dive_name") or "").strip()
+    if raw:
+        s = _slug(raw)
+        if s:
+            return s
+    return dive_file.stem  # e.g. "dive_0066"
+
+
+def _dest_filename(slug: str, log_num: int, src_name: str) -> str:
+    """``<slug>_<orig_num>.BIN`` (always-suffix per design)."""
+    m = _BIN_RE.match(src_name)
+    num_str = m.group(1) if m else f"{log_num:08d}"
+    return f"{slug}_{num_str}.BIN"
+
+
+# ── archive ─────────────────────────────────────────────────────────
+
+
+def _set_archive_status(
+    record: dict,
+    *,
+    status: str,
+    files: list[str] | None = None,
+    error: str | None = None,
+) -> None:
+    record["bin_log_status"] = status
+    record["bin_log_copied_at"] = datetime.now(tz=timezone.utc).isoformat()
+    if files is not None:
+        record["bin_log_files"] = files
+    elif "bin_log_files" not in record:
+        record["bin_log_files"] = []
+    if error is not None:
+        record["bin_log_error"] = error
+    else:
+        record.pop("bin_log_error", None)
+
+
+def _write_record(dive_file: Path, record: dict) -> None:
+    try:
+        dive_file.write_text(json.dumps(record, indent=2, default=str))
+    except OSError as e:
+        logger.warning("Failed to write dive record %s: %s", dive_file, e)
+
+
+def _copy_one(src: Path, dest: Path) -> None:
+    """Copy ``src`` to ``dest`` preserving mtime; create parent dirs."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        shutil.copy2(src, tmp)
+        os.replace(tmp, dest)
+    finally:
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+
+
+async def archive_dive_bin_logs(
+    dive_file: Path,
+    *,
+    logs_dir: Path | None = None,
+) -> dict:
+    """Locate this dive's BIN log(s), copy them to USB, update the record.
+
+    Idempotent: re-running replaces ``bin_log_files`` / ``bin_log_status``
+    with the latest result.  Returns a JSON-friendly status dict.
+    """
+    try:
+        record = json.loads(dive_file.read_text())
+    except OSError as e:
+        logger.warning("BIN archive: cannot read %s: %s", dive_file, e)
+        return {"status": "error", "error": f"read_dive: {e}"}
+    except json.JSONDecodeError as e:
+        logger.warning("BIN archive: invalid JSON in %s: %s", dive_file, e)
+        return {"status": "error", "error": f"parse_dive: {e}"}
+
+    src_paths = select_bin_logs_for_dive(record, logs_dir=logs_dir)
+    if not src_paths:
+        logger.info("BIN archive: no matching log for %s", dive_file.name)
+        _set_archive_status(record, status="no_match", files=[])
+        _write_record(dive_file, record)
+        return {"status": "no_match", "files": []}
+
+    usb_dir = usb_storage.get_recording_dir_if_available(USB_SUBDIR)
+    if usb_dir is None:
+        logger.warning(
+            "BIN archive: USB unavailable; skipping copy for %s (%d files matched)",
+            dive_file.name,
+            len(src_paths),
+        )
+        _set_archive_status(record, status="skipped_no_usb", files=[])
+        _write_record(dive_file, record)
+        return {"status": "skipped_no_usb", "matched": len(src_paths)}
+
+    dest_root = Path(usb_dir)
+    slug = slug_for_dive(record, dive_file)
+
+    written: list[str] = []
+    last_error: str | None = None
+    for src in src_paths:
+        m = _BIN_RE.match(src.name)
+        if not m:
+            continue
+        try:
+            log_num = int(m.group(1))
+        except ValueError:
+            continue
+
+        # Wait for the autopilot to release the file before copying.
+        try:
+            await wait_until_quiescent(src)
+        except Exception as e:
+            logger.debug("Quiescence wait error for %s: %s (continuing)", src, e)
+
+        dest = dest_root / _dest_filename(slug, log_num, src.name)
+        try:
+            await asyncio.to_thread(_copy_one, src, dest)
+            try:
+                size = dest.stat().st_size
+            except OSError:
+                size = -1
+            logger.info(
+                "BIN archive: copied %s -> %s (%d bytes)", src.name, dest, size
+            )
+            written.append(str(dest))
+        except Exception as e:
+            last_error = f"{src.name}: {e}"
+            logger.exception("BIN archive: copy failed for %s", src)
+
+    if not written:
+        _set_archive_status(
+            record, status="error", files=[], error=last_error or "copy_failed"
+        )
+        _write_record(dive_file, record)
+        return {"status": "error", "error": last_error or "copy_failed"}
+
+    status = "ok" if last_error is None else "partial"
+    _set_archive_status(record, status=status, files=written, error=last_error)
+    _write_record(dive_file, record)
+    return {"status": status, "files": written, "error": last_error}

--- a/extension/backend/src/doris/services/binlog.py
+++ b/extension/backend/src/doris/services/binlog.py
@@ -18,8 +18,12 @@ Selection rules (see :func:`select_bin_logs_for_dive`):
    start is the *previous* completed log; the dive's own arm cycle bumps
    the counter by at least one.
 2. Fallback (no ``bin_log_start_num`` recorded, e.g. a legacy dive or
-   the LASTLOG file was unreadable): every BIN whose mtime overlaps
-   ``started_at - 30s`` to ``ended_at + 60s``.
+   the LASTLOG file was unreadable): pick BIN files whose *active write
+   interval* overlaps the dive window.  A BIN file ``N`` has been
+   actively written from the previous BIN's mtime (``N-1``) up to its
+   own mtime (last write before disarm), so we treat it as active
+   during ``(prev_mtime, mtime]``.  A BIN matches when this interval
+   overlaps ``[started_at - 30s, ended_at + 60s]``.
 3. Skip empty / zero-byte files in either case.
 """
 
@@ -170,7 +174,11 @@ def select_bin_logs_for_dive(
         primary.sort(key=lambda x: x[0])
         return [p for _, p in primary]
 
-    # Fallback: time window
+    # Fallback: pick BINs whose *active write interval* overlaps the dive window.
+    # A BIN's interval is (prev_BIN.mtime, this.mtime].  We can't see when a
+    # BIN started being written, so we approximate it by the previous BIN's
+    # mtime (the moment the previous arm cycle ended).  Without this, fast
+    # dives whose BIN finalizes well after the dive ended would be skipped.
     started = _parse_iso_to_utc(dive_record.get("started_at"))
     ended = _parse_iso_to_utc(dive_record.get("ended_at"))
     if started is None:
@@ -181,17 +189,30 @@ def select_bin_logs_for_dive(
     lo = started - timedelta(seconds=_FALLBACK_PRE_S)
     hi = ended + timedelta(seconds=_FALLBACK_POST_S)
 
-    matches: list[tuple[int, Path]] = []
+    bins_with_mtime: list[tuple[int, Path, datetime]] = []
     for num, path in iter_bin_logs(logs_dir=base):
         if not _nonempty(path):
             continue
         try:
-            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+            m = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
         except OSError:
             continue
-        if lo <= mtime <= hi:
+        bins_with_mtime.append((num, path, m))
+    bins_with_mtime.sort(key=lambda x: x[0])
+
+    # Build prev_mtime per BIN (by ascending num).  The "active" interval is
+    # (prev_mtime, mtime].  If there is no predecessor, treat prev_mtime as
+    # the epoch so the predicate becomes simply ``mtime > lo``.
+    epoch = datetime.fromtimestamp(0, tz=timezone.utc)
+    matches: list[tuple[int, Path]] = []
+    for idx, (num, path, mtime) in enumerate(bins_with_mtime):
+        prev_mtime = bins_with_mtime[idx - 1][2] if idx > 0 else epoch
+        # Active interval (prev_mtime, mtime] overlaps [lo, hi] iff
+        #   prev_mtime < hi  AND  mtime > lo  (using > to honour the open
+        #   lower bound -- a BIN whose mtime equals the dive start is the
+        #   PREVIOUS one).
+        if prev_mtime < hi and mtime > lo:
             matches.append((num, path))
-    matches.sort(key=lambda x: x[0])
     return [p for _, p in matches]
 
 

--- a/extension/backend/src/doris/services/storage.py
+++ b/extension/backend/src/doris/services/storage.py
@@ -402,6 +402,19 @@ def build_dive_history_list(root: Path) -> list[DiveHistoryEntry]:
         if mcap_path is not None:
             rel_mcap = media_download_id_from_abs_path(mcap_path, root)
 
+        bin_log_status: str | None = data.get("bin_log_status") or None
+        raw_bin_files = data.get("bin_log_files") or []
+        bin_log_rel: list[str] = []
+        if isinstance(raw_bin_files, list):
+            for raw in raw_bin_files:
+                try:
+                    p = Path(str(raw))
+                except (TypeError, ValueError):
+                    continue
+                rel_id = media_download_id_from_abs_path(p, root)
+                if rel_id:
+                    bin_log_rel.append(rel_id)
+
         entries.append(
             DiveHistoryEntry(
                 id=stem,
@@ -417,6 +430,8 @@ def build_dive_history_list(root: Path) -> list[DiveHistoryEntry]:
                 image_count=img,
                 video_count=vid,
                 configuration=str(data.get("configuration") or ""),
+                bin_log_files=bin_log_rel,
+                bin_log_status=bin_log_status,
             )
         )
     return entries

--- a/extension/backend/tests/test_binlog.py
+++ b/extension/backend/tests/test_binlog.py
@@ -119,21 +119,68 @@ def test_select_skips_zero_byte(tmp_path: Path) -> None:
     assert [p.name for p in paths] == ["00000051.BIN"]
 
 
-def test_select_fallback_window(tmp_path: Path) -> None:
-    """No bin_log_start_num -> fall back to mtime overlap with dive window."""
+def test_select_fallback_window_active_interval(tmp_path: Path) -> None:
+    """Without bin_log_start_num, match by *active write interval* overlap.
+
+    A BIN's interval is (prev_mtime, mtime].  Here both 71 and 72 have an
+    active interval that overlaps the dive window:
+
+      71 active (now - 2h, now - 8m]   -- arms before dive, disarms in dive
+      72 active (now - 8m, now + 5m]   -- arms in dive, disarms after
+      73 active (now + 5m, now + 1h]   -- entirely after the dive
+      Dive window (with grace): [now - 10m30s, now + 60s]
+
+    71 and 72 should be selected; 70 (active far before) and 73 (active
+    after) should be skipped.
+    """
     now = datetime.now(tz=timezone.utc)
-    _make_bin(tmp_path, 70, mtime=now - timedelta(hours=3))  # before window
-    _make_bin(tmp_path, 71, mtime=now - timedelta(minutes=5))  # in window
-    _make_bin(tmp_path, 72, mtime=now - timedelta(minutes=1))  # in window
-    _make_bin(tmp_path, 73, mtime=now + timedelta(minutes=10))  # after window+grace
+    _make_bin(tmp_path, 70, mtime=now - timedelta(hours=2))
+    _make_bin(tmp_path, 71, mtime=now - timedelta(minutes=8))
+    _make_bin(tmp_path, 72, mtime=now + timedelta(minutes=5))
+    _make_bin(tmp_path, 73, mtime=now + timedelta(hours=1))
 
     record = {
         "started_at": (now - timedelta(minutes=10)).isoformat(),
         "ended_at": now.isoformat(),
-        # No bin_log_start_num, no LASTLOG -> fallback path
     }
     paths = binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path)
     assert [p.name for p in paths] == ["00000071.BIN", "00000072.BIN"]
+
+
+def test_select_fallback_skips_pre_dive_finalized(tmp_path: Path) -> None:
+    """A BIN finalized comfortably before the dive should NOT be selected."""
+    now = datetime.now(tz=timezone.utc)
+    # 81 was finalized 1 minute before dive start -> well outside grace.
+    _make_bin(tmp_path, 80, mtime=now - timedelta(hours=1))
+    _make_bin(tmp_path, 81, mtime=now - timedelta(minutes=20))
+    _make_bin(tmp_path, 82, mtime=now + timedelta(minutes=2))
+
+    record = {
+        "started_at": (now - timedelta(minutes=10)).isoformat(),
+        "ended_at": now.isoformat(),
+    }
+    paths = binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path)
+    assert [p.name for p in paths] == ["00000082.BIN"]
+
+
+def test_select_fallback_window_multi_overlap(tmp_path: Path) -> None:
+    """A long dive that spans multiple arm/disarm cycles selects all of them."""
+    now = datetime.now(tz=timezone.utc)
+    _make_bin(tmp_path, 80, mtime=now - timedelta(minutes=20))  # finalized before dive
+    _make_bin(tmp_path, 81, mtime=now - timedelta(minutes=10))  # finalized in dive
+    _make_bin(tmp_path, 82, mtime=now - timedelta(minutes=2))   # finalized in dive
+    _make_bin(tmp_path, 83, mtime=now + timedelta(minutes=3))   # spans dive end
+
+    record = {
+        "started_at": (now - timedelta(minutes=15)).isoformat(),
+        "ended_at": now.isoformat(),
+    }
+    paths = binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path)
+    assert [p.name for p in paths] == [
+        "00000081.BIN",
+        "00000082.BIN",
+        "00000083.BIN",
+    ]
 
 
 def test_select_no_match(tmp_path: Path) -> None:

--- a/extension/backend/tests/test_binlog.py
+++ b/extension/backend/tests/test_binlog.py
@@ -1,0 +1,315 @@
+"""Tests for the BIN log archiver (services/binlog.py)."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from doris.services import binlog
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _make_bin(logs_dir: Path, num: int, *, mtime: datetime, size: int = 64) -> Path:
+    p = logs_dir / f"{num:08d}.BIN"
+    p.write_bytes(b"X" * size)
+    ts = mtime.timestamp()
+    os.utime(p, (ts, ts))
+    return p
+
+
+def _write_lastlog(logs_dir: Path, num: int) -> None:
+    (logs_dir / "LASTLOG.TXT").write_text(f"{num}\n")
+
+
+def _make_dive(
+    dive_dir: Path,
+    *,
+    name: str = "Test Dive",
+    start: datetime,
+    end: datetime | None,
+    bin_log_start_num: int | None = 100,
+    dive_id: str = "dive_0001",
+) -> Path:
+    record: dict = {
+        "dive_name": name,
+        "started_at": start.isoformat(),
+        "status": "completed",
+        "profile_id": 7,
+    }
+    if end is not None:
+        record["ended_at"] = end.isoformat()
+    if bin_log_start_num is not None:
+        record["bin_log_start_num"] = bin_log_start_num
+    p = dive_dir / f"{dive_id}.json"
+    p.write_text(json.dumps(record, indent=2))
+    return p
+
+
+# ── LASTLOG / iter_bin_logs ────────────────────────────────────────
+
+
+def test_read_lastlog_num(tmp_path: Path) -> None:
+    _write_lastlog(tmp_path, 42)
+    assert binlog.read_lastlog_num(tmp_path) == 42
+
+
+def test_read_lastlog_num_missing(tmp_path: Path) -> None:
+    assert binlog.read_lastlog_num(tmp_path) is None
+
+
+def test_read_lastlog_num_garbage(tmp_path: Path) -> None:
+    (tmp_path / "LASTLOG.TXT").write_text("not a number\n")
+    assert binlog.read_lastlog_num(tmp_path) is None
+
+
+def test_iter_bin_logs_filters_and_sorts(tmp_path: Path) -> None:
+    now = datetime.now(tz=timezone.utc)
+    for n in (10, 11, 12, 13):
+        _make_bin(tmp_path, n, mtime=now)
+    (tmp_path / "LASTLOG.TXT").write_text("13")
+    (tmp_path / "junk.txt").write_text("ignore me")
+
+    nums = sorted(n for n, _ in binlog.iter_bin_logs(logs_dir=tmp_path))
+    assert nums == [10, 11, 12, 13]
+
+    nums_range = sorted(
+        n for n, _ in binlog.iter_bin_logs(min_num=11, max_num=12, logs_dir=tmp_path)
+    )
+    assert nums_range == [11, 12]
+
+
+# ── selection ──────────────────────────────────────────────────────
+
+
+def test_select_primary_range(tmp_path: Path) -> None:
+    """When ``bin_log_start_num`` + LASTLOG bracket the dive, that range wins."""
+    now = datetime.now(tz=timezone.utc)
+    # Pre-existing log (before dive)
+    _make_bin(tmp_path, 100, mtime=now - timedelta(hours=2))
+    # The dive's logs
+    _make_bin(tmp_path, 101, mtime=now - timedelta(minutes=10))
+    _make_bin(tmp_path, 102, mtime=now - timedelta(minutes=2))
+    _write_lastlog(tmp_path, 102)
+
+    record = {
+        "started_at": (now - timedelta(minutes=15)).isoformat(),
+        "ended_at": now.isoformat(),
+        "bin_log_start_num": 100,
+    }
+    paths = binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path)
+    assert [p.name for p in paths] == ["00000101.BIN", "00000102.BIN"]
+
+
+def test_select_skips_zero_byte(tmp_path: Path) -> None:
+    now = datetime.now(tz=timezone.utc)
+    _make_bin(tmp_path, 50, mtime=now, size=0)  # empty
+    _make_bin(tmp_path, 51, mtime=now, size=128)
+    _write_lastlog(tmp_path, 51)
+    record = {
+        "started_at": (now - timedelta(minutes=5)).isoformat(),
+        "ended_at": now.isoformat(),
+        "bin_log_start_num": 49,
+    }
+    paths = binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path)
+    assert [p.name for p in paths] == ["00000051.BIN"]
+
+
+def test_select_fallback_window(tmp_path: Path) -> None:
+    """No bin_log_start_num -> fall back to mtime overlap with dive window."""
+    now = datetime.now(tz=timezone.utc)
+    _make_bin(tmp_path, 70, mtime=now - timedelta(hours=3))  # before window
+    _make_bin(tmp_path, 71, mtime=now - timedelta(minutes=5))  # in window
+    _make_bin(tmp_path, 72, mtime=now - timedelta(minutes=1))  # in window
+    _make_bin(tmp_path, 73, mtime=now + timedelta(minutes=10))  # after window+grace
+
+    record = {
+        "started_at": (now - timedelta(minutes=10)).isoformat(),
+        "ended_at": now.isoformat(),
+        # No bin_log_start_num, no LASTLOG -> fallback path
+    }
+    paths = binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path)
+    assert [p.name for p in paths] == ["00000071.BIN", "00000072.BIN"]
+
+
+def test_select_no_match(tmp_path: Path) -> None:
+    now = datetime.now(tz=timezone.utc)
+    record = {
+        "started_at": now.isoformat(),
+        "ended_at": now.isoformat(),
+        "bin_log_start_num": 5,
+    }
+    assert binlog.select_bin_logs_for_dive(record, logs_dir=tmp_path) == []
+
+
+# ── slug / naming ──────────────────────────────────────────────────
+
+
+def test_slug_for_dive_uses_dive_name(tmp_path: Path) -> None:
+    p = tmp_path / "dive_0042.json"
+    p.write_text("{}")
+    s = binlog.slug_for_dive({"dive_name": "  Hello, World!  "}, p)
+    assert s == "hello_world"
+
+
+def test_slug_for_dive_falls_back_to_id(tmp_path: Path) -> None:
+    p = tmp_path / "dive_0042.json"
+    p.write_text("{}")
+    s = binlog.slug_for_dive({"dive_name": ""}, p)
+    assert s == "dive_0042"
+
+
+def test_dest_filename_always_suffix() -> None:
+    name = binlog._dest_filename("mydive", 364, "00000364.BIN")
+    assert name == "mydive_00000364.BIN"
+
+
+# ── archive integration ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_archive_skipped_no_usb(tmp_path: Path, monkeypatch) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    dives = tmp_path / "dives"
+    dives.mkdir()
+
+    now = datetime.now(tz=timezone.utc)
+    _make_bin(logs, 11, mtime=now)
+    _write_lastlog(logs, 11)
+    dive_file = _make_dive(
+        dives,
+        start=now - timedelta(minutes=2),
+        end=now,
+        bin_log_start_num=10,
+    )
+
+    # Force USB unavailable
+    monkeypatch.setattr(
+        binlog.usb_storage, "get_recording_dir_if_available", lambda _sub: None
+    )
+
+    result = await binlog.archive_dive_bin_logs(dive_file, logs_dir=logs)
+    assert result["status"] == "skipped_no_usb"
+    record = json.loads(dive_file.read_text())
+    assert record["bin_log_status"] == "skipped_no_usb"
+    assert record["bin_log_files"] == []
+
+
+@pytest.mark.asyncio
+async def test_archive_no_match(tmp_path: Path, monkeypatch) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    dives = tmp_path / "dives"
+    dives.mkdir()
+
+    now = datetime.now(tz=timezone.utc)
+    dive_file = _make_dive(
+        dives,
+        start=now - timedelta(minutes=10),
+        end=now,
+        bin_log_start_num=999,  # no logs after this number exist
+    )
+    # USB returned but unused since no files match
+    monkeypatch.setattr(
+        binlog.usb_storage,
+        "get_recording_dir_if_available",
+        lambda _sub: str(tmp_path / "usb"),
+    )
+
+    result = await binlog.archive_dive_bin_logs(dive_file, logs_dir=logs)
+    assert result["status"] == "no_match"
+    record = json.loads(dive_file.read_text())
+    assert record["bin_log_status"] == "no_match"
+
+
+@pytest.mark.asyncio
+async def test_archive_copies_to_usb_with_dive_name_slug(
+    tmp_path: Path, monkeypatch
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    dives = tmp_path / "dives"
+    dives.mkdir()
+    usb = tmp_path / "usb_root"
+    usb.mkdir()
+
+    now = datetime.now(tz=timezone.utc)
+    src1 = _make_bin(logs, 200, mtime=now - timedelta(minutes=5), size=512)
+    src2 = _make_bin(logs, 201, mtime=now - timedelta(minutes=1), size=1024)
+    _write_lastlog(logs, 201)
+    dive_file = _make_dive(
+        dives,
+        name="Reef Survey #1",
+        start=now - timedelta(minutes=15),
+        end=now,
+        bin_log_start_num=199,
+    )
+
+    monkeypatch.setattr(
+        binlog.usb_storage,
+        "get_recording_dir_if_available",
+        lambda _sub: str(usb),
+    )
+    # Skip the quiescence wait inside copy
+    async def _instant_quiescent(*_args, **_kwargs):
+        return True
+    monkeypatch.setattr(binlog, "wait_until_quiescent", _instant_quiescent)
+
+    result = await binlog.archive_dive_bin_logs(dive_file, logs_dir=logs)
+    assert result["status"] == "ok"
+    written = sorted(Path(p).name for p in result["files"])
+    assert written == ["reef_survey_1_00000200.BIN", "reef_survey_1_00000201.BIN"]
+
+    # Mtime preserved from source
+    src_mtime = src1.stat().st_mtime
+    dst_mtime = (usb / "reef_survey_1_00000200.BIN").stat().st_mtime
+    assert abs(src_mtime - dst_mtime) < 2.0
+    # Size preserved
+    assert (usb / "reef_survey_1_00000201.BIN").stat().st_size == src2.stat().st_size
+
+    record = json.loads(dive_file.read_text())
+    assert record["bin_log_status"] == "ok"
+    assert len(record["bin_log_files"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_archive_uses_dive_id_when_name_blank(
+    tmp_path: Path, monkeypatch
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    dives = tmp_path / "dives"
+    dives.mkdir()
+    usb = tmp_path / "usb"
+    usb.mkdir()
+
+    now = datetime.now(tz=timezone.utc)
+    _make_bin(logs, 10, mtime=now)
+    _write_lastlog(logs, 10)
+    dive_file = _make_dive(
+        dives,
+        name="",
+        start=now - timedelta(minutes=2),
+        end=now,
+        bin_log_start_num=9,
+        dive_id="dive_0066",
+    )
+
+    monkeypatch.setattr(
+        binlog.usb_storage,
+        "get_recording_dir_if_available",
+        lambda _sub: str(usb),
+    )
+
+    async def _instant_quiescent(*_args, **_kwargs):
+        return True
+    monkeypatch.setattr(binlog, "wait_until_quiescent", _instant_quiescent)
+
+    result = await binlog.archive_dive_bin_logs(dive_file, logs_dir=logs)
+    assert result["status"] == "ok"
+    assert (usb / "dive_0066_00000010.BIN").exists()

--- a/extension/frontend/src/components/MediaManager.vue
+++ b/extension/frontend/src/components/MediaManager.vue
@@ -48,11 +48,13 @@ function formatFileSize(bytes: number): string {
   return `${bytes} B`
 }
 
-function mapMediaType(mediaType: string): DisplayFile['type'] {
+function mapMediaType(mediaType: string, filename: string = ''): DisplayFile['type'] {
   if (mediaType === 'video') return 'video'
   if (mediaType === 'image') return 'image'
-  if (mediaType === 'data') return 'sensor'
   if (mediaType === 'system') return 'system'
+  // ArduPilot BIN logs land in the data bucket but render better as "log".
+  if (filename.toLowerCase().endsWith('.bin')) return 'log'
+  if (mediaType === 'data') return 'sensor'
   return 'log'
 }
 
@@ -88,7 +90,7 @@ const mediaFiles = computed<DisplayFile[]>(() => {
     return {
       id: f.id,
       fileName: f.filename,
-      type: mapMediaType(f.media_type),
+      type: mapMediaType(f.media_type, f.filename),
       diveName: (f.dive_name && f.dive_name.trim()) ? f.dive_name.trim() : '—',
       datePart,
       timePart,
@@ -327,6 +329,7 @@ const handlePageChange = (page: number) => {
               {{ mediaFiles.filter((f: DisplayFile) => f.type === 'video').length }} videos,
               {{ mediaFiles.filter((f: DisplayFile) => f.type === 'image').length }} images,
               {{ mediaFiles.filter((f: DisplayFile) => f.type === 'sensor').length }} sensor,
+              {{ mediaFiles.filter((f: DisplayFile) => f.type === 'log').length }} logs,
               {{ mediaFiles.filter((f: DisplayFile) => f.type === 'system').length }} system
             </p>
           </div>


### PR DESCRIPTION
## Summary

- After every dive (natural completion or `/dive/stop`), copy the matching ArduPilot `.BIN` log(s) from `/tmp/storage/firmware/logs/` to `/mnt/usb/DORIS/binlogs/<slug>_<orig_num>.BIN`, preserving mtime so the existing media scanner picks them up in the Data tab.
- New `services/binlog.py`: read `LASTLOG.TXT`, select BINs by log-number range (primary) or active-write-interval overlap with the dive window (fallback), wait for the autopilot to release the file, then copy. Records `bin_log_files` / `bin_log_status` / `bin_log_copied_at` on the dive JSON. Idempotent.
- `routes/dive.py`: capture `bin_log_start_num` at `/dive/start`; fire-and-forget archive on completed/cancelled. Adds `POST /api/v1/dive/history/:dive_id/archive_binlogs` for manual re-runs (e.g. when USB was missing).
- `DiveHistoryEntry` + `build_dive_history_list` expose `bin_log_files` / `bin_log_status` to the Previous Dives UI.
- `MediaManager.vue` tags `.BIN` files with the existing yellow `log` style and adds a logs counter.
- 17 new unit tests cover selection, slug/naming, USB-missing fallback, and copy.

## Test plan

- [x] `pytest tests/` green (27 passing).
- [x] Live dry-run on 192.168.1.73: archived `dive_0064` -> `/mnt/usb/DORIS/binlogs/live_verify_test_00000359.BIN` (138 MB), source mtime preserved, dive record updated, file visible via `/api/v1/media/files`.
- [ ] Full SITL dive on a fresh deploy: confirm `bin_log_start_num` is captured at `/dive/start`, `bin_log_files` populated post-dive, file shows in the Data tab tagged with the dive name.


Made with [Cursor](https://cursor.com)