### PR TITLE
fix(ui): 4S battery SOC, time-remaining estimate, and stuck light test

### DIFF
--- a/extension/backend/scripts/doris.lua
+++ b/extension/backend/scripts/doris.lua
@@ -711,6 +711,13 @@ function update()
             return update, UPDATE_INTERVAL_MS
         end
     else
+        -- Test just ended (DORIS_LGT_TST went back to 0). In CONFIG state no
+        -- dive branch calls update_lights(), so the last RC9 override stays
+        -- latched and the light stays on. Drive RC9 down once on the
+        -- transition so the light actually turns off.
+        if lgt_tst_start_ms ~= 0 and RC9 then
+            RC9:set_override(LIGHT_PWM_MIN)
+        end
         lgt_tst_start_ms = 0
     end
 

--- a/extension/backend/src/doris/services/system.py
+++ b/extension/backend/src/doris/services/system.py
@@ -1,7 +1,6 @@
 """System information service."""
 
 import logging
-import math
 import os
 from pathlib import Path
 
@@ -14,6 +13,64 @@ from .external_storage import get_migration_status
 from .storage import DATA_ROOT
 
 logger = logging.getLogger(__name__)
+
+# 4S LiPo pack voltage → State-of-Charge (%), piecewise-linear.
+# Derived from a typical resting-cell discharge curve (×4 cells in series).
+# Used because ArduPilot's BATTERY_STATUS.battery_remaining (coulomb-counted
+# against BATT_CAPACITY) defaults near 100% and is unreliable on this rig.
+_SOC_CURVE_4S: list[tuple[float, float]] = [
+    (16.80, 100.0),
+    (16.45, 90.0),
+    (16.08, 80.0),
+    (15.80, 70.0),
+    (15.48, 60.0),
+    (15.36, 50.0),
+    (15.20, 40.0),
+    (15.08, 30.0),
+    (14.92, 20.0),
+    (14.76, 10.0),
+    (14.44, 5.0),
+    (13.20, 0.0),
+]
+
+# Battery pack: 2× Blue Robotics 10 Ah 4S Li-ion packs wired in parallel.
+# Update these together with the matching constants in the frontend
+# (HomeScreen.vue / MissionProgramming.vue) if the hardware ever changes.
+_BATTERY_PACK_COUNT = 2
+_BATTERY_PACK_AH = 10.0
+_BATTERY_NOMINAL_V = 14.8  # 4S Li-ion nominal
+_BATTERY_TOTAL_AH = _BATTERY_PACK_COUNT * _BATTERY_PACK_AH      # 20 Ah
+_BATTERY_CAPACITY_WH = _BATTERY_TOTAL_AH * _BATTERY_NOMINAL_V   # 296 Wh
+
+# Reserve held back from the time-remaining estimate so the vehicle has
+# margin for surfacing, recovery, and unexpected loads. SOC% below this
+# value is reported as zero hours remaining.
+_BATTERY_RESERVE_PCT = 15.0
+
+# Standard platform load (W) used when no live current measurement is
+# available. Pi5 (15) + RadCAM (5) + 2× lumen lights (15 each) = 50 W.
+_STANDARD_LOAD_W = 50.0
+
+
+def _voltage_to_soc_4s(voltage: float) -> float:
+    """Map a measured 4S pack voltage to State-of-Charge (0–100 %).
+
+    Linearly interpolates between points on `_SOC_CURVE_4S`. Voltages above
+    or below the curve are clamped to 100 % / 0 %.
+    """
+    curve = _SOC_CURVE_4S
+    if voltage >= curve[0][0]:
+        return curve[0][1]
+    if voltage <= curve[-1][0]:
+        return curve[-1][1]
+    for (v_hi, soc_hi), (v_lo, soc_lo) in zip(curve, curve[1:]):
+        if v_lo <= voltage <= v_hi:
+            span = v_hi - v_lo
+            if span <= 0:
+                return soc_lo
+            frac = (voltage - v_lo) / span
+            return soc_lo + frac * (soc_hi - soc_lo)
+    return 0.0
 
 
 class SystemService:
@@ -100,14 +157,14 @@ class SystemService:
             voltages = message.get("voltages", [0])
             voltage = voltages[0] / 1000.0 if voltages and voltages[0] > 0 else None
             current = message.get("current_battery", 0) / 100.0
-            remaining = message.get("battery_remaining", -1)
 
-            if remaining < 0 and voltage is not None:
-                k = 3.0
-                v_mid = 14.52
-                soc = 100.0 / (1.0 + math.exp(-k * (voltage - v_mid)))
-                remaining = max(0.0, min(100.0, soc))
-            elif remaining < 0:
+            # Always derive SOC from the measured pack voltage. ArduPilot's
+            # battery_remaining field is a coulomb-counted estimate that
+            # defaults to ~99 % until BATT_CAPACITY worth of mAh have been
+            # consumed, so it misreports SOC on a partially-charged pack.
+            if voltage is not None:
+                remaining = _voltage_to_soc_4s(voltage)
+            else:
                 remaining = 0.0
 
             remaining_hours = self._estimate_remaining_hours(remaining, current)
@@ -264,13 +321,20 @@ class SystemService:
     def _estimate_remaining_hours(
         self, percent: float, current: float | None
     ) -> float | None:
-        """Estimate remaining battery hours."""
+        """Estimate remaining battery hours before hitting the safety reserve.
+
+        Assumes 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel (20 Ah
+        total) with `_BATTERY_RESERVE_PCT` of capacity held back as
+        margin. With a measured current draw the remaining usable
+        ampere-hours are divided by the instantaneous current; otherwise
+        we fall back to the standard DORIS platform load (~50 W).
+        """
+        usable_pct = max(0.0, percent - _BATTERY_RESERVE_PCT)
+        usable_ah = (usable_pct / 100.0) * _BATTERY_TOTAL_AH
         if current is None or current <= 0:
-            capacity_ah = 100
-            return (percent / 100) * (capacity_ah / 10)
-        capacity_ah = 100
-        remaining_ah = (percent / 100) * capacity_ah
-        return remaining_ah / current if current > 0 else None
+            standard_current_a = _STANDARD_LOAD_W / _BATTERY_NOMINAL_V
+            return usable_ah / standard_current_a
+        return usable_ah / current
 
     def _format_time_remaining(self, hours: float | None) -> str:
         """Format remaining hours as a human-readable string."""

--- a/extension/frontend/src/components/HomeScreen.vue
+++ b/extension/frontend/src/components/HomeScreen.vue
@@ -64,20 +64,31 @@ const storageUsed = computed(() => storage.value?.used_percent ?? systemStatus.v
 const storageTotal = computed(() => storage.value?.total_gb ?? systemStatus.value?.storage_total_gb ?? 100)
 const storageAvailableGb = computed(() => storage.value?.available_gb ?? (storageTotal.value - (storage.value?.used_gb ?? systemStatus.value?.storage_used_gb ?? 0)))
 const storageType = computed(() => storage.value?.storage_type ?? 'SD Card')
+// Pack: 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel (20 Ah / 296 Wh).
+// Keep these in sync with the backend (system.py) and the dive planner
+// (MissionProgramming.vue).
+const BATTERY_PACK_COUNT = 2
+const BATTERY_PACK_AH = 10
+const BATTERY_NOMINAL_V = 14.8
+const BATTERY_TOTAL_WH = BATTERY_PACK_COUNT * BATTERY_PACK_AH * BATTERY_NOMINAL_V
+const BATTERY_RESERVE_PCT = 15
+
 const batteryTimeRemaining = computed(() => {
   const powerRPi5_W = 15
   const powerRadCAM_W = 5
   const powerPerLumen_W = 15
   const lumenCount = 2
-  const batteryCapacity_Wh = 266
 
   const totalPower_W = powerRPi5_W + powerRadCAM_W + (powerPerLumen_W * lumenCount)
-  const remainingCapacity_Wh = batteryCapacity_Wh * (batteryLevel.value / 100)
-  const hoursRemaining = totalPower_W > 0 ? remainingCapacity_Wh / totalPower_W : 0
+  const usablePct = Math.max(0, batteryLevel.value - BATTERY_RESERVE_PCT)
+  const usableCapacity_Wh = BATTERY_TOTAL_WH * (usablePct / 100)
+  const hoursRemaining = totalPower_W > 0 ? usableCapacity_Wh / totalPower_W : 0
   const h = Math.floor(hoursRemaining)
   const m = Math.round((hoursRemaining - h) * 60)
   return `${h}h ${m}m`
 })
+
+const batteryEstimateAssumption = `Assumes ${BATTERY_PACK_COUNT}× ${BATTERY_PACK_AH} Ah Blue Robotics 4S packs (${BATTERY_TOTAL_WH.toFixed(0)} Wh) at ~50 W draw, ${BATTERY_RESERVE_PCT}% reserve held back`
 
 const gpsStatus = computed<'active' | 'searching' | 'inactive'>(() => {
   if (!location.value) return 'inactive'
@@ -834,7 +845,12 @@ const formatReleaseTime = (date: Date) => {
             }"
           />
         </div>
-        <p class="text-sm mt-2" style="color: #96EEF2">Estimated: {{ batteryTimeRemaining }} remaining</p>
+        <p class="text-sm mt-2" style="color: #96EEF2" :title="batteryEstimateAssumption">
+          Estimated: {{ batteryTimeRemaining }} remaining
+        </p>
+        <p class="text-xs mt-1 opacity-75" style="color: #96EEF2">
+          2× 10 Ah 4S packs · 50 W draw · 15% reserve
+        </p>
       </div>
 
       <!-- Storage Available -->

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -165,7 +165,9 @@ const batteryData = computed(() => {
   const lumenCount = 2                  // number of lumen lights installed
 
   // -- Battery --
-  const batteryCapacity_Wh = 266        // onboard battery capacity in watt-hours
+  // 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel @ 14.8 V nominal.
+  // Keep in sync with HomeScreen.vue and backend system.py.
+  const batteryCapacity_Wh = 2 * 10 * 14.8   // 296 Wh total
 
   // -- Dive duration from depth + release weight settings --
   const depth = parseFloat(estimatedDepth.value) || 0


### PR DESCRIPTION
## Summary

- **Battery percentage** now derives State-of-Charge from the measured pack voltage using a 12-point 4S LiPo curve (16.8 V -> 100 %, 13.2 V -> 0 %). Stops trusting ArduPilot's  + '' + BATTERY_STATUS.battery_remaining + '' +  field, which is coulomb-counted against  + '' + BATT_CAPACITY + '' +  and stays at ~99 % until enough mAh have been drained -- exactly the symptom that was being seen (99 % even with the pack below 15 V).
- **Time-remaining estimate** now models the actual hardware: 2x Blue Robotics 10 Ah 4S Li-ion packs in parallel (20 Ah / 296 Wh), 50 W standard load, 15 % reserve held back. Reports 0h 0m once SOC drops into the reserve. Frontend mirrors the same constants and surfaces  + '' + 2x 10 Ah 4S packs * 50 W draw * 15% reserve + '' +  next to the displayed time.
- **Light test** no longer leaves the LED on. When  + '' + DORIS_LGT_TST + '' +  drops back to 0 the lua script's else branch was only resetting the timer marker; in CONFIG state nothing else was driving RC9 down, so the override stayed latched at the last brightness PWM. Now the on->off transition explicitly drives RC9 to  + '' + LIGHT_PWM_MIN + '' +  once, matching the pattern already used by dive cancel and recovery.

## Test plan

- [ ] Battery: check displayed % at known pack voltages (16.8 V should read 100 %, 15.0 V should read ~25 %, 13.2 V should read 0 %).
- [ ] Battery:  + '' + Estimated remaining + '' +  line on Home shows hours that match the new model (~5h 02m at full charge, no current sensor).
- [ ] Battery: caption under the bar reads  + '' + 2x 10 Ah 4S packs * 50 W draw * 15% reserve + '' + .
- [ ] Light test: hold the test button -> light comes on; release -> light turns off within one lua tick (~50 ms). Repeat several times back-to-back.
- [ ] Light test: hold for >10 s -> existing 10 s auto-clear still kicks in and turns the light off.

## Notes

-  + '' + BATT_CAPACITY=10000 + '' +  in  + '' + extension/backend/frames/doris.json + '' +  still describes a single 10 Ah pack -- harmless now that we don't rely on the autopilot's coulomb count, but worth bumping to  + '' + 20000 + '' +  in a follow-up so ArduPilot's own logging is consistent with the 2-pack rig.
- Hot-deploy path when ready to verify on the vehicle: restart the doris container (its startup hook copies  + '' + doris.lua + '' +  into the firmware scripts dir) or hot-upload  + '' + doris.lua + '' +  to  + '' + /tmp/storage/firmware/scripts/ + '' +  in  + '' + lueos-core + '' +  and  + '' + POST autopilot_manager/v1.0/restart + '' + .