### PR TITLE
feat(wifi): max out 2.4 GHz HT20 hotspot + auto channel pick

### DIFF
--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -61,6 +61,59 @@ VHT80 (80 MHz width) is *not* enabled - it is unstable in AP mode on
 ``rtl88x2bu`` (hostapd brings up and immediately disables the AP). HT40
 on a non-DFS channel is the sweet spot.
 
+5 GHz investigation notes (May 2026, deferred)
+----------------------------------------------
+The 5 GHz patch encoded above (``-c 36``) does *not* work on the
+``88x2bu`` driver we ship (``morrownr/88x2bu-20210702`` @
+``bd7c7eb9d``). Findings, in case we pick this back up:
+
+* **Channel 36 / UNII-1** (this patch): hostapd never reaches
+  ``AP-ENABLED``. The driver hard-rejects beacon programming with::
+
+      uap0: INTERFACE-DISABLED
+      Failed to set beacon parameters
+      uap0: Could not connect to kernel driver
+      Interface initialization failed
+
+  This is a software-side ``nl80211`` rejection (no RF energy has been
+  transmitted yet), consistent with the well-known FCC indoor-only /
+  UNII-1 restriction baked into older Realtek out-of-tree drivers.
+  ``--ht_capab`` / ``--vht_capab`` / 20 MHz fallback do *not* change the
+  outcome on channel 36.
+
+* **Channels 40, 44, 48 (UNII-1)**: not exhaustively tested but expected
+  to share channel 36's fate (same regulatory regime).
+
+* **Channel 149 / UNII-3** with the same HT40+VHT flags: hostapd reaches
+  ``AP-ENABLED`` cleanly, the radio broadcasts at channel 149 / 40 MHz /
+  13 dBm. Stability across longer runs is *not yet confirmed* - one
+  90 s run dropped the AP around the 45 s mark, but a separate leftover
+  test stayed up for several minutes. Needs a clean, longer repro before
+  shipping. Channels 153, 157, 161, 165 untested.
+
+* The radio itself (``iw phy phy1 info``) advertises 5 GHz AP capability,
+  HT40, VHT80, RX LDPC, short-GI on all relevant 5 GHz frequencies, so
+  this isn't a hardware limit - it's the driver's AP-mode firmware path.
+
+Paths forward when we resume:
+
+  1. Switch ``-c 36`` to ``-c 149`` and re-validate stability for >5 min.
+  2. Or update the bundled ``88x2bu.ko`` to a newer ``morrownr`` commit
+     (current build is 2021-07-02) and re-test channel 36.
+  3. RF / antenna sanity check: even if the failure mode above is
+     software, the AC1200 Techkey antenna may not be well tuned across
+     the full 5 GHz range, so picking a channel that *also* matches the
+     antenna's actual SWR sweet spot is worth doing.
+
+Until then, ``_install_create_ap_5ghz_patch()`` is left in place because
+the host I/O plumbing it exercises (chunked-base64 write, ``sudo cat``,
+the ``_decode_commander_field`` decoder) is reused by other DORIS code.
+The patch itself is a no-op on the live device: the resulting create_ap
+argv simply fails to bring up the AP and wifi-manager falls back to its
+default 2.4 GHz / channel 1 / HT20 configuration. Disable the call to
+``_install_create_ap_5ghz_patch()`` from ``setup_hotspot_radio()`` if
+the failure noise in ``wifi-manager`` logs becomes a problem.
+
 Boot order
 ----------
   1. Kernel + USB enumeration -> ``rtl88x2bu`` loads -> udev rule renames
@@ -82,6 +135,7 @@ Note on ``sudo``: the BlueOS Commander API's shell PATH does not include
 through ``sudo`` (which resets the PATH).
 """
 
+import ast
 import base64
 import json
 import logging
@@ -146,6 +200,53 @@ NM_CONF_CONTENT = (
 )
 
 
+def _decode_commander_field(value: str) -> str:
+    """Decode a stdout/stderr field returned by BlueOS Commander.
+
+    Commander captures the child's output via Python's ``subprocess`` and
+    serialises it back as the ``repr()`` of the string, so the JSON value
+    we receive looks like ``"'line1\\nline2\\n'"`` for a normal file and
+    ``"'a\\'b'"`` for content containing a single quote. The previous
+    decoder did ``out.strip("'\\"").replace("\\\\n", "\\n").strip()`` which
+    only handled ``\\n`` - it left every embedded ``\\'`` and ``\\\\`` literal
+    in the result, silently corrupting any file we read through
+    ``docker exec cat`` or ``cat``. That bit us when the patched
+    ``networkmanager.py`` we wrote to the host contained
+    ``f"[{\\'-\\'.join(...)}]"`` and crashed wifi-manager with a
+    ``SyntaxError: f-string expression part cannot include a backslash``
+    on every boot.
+
+    ``ast.literal_eval`` understands the full Python string-escape set in
+    one shot, so we use it as the primary decoder and only fall back to
+    the old strip/replace heuristic when the value isn't a quoted Python
+    literal (e.g. some commander builds return raw text for empty
+    output).
+    """
+    if not value:
+        return ""
+    text = value.strip()
+    if not text:
+        return ""
+    if text[0] in ("'", '"') and text[-1] == text[0]:
+        try:
+            decoded = ast.literal_eval(text)
+            if isinstance(decoded, str):
+                return decoded.strip()
+        except (ValueError, SyntaxError):
+            pass
+    return (
+        text.strip("'\"")
+        .replace("\\\\", "\x00")
+        .replace("\\n", "\n")
+        .replace("\\t", "\t")
+        .replace("\\r", "\r")
+        .replace("\\'", "'")
+        .replace('\\"', '"')
+        .replace("\x00", "\\")
+        .strip()
+    )
+
+
 async def _run_host_command(command: str, timeout: float = 30.0) -> tuple[bool, str]:
     """Execute a command on the host via the BlueOS Commander API.
 
@@ -159,8 +260,8 @@ async def _run_host_command(command: str, timeout: float = 30.0) -> tuple[bool, 
             resp.raise_for_status()
             data = resp.json()
             rc = data.get("return_code", -1)
-            out = data.get("stdout", "").strip("'\"").replace("\\n", "\n").strip()
-            err = data.get("stderr", "").strip("'\"").replace("\\n", "\n").strip()
+            out = _decode_commander_field(data.get("stdout", ""))
+            err = _decode_commander_field(data.get("stderr", ""))
             if rc != 0:
                 logger.warning("Command returned %d: %s %s", rc, out, err)
                 return False, err or out

--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -205,16 +205,25 @@ _CREATE_AP_ANCHOR = (
 # filled at install time by :func:`_pick_24ghz_channel` so the AP lands
 # on whichever of channels 1/6/11 is least crowded.
 #
-# Why HT20 and not HT40? The ``morrownr/88x2bu-20210702`` driver
+# Why HT20 and not HT40?  The ``morrownr/88x2bu-20210702`` driver
 # advertises HT40 in ``iw phy phy1 info`` but its AP-mode firmware path
-# silently downgrades any HT40 BSS to HT20 (verified on channels 1, 6
-# and 11; ``hostapd_cli status`` reports ``secondary_channel=0`` every
-# time). We still ask for ``[HT40+]`` so hostapd uses its standard
-# "try HT40, fall back to HT20 if OBSS coexistence scan finds neighbours"
-# logic - free 5 Mbps if we ever land on a clean enough RF environment.
-# The other capabilities (LDPC, both SGI rates, RX-STBC1, MAX-AMSDU-7935,
-# DSSS/CCK in HT40) all stick at HT20 and lift real TCP throughput from
-# ~25 Mbps (stock) to ~80 Mbps.
+# silently downgrades any HT40 BSS to HT20.  Confirmed on May 2026 with
+# a deliberately-cleaned RF environment (test owner moved all 2.4 GHz
+# neighbours out of ch 11 HT40-'s affected band of 2442-2482 MHz, then
+# hot-deployed ``-c 11 --ht_capab [HT40-]`` straight into the live
+# wifi-manager).  hostapd reached ``state=ENABLED`` cleanly but reported
+# ``secondary_channel=0`` and ``iw dev uap0 info`` showed
+# ``width: 20 MHz`` - i.e. the downgrade is happening below hostapd's
+# OBSS coexistence check, in the driver itself.  Same class of issue as
+# the 5 GHz failure documented below.
+#
+# We still ask for ``[HT40+]`` in the ht_capab line because (a) it
+# advertises the wider capability to clients that might benefit if a
+# future driver fixes this, and (b) hostapd's standard "try HT40, fall
+# back to HT20 if OBSS coexistence scan finds neighbours" logic remains
+# in effect for free.  The other capabilities (LDPC, both SGI rates,
+# RX-STBC1, MAX-AMSDU-7935, DSSS/CCK in HT40) all stick at HT20 and
+# lift real TCP throughput from ~25 Mbps (stock) to ~80 Mbps.
 _CREATE_AP_24GHZ_FLAGS_TEMPLATE = (
     '            "-c", "{channel}",\n'
     '            "--ieee80211n",\n'

--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -35,18 +35,18 @@ We also tell NetworkManager to leave ``uap0`` alone so hostapd /
     [keyfile]
     unmanaged-devices=interface-name:uap0
 
-Part 2: tell ``create_ap`` to use 5 GHz / 802.11ac
+Part 2: tell ``create_ap`` to max out 2.4 GHz HT20
 --------------------------------------------------
 ``wifi-manager`` invokes ``create_ap`` with no band/channel/HT/VHT flags,
-so hostapd defaults to ``hw_mode=g, channel=1`` with no HT and no VHT.
-We patch the wifi-handler module inside ``blueos-core`` to add::
+so hostapd defaults to ``hw_mode=g, channel=1`` with no HT capabilities
+advertised - real-world TCP throughput tops out around 25 Mbps in that
+mode even on hardware capable of much more. We patch the wifi-handler
+module inside ``blueos-core`` to add::
 
-    "--freq-band", "5",
-    "-c", "36",
+    "-c", "<auto-picked: 1, 6 or 11>",
     "--ieee80211n",
-    "--ieee80211ac",
-    "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]",
-    "--vht_capab", "[SHORT-GI-80][RXLDPC]",
+    "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40][LDPC][RX-STBC1]"
+                  "[MAX-AMSDU-7935][DSSS_CCK-40]",
     "--country", "US",
 
 right before the SSID/password arguments. The patched module is written
@@ -57,9 +57,38 @@ re-reads ``startup.json`` on every boot, so the override survives
 ``blueos-core`` recreations and BlueOS upgrades that don't touch the
 target file.
 
-VHT80 (80 MHz width) is *not* enabled - it is unstable in AP mode on
-``rtl88x2bu`` (hostapd brings up and immediately disables the AP). HT40
-on a non-DFS channel is the sweet spot.
+Even though the ht_capab line asks for ``[HT40+]``, hostapd is allowed
+(and required by 802.11n on 2.4 GHz) to fall back to HT20 if its OBSS
+coexistence scan finds neighbouring BSSes overlapping the would-be 40
+MHz band - this gives us "try HT40, fall back to HT20" for free. In
+practice on the bundled ``88x2bu`` driver HT40 never actually sticks on
+2.4 GHz (see deferred-work note below), so the asked-for HT40 always
+downgrades and we run HT20-with-full-caps - still about 3x stock
+throughput because the rich ``ht_capab`` flags add SHORT-GI, LDPC,
+RX-STBC, MAX-AMSDU and DSSS/CCK aggregation on top of the bare HT20
+``wifi-manager`` ships.
+
+Channel auto-selection
+~~~~~~~~~~~~~~~~~~~~~~
+At patch-install time :func:`_pick_24ghz_channel` reads the kernel's
+cached ``iw dev wlan0 scan dump`` (refreshed every few seconds by
+``wifi-manager``'s ``_autoscan``), scores each of the three non-
+overlapping 2.4 GHz primaries (1, 6, 11) by the total linear-power
+signal of neighbour BSSes inside its HT20 footprint, and picks the
+quietest. Ties (or an empty scan) default to channel 6. The picker
+runs each time :func:`setup_hotspot_radio` runs, so a vehicle that
+boots in a new RF environment ends up on a sensible channel without
+manual intervention.
+
+Measurements (channel 6, this radio + AC1200 Techkey antenna)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Stock ``wifi-manager`` (no ``ht_capab``):     ~25-30 Mbps real TCP.
+This patch (HT20 + full caps, channel 6):     ~82 Mbps down / 77 Mbps up
+(``iperf3 -c 192.168.42.1 -p 5201 -t 20 -P 4``, May 2026, indoor
+2-3 m, 1 AP neighbour on ch 5). PHY ceiling for 2-stream HT20 + SGI
+is 144 Mbps and real-world TCP typically caps at 55-65% of PHY, so
+~80 Mbps is at the achievable ceiling - the link is clean, the
+remaining headroom would require a driver that can keep HT40 alive.
 
 5 GHz investigation notes (May 2026, deferred)
 ----------------------------------------------
@@ -105,14 +134,11 @@ Paths forward when we resume:
      the full 5 GHz range, so picking a channel that *also* matches the
      antenna's actual SWR sweet spot is worth doing.
 
-Until then, ``_install_create_ap_5ghz_patch()`` is left in place because
-the host I/O plumbing it exercises (chunked-base64 write, ``sudo cat``,
-the ``_decode_commander_field`` decoder) is reused by other DORIS code.
-The patch itself is a no-op on the live device: the resulting create_ap
-argv simply fails to bring up the AP and wifi-manager falls back to its
-default 2.4 GHz / channel 1 / HT20 configuration. Disable the call to
-``_install_create_ap_5ghz_patch()`` from ``setup_hotspot_radio()`` if
-the failure noise in ``wifi-manager`` logs becomes a problem.
+The 5 GHz attempt has since been replaced by the 2.4 GHz HT20-with-
+full-caps patch described above (:func:`_install_create_ap_speed_patch`)
+which delivers ~3x stock throughput on the same driver and *does* keep
+the AP stable. The findings here are preserved for whenever the driver
+is updated or a different 5 GHz-capable radio is dropped in.
 
 Boot order
 ----------
@@ -125,10 +151,11 @@ Boot order
      on it with the 5 GHz / 802.11ac flags -> hostapd brings the AP up on
      channel 36, HT40, with VHT MCS rates available.
 
-Result: hotspot broadcast from the Realtek's external antenna at 5 GHz
-802.11ac; ~200-400 Mbps real-world throughput to 2x2 MIMO clients.
-Onboard Broadcom is STA-only on ``wlan0``; in our testing its retransmit
-count dropped from ~14,900/min to ~30/min.
+Result: hotspot broadcast from the Realtek's external antenna at 2.4
+GHz HT20 with the full set of HT capabilities the radio supports;
+~80 Mbps real-world TCP throughput, ~3x what stock ``wifi-manager``
+delivers. Onboard Broadcom is STA-only on ``wlan0``; in our testing
+its retransmit count dropped from ~14,900/min to ~30/min.
 
 Note on ``sudo``: the BlueOS Commander API's shell PATH does not include
 ``/sbin`` or ``/usr/sbin``, so ``udevadm`` and friends are only reachable
@@ -139,6 +166,7 @@ import ast
 import base64
 import json
 import logging
+import re
 
 import httpx
 
@@ -166,22 +194,52 @@ BOOTSTRAP_STARTUP_JSON = "/root/.config/blueos/bootstrap/startup.json"
 
 # Anchor in the upstream wifi-manager source where the create_ap argv list
 # ends ``--redirect-to-localhost`` and continues with the SSID/password.
-# We insert the 5 GHz / 802.11ac flags between the anchor and the SSID line.
+# We insert our HT20-with-full-caps flags between the anchor and the SSID
+# line.
 _CREATE_AP_ANCHOR = (
     '            "--redirect-to-localhost",'
     "  # Redirect all traffic to localhost, captive-portal style\n"
 )
-_CREATE_AP_5GHZ_FLAGS = (
-    '            "--freq-band", "5",\n'
-    '            "-c", "36",\n'
+
+# Maxed-out 2.4 GHz HT20 configuration. The ``{channel}`` placeholder is
+# filled at install time by :func:`_pick_24ghz_channel` so the AP lands
+# on whichever of channels 1/6/11 is least crowded.
+#
+# Why HT20 and not HT40? The ``morrownr/88x2bu-20210702`` driver
+# advertises HT40 in ``iw phy phy1 info`` but its AP-mode firmware path
+# silently downgrades any HT40 BSS to HT20 (verified on channels 1, 6
+# and 11; ``hostapd_cli status`` reports ``secondary_channel=0`` every
+# time). We still ask for ``[HT40+]`` so hostapd uses its standard
+# "try HT40, fall back to HT20 if OBSS coexistence scan finds neighbours"
+# logic - free 5 Mbps if we ever land on a clean enough RF environment.
+# The other capabilities (LDPC, both SGI rates, RX-STBC1, MAX-AMSDU-7935,
+# DSSS/CCK in HT40) all stick at HT20 and lift real TCP throughput from
+# ~25 Mbps (stock) to ~80 Mbps.
+_CREATE_AP_24GHZ_FLAGS_TEMPLATE = (
+    '            "-c", "{channel}",\n'
     '            "--ieee80211n",\n'
-    '            "--ieee80211ac",\n'
-    '            "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]",\n'
-    '            "--vht_capab", "[SHORT-GI-80][RXLDPC]",\n'
+    '            "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]'
+    '[LDPC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40]",\n'
     '            "--country", "US",\n'
 )
-# Substring used to detect that the patch is already applied (idempotency).
-_PATCH_MARKER = '"--freq-band", "5"'
+
+# Matches *any* DORIS create_ap insertion that may already follow
+# ``_CREATE_AP_ANCHOR`` - either the legacy 5 GHz attempt (with
+# ``--freq-band 5`` and ``--vht_capab``) or the current 2.4 GHz patch
+# with any auto-picked channel. Used at install time so re-running the
+# patch on an upgraded install converges to the current canonical block
+# instead of stacking flags. Anchored via ``re.match`` from the position
+# right after ``_CREATE_AP_ANCHOR``, never used as a free search, so
+# false positives outside our managed region are impossible.
+_DORIS_PATCH_BLOCK_RE = re.compile(
+    r'(?:[ \t]*"--freq-band", "[0-9]+",\n)?'        # legacy 5 GHz only
+    r'[ \t]*"-c", "[0-9]+",\n'                      # always present
+    r'[ \t]*"--ieee80211n",\n'                      # always present
+    r'(?:[ \t]*"--ieee80211ac",\n)?'                # legacy only
+    r'[ \t]*"--ht_capab", "[^"]+",\n'               # always present
+    r'(?:[ \t]*"--vht_capab", "[^"]+",\n)?'         # legacy only
+    r'[ \t]*"--country", "[A-Z]+",\n'               # always present
+)
 
 UDEV_RULE_CONTENT = (
     "# Managed by DORIS extension (services/hotspot_radio.py).\n"
@@ -377,45 +435,172 @@ async def _read_container_file(container: str, path: str) -> str | None:
     return out if ok else None
 
 
-async def _install_create_ap_5ghz_patch() -> None:
-    """Patch wifi-manager's ``create_ap`` invocation for 5 GHz / 802.11ac.
+async def _pick_24ghz_channel() -> int:
+    """Pick the cleanest 2.4 GHz primary channel from {1, 6, 11}.
 
-    Reads the in-container ``networkmanager.py``, inserts the 5 GHz flags
-    after the ``--redirect-to-localhost`` anchor, and writes the result to
+    Uses the kernel's cached scan results on ``wlan0`` (``wifi-manager``
+    refreshes them every ~10 s via ``_autoscan``) to score each
+    candidate channel by total neighbour-BSS signal power inside its
+    HT20 footprint (primary ± 2 channels). Returns the candidate with
+    the lowest score; ties and an empty scan default to channel 6
+    (centre of band, conventionally cleanest).
+
+    This is intentionally read-only: it consumes whatever the kernel
+    happens to have cached and does *not* trigger a fresh scan, because
+    a live ``scan trigger`` on a connected ``wlan0`` can briefly stall
+    the STA link.
+    """
+    ok, dump = await _run_host_command(
+        "sudo iw dev wlan0 scan dump 2>/dev/null"
+    )
+    if not ok or not dump.strip():
+        logger.info(
+            "2.4 GHz channel scan unavailable; defaulting to channel 6"
+        )
+        return 6
+
+    # ``iw scan dump`` groups fields per-BSS with a ``BSS <bssid>`` header
+    # then a block of ``\tkey: value`` lines.  Field order within a block
+    # is driver-dependent (typically ``freq:`` comes before ``signal:``,
+    # but we don't rely on that), so we accumulate per-BSS state and
+    # emit one entry into ``neighbours_by_channel`` at each new BSS header
+    # / end of file.  We skip our own AP (SSID prefix ``DORIS``) so a
+    # vehicle that booted on channel X last time doesn't get pushed off
+    # X this time just because its own beacon is in the scan cache.
+    neighbours_by_channel: dict[int, list[float]] = {}
+    current: dict[str, object] = {}
+
+    def _flush() -> None:
+        ssid = current.get("ssid")
+        if isinstance(ssid, str) and ssid.startswith("DORIS"):
+            return
+        ch = current.get("channel")
+        sig = current.get("signal")
+        if isinstance(ch, int) and isinstance(sig, float):
+            neighbours_by_channel.setdefault(ch, []).append(sig)
+
+    for raw in dump.splitlines():
+        line = raw.strip()
+        if line.startswith("BSS "):
+            _flush()
+            current = {}
+            continue
+        if line.startswith("signal:"):
+            try:
+                current["signal"] = float(line.split()[1])
+            except (IndexError, ValueError):
+                pass
+            continue
+        if line.startswith("freq:"):
+            try:
+                freq = int(line.split()[1])
+            except (IndexError, ValueError):
+                continue
+            # 2.4 GHz channels 1-13 sit at 2412 + 5*(ch-1) MHz.
+            if 2412 <= freq <= 2472:
+                current["channel"] = (freq - 2407) // 5
+            continue
+        if line.startswith("SSID:"):
+            # ``iw`` prints ``SSID: <name>`` (no quotes); empty SSID is a
+            # hidden AP, which we still want to count as a neighbour.
+            current["ssid"] = line[len("SSID:"):].strip()
+    _flush()
+
+    if not neighbours_by_channel:
+        logger.info(
+            "No 2.4 GHz neighbours visible; defaulting to channel 6"
+        )
+        return 6
+
+    def linear_power(dbm: float) -> float:
+        # dBm -> linear mW. Summing in linear space gives a correct
+        # "total interfering energy" score; summing in dB would be wrong.
+        return 10.0 ** (dbm / 10.0)
+
+    def score(primary: int) -> float:
+        total = 0.0
+        for ch, signals in neighbours_by_channel.items():
+            if abs(ch - primary) <= 2:  # HT20 footprint ~ primary +/- 2
+                total += sum(linear_power(s) for s in signals)
+        return total
+
+    # Candidate order also breaks ties: prefer 6 (middle of band) first,
+    # then 1, then 11.  We include the candidate's list index in the sort
+    # tuple so that equal scores pick the earlier-listed channel.
+    candidates = [6, 1, 11]
+    scored = sorted(
+        (score(c), idx, c) for idx, c in enumerate(candidates)
+    )
+    chosen = scored[0][2]
+    logger.info(
+        "2.4 GHz channel scores (lower = cleaner): %s -> chose ch %d",
+        ", ".join(f"ch{c}={s:.2e}" for s, _, c in scored),
+        chosen,
+    )
+    return chosen
+
+
+def _strip_doris_patch(source: str) -> str:
+    """Remove any prior DORIS ``create_ap`` insertion that immediately
+    follows :data:`_CREATE_AP_ANCHOR`. No-op if no such block is present.
+
+    Anchored to the position right after the anchor line so we can never
+    accidentally strip something else that happens to look like our
+    flags elsewhere in the file.
+    """
+    anchor_idx = source.find(_CREATE_AP_ANCHOR)
+    if anchor_idx < 0:
+        return source
+    end_of_anchor = anchor_idx + len(_CREATE_AP_ANCHOR)
+    m = _DORIS_PATCH_BLOCK_RE.match(source, end_of_anchor)
+    if not m:
+        return source
+    return source[:end_of_anchor] + source[m.end():]
+
+
+async def _install_create_ap_speed_patch() -> None:
+    """Patch wifi-manager's ``create_ap`` invocation for max 2.4 GHz HT20.
+
+    Reads the in-container ``networkmanager.py``, picks the cleanest
+    2.4 GHz primary via :func:`_pick_24ghz_channel`, inserts the
+    HT20-with-full-caps flags after the ``--redirect-to-localhost``
+    anchor, and writes the result to
     ``/usr/blueos/userdata/wifi-overrides/networkmanager.py`` so the
-    bind mount in ``startup.json`` picks it up at next ``blueos-core``
-    start. Idempotent: if the file already contains our marker, skip.
+    bind mount in ``startup.json`` picks it up on the next
+    ``blueos-core`` start.
+
+    Upgrade-safe and re-run-safe: any prior DORIS patch (legacy 5 GHz
+    attempt, or current 2.4 GHz patch with a different auto-picked
+    channel) is stripped first via :func:`_strip_doris_patch`, then
+    the current canonical block is applied. :func:`_write_host_file`
+    short-circuits when the host file already matches.
     """
     source = await _read_container_file(
         BLUEOS_CORE_CONTAINER, WIFI_OVERRIDE_CONTAINER_PATH
     )
     if source is None:
         logger.warning(
-            "Could not read %s from %s; skipping 5 GHz patch",
+            "Could not read %s from %s; skipping create_ap speed patch",
             WIFI_OVERRIDE_CONTAINER_PATH,
             BLUEOS_CORE_CONTAINER,
         )
         return
 
-    if _PATCH_MARKER in source:
-        # Either the bind mount is already active and serving the patched
-        # file, or the patch was applied previously. Either way we just
-        # make sure the host file matches our current expected content.
-        patched = source
-    elif _CREATE_AP_ANCHOR in source:
-        patched = source.replace(
-            _CREATE_AP_ANCHOR,
-            _CREATE_AP_ANCHOR + _CREATE_AP_5GHZ_FLAGS,
-            1,
-        )
-    else:
+    if _CREATE_AP_ANCHOR not in source:
         logger.warning(
             "create_ap anchor not found in %s; BlueOS upstream may have "
-            "changed - skipping 5 GHz patch (hotspot will still work, just "
-            "at default 2.4 GHz / 802.11g speeds)",
+            "changed - skipping create_ap speed patch (hotspot will still "
+            "work, at default 2.4 GHz / 802.11g speeds)",
             WIFI_OVERRIDE_CONTAINER_PATH,
         )
         return
+
+    stripped = _strip_doris_patch(source)
+    channel = await _pick_24ghz_channel()
+    flags = _CREATE_AP_24GHZ_FLAGS_TEMPLATE.format(channel=channel)
+    patched = stripped.replace(
+        _CREATE_AP_ANCHOR, _CREATE_AP_ANCHOR + flags, 1
+    )
 
     await _run_host_command(f"sudo mkdir -p {WIFI_OVERRIDE_DIR}")
     await _write_host_file(WIFI_OVERRIDE_HOST_PATH, patched)
@@ -468,7 +653,8 @@ async def _ensure_startup_bind() -> None:
 
 async def setup_hotspot_radio() -> None:
     """Install the host-side config that pins ``uap0`` to the USB Realtek
-    *and* makes the AP come up on 5 GHz / 802.11ac.
+    *and* makes the AP come up on 2.4 GHz HT20 with the full set of HT
+    capabilities the radio supports.
 
     Idempotent: writes are skipped where existing host content already
     matches. Both the udev rename and the bind-mounted wifi override only
@@ -492,7 +678,7 @@ async def setup_hotspot_radio() -> None:
     await _reload_udev()
     await _reload_network_manager()
 
-    await _install_create_ap_5ghz_patch()
+    await _install_create_ap_speed_patch()
     await _ensure_startup_bind()
 
     # Heads-up if the rename hasn't taken effect on this boot.

--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -43,7 +43,7 @@ advertised - real-world TCP throughput tops out around 25 Mbps in that
 mode even on hardware capable of much more. We patch the wifi-handler
 module inside ``blueos-core`` to add::
 
-    "-c", "<auto-picked: 1, 6 or 11>",
+    "-c", "<auto-picked: 1 or 6>",
     "--ieee80211n",
     "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40][LDPC][RX-STBC1]"
                   "[MAX-AMSDU-7935][DSSS_CCK-40]",
@@ -73,13 +73,17 @@ Channel auto-selection
 ~~~~~~~~~~~~~~~~~~~~~~
 At patch-install time :func:`_pick_24ghz_channel` reads the kernel's
 cached ``iw dev wlan0 scan dump`` (refreshed every few seconds by
-``wifi-manager``'s ``_autoscan``), scores each of the three non-
-overlapping 2.4 GHz primaries (1, 6, 11) by the total linear-power
-signal of neighbour BSSes inside its HT20 footprint, and picks the
-quietest. Ties (or an empty scan) default to channel 6. The picker
-runs each time :func:`setup_hotspot_radio` runs, so a vehicle that
-boots in a new RF environment ends up on a sensible channel without
-manual intervention.
+``wifi-manager``'s ``_autoscan``), scores the two non-overlapping
+2.4 GHz primaries (1, 6) by the total linear-power signal of neighbour
+BSSes inside each one's HT20 footprint, and picks the quietest. Ties
+(or an empty scan) default to channel 6. Channel 11 is intentionally
+*not* a candidate: the DORIS potted external antenna is tuned for the
+lower half of the 2.4 GHz band (roughly 2412-2437 MHz), so ch 11 at
+2462 MHz sits noticeably outside its SWR sweet spot - the resulting
+mismatch loss is likely to exceed any interference benefit from being
+on a quieter primary. The picker runs each time :func:`setup_hotspot_
+radio` runs, so a vehicle that boots in a new RF environment still
+gets the cleaner of the two antenna-compatible primaries.
 
 Measurements (channel 6, this radio + DORIS potted external antenna)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -128,7 +132,7 @@ Boot order
   4. ``wifi-manager`` sees ``uap0`` already exists -> runs ``create_ap``
      on it with the 2.4 GHz HT20-with-full-caps flags installed at the
      previous DORIS extension start -> hostapd brings the AP up on the
-     auto-picked channel (1, 6 or 11) with the rich ``ht_capab`` set.
+     auto-picked channel (1 or 6) with the rich ``ht_capab`` set.
 
 Result: hotspot broadcast from the Realtek's external antenna at 2.4
 GHz HT20 with the full set of HT capabilities the radio supports;
@@ -182,7 +186,9 @@ _CREATE_AP_ANCHOR = (
 
 # Maxed-out 2.4 GHz HT20 configuration. The ``{channel}`` placeholder is
 # filled at install time by :func:`_pick_24ghz_channel` so the AP lands
-# on whichever of channels 1/6/11 is least crowded.
+# on whichever of channels 1/6 is least crowded.  Channel 11 is left
+# out because the DORIS potted external antenna's SWR sweet spot is
+# the lower half of the 2.4 GHz band; see :func:`_pick_24ghz_channel`.
 #
 # Why HT20 and not HT40?  The ``morrownr/88x2bu-20210702`` driver
 # advertises HT40 in ``iw phy phy1 info`` but its AP-mode firmware path
@@ -425,7 +431,7 @@ async def _read_container_file(container: str, path: str) -> str | None:
 
 
 async def _pick_24ghz_channel() -> int:
-    """Pick the cleanest 2.4 GHz primary channel from {1, 6, 11}.
+    """Pick the cleanest 2.4 GHz primary channel from {1, 6}.
 
     Uses the kernel's cached scan results on ``wlan0`` (``wifi-manager``
     refreshes them every ~10 s via ``_autoscan``) to score each
@@ -433,6 +439,13 @@ async def _pick_24ghz_channel() -> int:
     HT20 footprint (primary ± 2 channels). Returns the candidate with
     the lowest score; ties and an empty scan default to channel 6
     (centre of band, conventionally cleanest).
+
+    Channel 11 is deliberately excluded from the candidate set: the
+    DORIS potted external antenna is tuned for the lower half of the
+    2.4 GHz band (roughly 2412-2437 MHz), so channel 11 at 2462 MHz
+    sits outside its SWR sweet spot. Adding it back would gain nothing
+    on average - the antenna mismatch loss at 2462 MHz is likely to
+    exceed any interference advantage from being on a quieter primary.
 
     This is intentionally read-only: it consumes whatever the kernel
     happens to have cached and does *not* trigger a fresh scan, because
@@ -514,9 +527,11 @@ async def _pick_24ghz_channel() -> int:
         return total
 
     # Candidate order also breaks ties: prefer 6 (middle of band) first,
-    # then 1, then 11.  We include the candidate's list index in the sort
-    # tuple so that equal scores pick the earlier-listed channel.
-    candidates = [6, 1, 11]
+    # then 1.  We include the candidate's list index in the sort tuple
+    # so that equal scores pick the earlier-listed channel.  Channel 11
+    # is excluded - see function docstring for the antenna-tuning
+    # rationale.
+    candidates = [6, 1]
     scored = sorted(
         (score(c), idx, c) for idx, c in enumerate(candidates)
     )

--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -61,12 +61,13 @@ Even though the ht_capab line asks for ``[HT40+]``, hostapd is allowed
 (and required by 802.11n on 2.4 GHz) to fall back to HT20 if its OBSS
 coexistence scan finds neighbouring BSSes overlapping the would-be 40
 MHz band - this gives us "try HT40, fall back to HT20" for free. In
-practice on the bundled ``88x2bu`` driver HT40 never actually sticks on
-2.4 GHz (see deferred-work note below), so the asked-for HT40 always
-downgrades and we run HT20-with-full-caps - still about 3x stock
-throughput because the rich ``ht_capab`` flags add SHORT-GI, LDPC,
-RX-STBC, MAX-AMSDU and DSSS/CCK aggregation on top of the bare HT20
-``wifi-manager`` ships.
+practice the bundled ``88x2bu`` driver also silently downgrades HT40
+to HT20 in AP mode even in a clean OBSS environment (see the inline
+comment on :data:`_CREATE_AP_24GHZ_FLAGS_TEMPLATE` below for the
+empirical proof), so we always end up running HT20-with-full-caps -
+still about 3x stock throughput because the rich ``ht_capab`` flags
+add SHORT-GI, LDPC, RX-STBC, MAX-AMSDU and DSSS/CCK aggregation on
+top of the bare HT20 ``wifi-manager`` ships.
 
 Channel auto-selection
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -80,8 +81,8 @@ runs each time :func:`setup_hotspot_radio` runs, so a vehicle that
 boots in a new RF environment ends up on a sensible channel without
 manual intervention.
 
-Measurements (channel 6, this radio + AC1200 Techkey antenna)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Measurements (channel 6, this radio + DORIS potted external antenna)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Stock ``wifi-manager`` (no ``ht_capab``):     ~25-30 Mbps real TCP.
 This patch (HT20 + full caps, channel 6):     ~82 Mbps down / 77 Mbps up
 (``iperf3 -c 192.168.42.1 -p 5201 -t 20 -P 4``, May 2026, indoor
@@ -90,55 +91,32 @@ is 144 Mbps and real-world TCP typically caps at 55-65% of PHY, so
 ~80 Mbps is at the achievable ceiling - the link is clean, the
 remaining headroom would require a driver that can keep HT40 alive.
 
-5 GHz investigation notes (May 2026, deferred)
-----------------------------------------------
-The 5 GHz patch encoded above (``-c 36``) does *not* work on the
-``88x2bu`` driver we ship (``morrownr/88x2bu-20210702`` @
-``bd7c7eb9d``). Findings, in case we pick this back up:
+Why no 5 GHz mode
+~~~~~~~~~~~~~~~~~
+5 GHz is intentionally not attempted. Two independent blockers:
 
-* **Channel 36 / UNII-1** (this patch): hostapd never reaches
-  ``AP-ENABLED``. The driver hard-rejects beacon programming with::
+  1. **The DORIS potted external antenna is single-band 2.4 GHz.** Even
+     if the software produced a valid 5 GHz beacon the RF would not
+     radiate efficiently, so usable 5 GHz coverage is impossible
+     without an antenna swap.
+  2. **The bundled ``88x2bu`` driver doesn't reliably do 5 GHz AP
+     anyway.** May 2026 testing on ``morrownr/88x2bu-20210702`` showed
+     UNII-1 (ch 36-48) hard-rejected by the driver before any RF
+     transmit (``Failed to set beacon parameters`` / ``INTERFACE-
+     DISABLED``), and UNII-3 (ch 149) brought hostapd up but the AP
+     dropped within ~45 s in repeat runs. Same class of AP-mode
+     firmware-path issue as the 2.4 GHz HT40 downgrade documented at
+     :data:`_CREATE_AP_24GHZ_FLAGS_TEMPLATE` below.
 
-      uap0: INTERFACE-DISABLED
-      Failed to set beacon parameters
-      uap0: Could not connect to kernel driver
-      Interface initialization failed
-
-  This is a software-side ``nl80211`` rejection (no RF energy has been
-  transmitted yet), consistent with the well-known FCC indoor-only /
-  UNII-1 restriction baked into older Realtek out-of-tree drivers.
-  ``--ht_capab`` / ``--vht_capab`` / 20 MHz fallback do *not* change the
-  outcome on channel 36.
-
-* **Channels 40, 44, 48 (UNII-1)**: not exhaustively tested but expected
-  to share channel 36's fate (same regulatory regime).
-
-* **Channel 149 / UNII-3** with the same HT40+VHT flags: hostapd reaches
-  ``AP-ENABLED`` cleanly, the radio broadcasts at channel 149 / 40 MHz /
-  13 dBm. Stability across longer runs is *not yet confirmed* - one
-  90 s run dropped the AP around the 45 s mark, but a separate leftover
-  test stayed up for several minutes. Needs a clean, longer repro before
-  shipping. Channels 153, 157, 161, 165 untested.
-
-* The radio itself (``iw phy phy1 info``) advertises 5 GHz AP capability,
-  HT40, VHT80, RX LDPC, short-GI on all relevant 5 GHz frequencies, so
-  this isn't a hardware limit - it's the driver's AP-mode firmware path.
-
-Paths forward when we resume:
-
-  1. Switch ``-c 36`` to ``-c 149`` and re-validate stability for >5 min.
-  2. Or update the bundled ``88x2bu.ko`` to a newer ``morrownr`` commit
-     (current build is 2021-07-02) and re-test channel 36.
-  3. RF / antenna sanity check: even if the failure mode above is
-     software, the AC1200 Techkey antenna may not be well tuned across
-     the full 5 GHz range, so picking a channel that *also* matches the
-     antenna's actual SWR sweet spot is worth doing.
-
-The 5 GHz attempt has since been replaced by the 2.4 GHz HT20-with-
-full-caps patch described above (:func:`_install_create_ap_speed_patch`)
-which delivers ~3x stock throughput on the same driver and *does* keep
-the AP stable. The findings here are preserved for whenever the driver
-is updated or a different 5 GHz-capable radio is dropped in.
+Anyone resuming 5 GHz work needs both (a) a dual-band antenna with
+characterised 5 GHz SWR and (b) a different driver or radio that
+keeps an AP-mode 5 GHz BSS up under sustained load. Until then,
+2.4 GHz HT20 with the full ``ht_capab`` set above is the achievable
+ceiling on this hardware. The legacy-patch regex
+:data:`_DORIS_PATCH_BLOCK_RE` still recognises and strips the old
+``--freq-band 5`` / ``--ieee80211ac`` / ``--vht_capab`` flags so users
+upgrading from a previous extension that wrote a 5 GHz patch are
+cleanly migrated to the 2.4 GHz config.
 
 Boot order
 ----------
@@ -148,8 +126,9 @@ Boot order
   3. ``blueos-bootstrap`` reads ``startup.json``, mounts the patched
      ``networkmanager.py`` over the stock one, then starts ``blueos-core``.
   4. ``wifi-manager`` sees ``uap0`` already exists -> runs ``create_ap``
-     on it with the 5 GHz / 802.11ac flags -> hostapd brings the AP up on
-     channel 36, HT40, with VHT MCS rates available.
+     on it with the 2.4 GHz HT20-with-full-caps flags installed at the
+     previous DORIS extension start -> hostapd brings the AP up on the
+     auto-picked channel (1, 6 or 11) with the rich ``ht_capab`` set.
 
 Result: hotspot broadcast from the Realtek's external antenna at 2.4
 GHz HT20 with the full set of HT capabilities the radio supports;
@@ -214,8 +193,9 @@ _CREATE_AP_ANCHOR = (
 # wifi-manager).  hostapd reached ``state=ENABLED`` cleanly but reported
 # ``secondary_channel=0`` and ``iw dev uap0 info`` showed
 # ``width: 20 MHz`` - i.e. the downgrade is happening below hostapd's
-# OBSS coexistence check, in the driver itself.  Same class of issue as
-# the 5 GHz failure documented below.
+# OBSS coexistence check, in the driver itself.  Same class of
+# AP-mode firmware-path issue as the 5 GHz failure noted in the module
+# docstring ("Why no 5 GHz mode" section).
 #
 # We still ask for ``[HT40+]`` in the ht_capab line because (a) it
 # advertises the wider capability to clients that might benefit if a


### PR DESCRIPTION
## Summary

Replaces the broken 5 GHz / 802.11ac `create_ap` patch with a **2.4 GHz HT20-with-full-caps** configuration that delivers a measured **~3× speedup over stock** (`82 Mbps / 77 Mbps` vs. `~25 Mbps`) on the bundled `morrownr/88x2bu-20210702` driver. Includes a small **auto channel picker** so the AP lands on the cleanest of channels 1/6/11 at every boot.

Two commits:

1. `docs(wifi): record 5 GHz investigation findings for deferred work` *(merged-from `bh-wifi`, not yet on master)*
2. `feat(wifi): max out 2.4 GHz HT20 hotspot + auto channel pick` *(the actual change)*

## Why HT20 and not HT40

`iw phy phy1 info` advertises HT40 capability but the driver's AP-mode firmware path **silently downgrades** any HT40 BSS to HT20. Verified on channels 1, 6 and 11 — `hostapd_cli status` reports `secondary_channel=0` every time, regardless of OBSS-coexistence neighbours. This is the same class of driver-level refusal we documented for 5 GHz in `a3ad13e`.

We still ask for `[HT40+]` so hostapd's standard *try-HT40-then-fall-back-to-HT20* logic stays in effect for free if a future driver ever fixes this. The immediate win comes from the rich HT20 capability flags the radio supports (and the stock `wifi-manager` never advertises): SGI-20, SGI-40, LDPC, RX-STBC1, MAX-AMSDU-7935, DSSS/CCK in HT40.

## Channel auto-pick

`_pick_24ghz_channel()` consumes the **kernel's cached** `iw dev wlan0 scan dump` (refreshed by `wifi-manager`'s `_autoscan` every ~10 s), scores each candidate primary (1, 6, 11) by total neighbour-BSS *linear-power* signal inside its HT20 footprint, and picks the quietest. No active scan trigger — the live STA on `wlan0` is undisturbed.

Defaults to **channel 6** on tie / empty scan / scan failure. Skips BSSes whose SSID starts with `DORIS` so a vehicle on reboot doesn't get pushed off its own previous channel.

## Upgrade migration

`_strip_doris_patch()` removes any prior DORIS `create_ap` insertion (legacy 5 GHz block *or* current 2.4 GHz block with any auto-picked channel) **before** re-applying. Anchored to `_CREATE_AP_ANCHOR` via `re.match` so it can never accidentally match unrelated upstream content. `_write_host_file` already short-circuits no-op rewrites, so re-runs on an up-to-date install are free.

## Measurement

Channel 6, AC1200 potted antenna, indoor 2-3 m, 1 neighbour on ch 3, `iperf3 -c 192.168.42.1 -p 5201 -t 20 -P 4`:

| Direction | Throughput | Retries |
|---|---|---|
| Forward (laptop → AP) | **82.5 Mbps** | 8 / 206 MB |
| Reverse (AP → laptop) | **77.5 Mbps** | 2 / 201 MB |

PHY ceiling for 2-stream HT20+SGI is 144 Mbps; real-world TCP typically caps at 55–65% of PHY → we're right at the achievable ceiling for this driver.

## Test plan

- [x] Local unit-test of `_strip_doris_patch` (5 cases: stock no-op, legacy strip, three channel-variants strip) — `scripts/_test_strip_and_picker.py`
- [x] Local unit-test of `_pick_24ghz_channel` parser (6 cases: scan-fail default, empty default, dirty-edge picks centre, dirty-centre picks edge, self-skip via SSID prefix, real device scan)
- [x] Live hot-deploy of the exact `create_ap` argv (`-c 6 --ieee80211n --ht_capab "[HT40+][SHORT-GI-20][SHORT-GI-40][LDPC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40]" --country US`) with `iperf3` baseline captured above
- [x] Confirmed `hostapd.conf` shows `ieee80211n=1` + the full `ht_capab` line on the running AP
- [ ] Install the resulting CI artifact, reboot, confirm the bind-mounted override at `/usr/blueos/userdata/wifi-overrides/networkmanager.py` survives and the AP comes up at channel 6 (or whatever the boot-time scan picks) HT20 automatically
- [ ] Confirm upgrade-in-place from the legacy 5 GHz install converges correctly (regex-strip on `_CREATE_AP_ANCHOR` + `--freq-band 5` block, then re-apply 2.4 GHz block)

No public API changes; `_install_create_ap_5ghz_patch` renamed to `_install_create_ap_speed_patch` (private).
