### PR TITLE
fix(wifi): make hotspot rename + 5 GHz patch actually work on v1-only BlueOS

### DIFF
--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -82,6 +82,7 @@ Note on ``sudo``: the BlueOS Commander API's shell PATH does not include
 through ``sudo`` (which resets the PATH).
 """
 
+import base64
 import json
 import logging
 
@@ -170,32 +171,86 @@ async def _run_host_command(command: str, timeout: float = 30.0) -> tuple[bool, 
 
 
 async def _read_host_file(path: str) -> str | None:
-    """Return the contents of a host file, or None if it doesn't exist."""
-    ok, out = await _run_host_command(f"cat {path} 2>/dev/null")
+    """Return the contents of a host file, or None if it doesn't exist.
+
+    Uses ``sudo cat`` so we can read root-owned config like
+    ``/root/.config/blueos/bootstrap/startup.json`` - Commander runs as
+    ``pi``, so a bare ``cat`` returns empty/EACCES on such files and we'd
+    incorrectly conclude the file doesn't exist.
+    """
+    ok, out = await _run_host_command(f"sudo cat {path} 2>/dev/null")
     return out if ok else None
+
+
+# Max number of base64 chars per chunk-append command. nginx in front of
+# Commander caps the request URI around 8 KB; the chunk lives inside a
+# ``printf %s '...' >> /tmp/...`` shell command plus the
+# ``i_know_what_i_am_doing`` flag, both of which inflate further under
+# URL-encoding. 2000 keeps comfortable headroom.
+_HOSTFILE_CHUNK_SIZE = 2000
+_HOSTFILE_STAGING = "/tmp/.doris_hostfile_stage"
 
 
 async def _write_host_file(path: str, content: str) -> bool:
     """Write *content* to *path* on the host atomically.
 
-    Skips the write if the existing file already has the same content,
-    avoiding unnecessary inotify churn.
+    Streams the payload as base64 in small chunks appended to a staging
+    file, then atomically renames into place under ``sudo``. The previous
+    implementation used a single ``sudo tee <<HEREDOC`` shell command sent
+    through the Commander API's query string, which hit nginx's request
+    URI length limit (around 8 KB) for anything bigger than a few KB and
+    silently failed with HTTP 400 - notably the ~25 KB patched
+    ``networkmanager.py``. Chunked base64 keeps each request well under
+    the limit and works for any file size.
+
+    Skips the write entirely if the destination already has the same
+    content, avoiding unnecessary inotify churn.
     """
     existing = await _read_host_file(path)
     if existing is not None and existing.strip() == content.strip():
         logger.info("Host file %s already up to date, skipping", path)
         return True
 
-    # Use a heredoc with a unique sentinel to avoid quote-escaping headaches.
-    sentinel = "DORIS_HOSTFILE_EOF"
-    cmd = (
-        f"sudo tee {path} > /dev/null <<'{sentinel}'\n"
-        f"{content}"
-        f"{sentinel}\n"
+    encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    total_chunks = (len(encoded) + _HOSTFILE_CHUNK_SIZE - 1) // _HOSTFILE_CHUNK_SIZE
+
+    ok, _ = await _run_host_command(f"true > {_HOSTFILE_STAGING}")
+    if not ok:
+        logger.warning("Could not truncate staging file %s", _HOSTFILE_STAGING)
+        return False
+
+    for idx in range(total_chunks):
+        chunk = encoded[idx * _HOSTFILE_CHUNK_SIZE : (idx + 1) * _HOSTFILE_CHUNK_SIZE]
+        # Base64 alphabet is shell-safe, so single-quoting the chunk is
+        # sufficient escaping; no embedded quotes possible.
+        ok, _ = await _run_host_command(
+            f"printf %s '{chunk}' >> {_HOSTFILE_STAGING}"
+        )
+        if not ok:
+            logger.warning(
+                "Chunk %d/%d failed while writing %s; aborting",
+                idx + 1, total_chunks, path,
+            )
+            await _run_host_command(f"rm -f {_HOSTFILE_STAGING}")
+            return False
+
+    # Atomic install: decode-to-temp, rename, clean up staging. The
+    # redirect must live inside the sudo'd shell so root owns the target.
+    final_cmd = (
+        f"sudo bash -c 'base64 -d {_HOSTFILE_STAGING} > {path}.doris.tmp"
+        f" && mv {path}.doris.tmp {path}"
+        f" && rm -f {_HOSTFILE_STAGING}'"
     )
-    ok, _ = await _run_host_command(cmd)
+    ok, _ = await _run_host_command(final_cmd)
     if ok:
-        logger.info("Wrote %s on host (%d bytes)", path, len(content))
+        logger.info(
+            "Wrote %s on host (%d bytes via %d base64 chunks)",
+            path, len(content), total_chunks,
+        )
+    else:
+        await _run_host_command(
+            f"sudo rm -f {_HOSTFILE_STAGING} {path}.doris.tmp"
+        )
     return ok
 
 

--- a/extension/backend/src/doris/services/network.py
+++ b/extension/backend/src/doris/services/network.py
@@ -283,7 +283,12 @@ class NetworkService:
 
         interfaces_data = await self._client.list_interfaces()
         if not interfaces_data:
-            logger.warning("No WiFi interfaces found (v2 API unavailable)")
+            # BlueOS WiFi Manager v2 is not available on this build
+            # (e.g. blueos-core 1.5.0-beta.36 ships v1 only). The v2 path
+            # below uses per-interface mode/hotspot APIs that don't exist
+            # in v1, so all we can do is rename the global hotspot SSID
+            # and restart the AP via v1.
+            await self._configure_hotspot_v1(ssid, password)
             return
 
         interfaces = interfaces_data.get("interfaces", [])
@@ -340,6 +345,51 @@ class NetworkService:
 
         # -- ensure the secondary is in hotspot (or dual) mode --
         await self._ensure_secondary_hotspot(iface_name)
+
+    async def _configure_hotspot_v1(self, ssid: str, password: str) -> None:
+        """Rename the global BlueOS hotspot via the v1 WiFi Manager API.
+
+        Used when v2 is unavailable. v1 has no concept of per-interface
+        hotspots, so we just retarget the single global hotspot. If the
+        SSID already matches, we skip the toggle so we don't interrupt
+        connected clients on every backend restart.
+        """
+        try:
+            current = await self._client.get_hotspot_credentials()
+            current_ssid = current.get("ssid") if isinstance(current, dict) else None
+        except Exception as e:
+            logger.warning("v1 hotspot: failed to read current credentials: %s", e)
+            current_ssid = None
+
+        if current_ssid == ssid:
+            logger.info("Hotspot SSID already %r (v1 path), nothing to do", ssid)
+            return
+
+        logger.info(
+            "Renaming hotspot via v1 API: %r -> %r (BlueOS v2 unavailable)",
+            current_ssid, ssid,
+        )
+
+        try:
+            await self._client.set_hotspot_credentials(ssid, password)
+        except Exception as e:
+            logger.warning("v1 hotspot: set_hotspot_credentials failed: %s", e)
+            return
+
+        try:
+            if await self._client.get_smart_hotspot():
+                await self._client.set_smart_hotspot(False)
+                logger.info("Smart hotspot disabled (v1 path)")
+        except Exception as e:
+            logger.debug("v1 hotspot: smart_hotspot check failed: %s", e)
+
+        try:
+            await self._client.set_hotspot(False)
+            await asyncio.sleep(3)
+            await self._client.set_hotspot(True)
+            logger.info("Hotspot restarted via v1; broadcasting %r", ssid)
+        except Exception as e:
+            logger.warning("v1 hotspot: toggle failed (creds set but not applied): %s", e)
 
     async def _is_hotspot_actually_running(self, iface_name: str) -> bool:
         """Check if the AP is genuinely serving, not just labelled 'hotspot'."""


### PR DESCRIPTION
## Summary

Fixes three latent WiFi/AP bugs that together prevented the DORIS hotspot from coming up correctly on BlueOS 1.5.0-beta.36. After this branch and a reboot, the AP comes up as `DORIS (<serial>)` on the Realtek USB radio at 5 GHz / 802.11ac (with `--country US`) instead of the default `BlueOS (<serial>)` on 2.4 GHz / 802.11g.

### Bug 1 — `network.py::configure_hotspot()` silently no-ops on v1-only BlueOS

`NetworkService.configure_hotspot()` previously bailed out whenever the BlueOS WiFi Manager v2 API returned nothing, so on builds that still only ship v1 (e.g. `blueos-core 1.5.0-beta.36`) the SSID never got renamed - the AP stayed as the default `BlueOS (<serial>)`, no error surfaced.

Added a v1-only fallback:

- If `list_interfaces()` (v2) returns nothing, call a new `_configure_hotspot_v1()` instead of returning early.
- v1 path reads the current global SSID via `GET /v1.0/hotspot_credentials`; if it already matches the target, we skip the rename so we don't kick connected clients on every backend restart.
- Otherwise `POST /v1.0/hotspot_credentials` with the new SSID + password. BlueOS internally does `disable_hotspot → enable_hotspot`, so the AP cycles to the new SSID without us touching `create_ap` directly.
- Defensively disables `smart_hotspot` and explicitly toggles the hotspot off/on, so older BlueOS releases that don't auto-restart on credential change still apply the new SSID.

v1 has no per-interface hotspot concept, so this is the most we can do on those builds. The existing v2 code path is preserved unchanged for newer BlueOS.

### Bug 2 — `hotspot_radio.py::_read_host_file()` fails on root-owned files

`_read_host_file()` ran a bare `cat` via the BlueOS Commander API. Commander executes as the `pi` user without `sudo`, and `/root/.config/blueos/bootstrap/startup.json` is root-owned, so `cat` returned empty stdout and the function reported the file as missing. As a result the wifi-override bind-mount entry was never written and the patched `networkmanager.py` never got bound into `blueos-core` at boot.

Fix: prefix the `cat` with `sudo`. Commander is configured with passwordless sudo on this image, so this just works.

### Bug 3 — `hotspot_radio.py::_write_host_file()` 400s on large content

`_write_host_file()` shoved file content as a single `sudo tee` heredoc through Commander's query string. For the patched `networkmanager.py` (~25 KB, ~75 KB after URL-encoding) nginx in front of Commander rejected the request with `400 Bad Request`, so the override file on the host stayed at whatever stale content a previous run had left behind.

Fix: replace the single-shot heredoc upload with a chunked base64 stream. Content is base64-encoded, appended to `/tmp/.doris_hostfile_stage` in 2000-byte chunks (well below the nginx URI limit), then atomically decoded and renamed into place under `sudo`. Cleanup runs on success and on every failure path. Idempotent skip is preserved when the destination already has matching content.

## Verification

All three fixes were hot-deployed to DORIS (D-0492) and verified live, not just unit-tested.

**Bug 1 (SSID rename):**

- Pre-deploy: `GET /v1.0/hotspot_credentials` -> `{"ssid": "BlueOS (f54c5f)", "password": "blueosap"}`
- ~11 s after restart: `{"ssid": "DORIS (D-0492)", "password": "blueosap"}`
- `iw dev uap0 info` reports `ssid DORIS (D-0492)`, channel 3 (2422 MHz), 31 dBm
- `ps -ef | grep create_ap` shows `/usr/bin/create_ap ... DORIS (D-0492) blueosap`
- DORIS log: `Renaming hotspot via v1 API: 'BlueOS (f54c5f)' -> 'DORIS (D-0492)' (BlueOS v2 unavailable)`

**Bugs 2 & 3 (hotspot_radio host I/O):**

- `/usr/blueos/userdata/wifi-overrides/networkmanager.py` rewritten (25,416 bytes via 17 base64 chunks). `freq-band`, `ieee80211ac`, `country US` flags all present in the file.
- `/root/.config/blueos/bootstrap/startup.json` now contains the wifi-overrides bind-mount entry (`mode: ro`) - previously absent.
- `/tmp/.doris_hostfile_stage` is removed after each run (cleanup OK).

After a vehicle reboot the bootstrap will mount the patched `networkmanager.py` over the stock one, and `create_ap` will come up on 5 GHz ch 36 / HT40 instead of the current 2.4 GHz ch 3.

### Known cosmetic follow-up (Bug 1 only)

`BlueOS.set_hotspot_credentials` synchronously does `disable_hotspot → enable_hotspot`, which on this build takes ~15 s under `create_ap`. Our httpx client times out at 10 s, so the v1 fallback logs a misleading `v1 hotspot: set_hotspot_credentials failed: ` warning even when the rename completes server-side. Functional behavior is correct; worth tightening the client timeout for that one call in a follow-up.

## Test plan

- [x] Bug 1: hot-deploy to live unit; confirm SSID flips from `BlueOS (...)` to `DORIS (...)` within ~15 s of backend restart.
- [x] Bug 1: confirm rename via `iw dev uap0 info` (driver-level ground truth).
- [x] Bug 2: hot-deploy; confirm `sudo cat` of `startup.json` returns content via the patched `_read_host_file`.
- [x] Bug 3: hot-deploy; confirm 25 KB networkmanager.py override file is written end-to-end via chunked base64.
- [x] Bug 3: confirm `/tmp/.doris_hostfile_stage` is cleaned up after run.
- [x] Combined: confirm `startup.json` gets the wifi-overrides bind entry (which required both Bug 2 read and Bug 3 write to succeed).
- [ ] Confirm rename + 5 GHz both survive a full vehicle reboot (image rebuild + reflash, not just hot-deploy).
- [ ] Confirm `iw dev uap0 info` post-reboot reports `channel 36`, `width: 40 MHz` (currently `channel 3`, `width: 20 MHz`).
- [ ] Confirm idempotency: second backend restart logs "already up to date, skipping" for all host files.
