### PR TITLE
fix(wifi): self-heal corrupt override + preserve bind-mount inode

### DIFF
--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -346,19 +346,46 @@ _HOSTFILE_STAGING = "/tmp/.doris_hostfile_stage"
 
 
 async def _write_host_file(path: str, content: str) -> bool:
-    """Write *content* to *path* on the host atomically.
+    """Write *content* to *path* on the host, preserving the inode in place.
 
     Streams the payload as base64 in small chunks appended to a staging
-    file, then atomically renames into place under ``sudo``. The previous
-    implementation used a single ``sudo tee <<HEREDOC`` shell command sent
-    through the Commander API's query string, which hit nginx's request
-    URI length limit (around 8 KB) for anything bigger than a few KB and
-    silently failed with HTTP 400 - notably the ~25 KB patched
-    ``networkmanager.py``. Chunked base64 keeps each request well under
-    the limit and works for any file size.
+    file, decodes the staging into a verified ``.doris.tmp`` binary,
+    then writes the verified bytes *through* the destination path with
+    a final ``cat tmp > path`` redirect. The redirect opens ``path``
+    with ``O_WRONLY|O_CREAT|O_TRUNC``, which truncates and rewrites the
+    existing inode in place when the file already exists - bind mounts
+    that target this inode (notably the wifi override mount in
+    ``blueos-core``) keep seeing the new content with no remount.
+
+    Why not the obvious ``mv tmp path``?  ``mv`` always allocates a
+    new inode; the old inode lingers as long as something else holds
+    it open. ``blueos-core``'s bind mount is established at container
+    start against the host file's inode at that moment, so after a
+    ``mv`` the in-container view still points at the previous
+    (now-orphaned) inode while the host filesystem path resolves to
+    the fresh one. We hit this in May 2026 when ``setup_hotspot_radio``
+    rewrote a corrupt override on the host but ``wifi-manager`` kept
+    crash-looping for hours because its bind-mounted view was still
+    the corrupt orphan inode. Symptom on the host:
+    ``stat -c %i host_path != stat -c %i container_path`` even though
+    the bind-mount config in ``startup.json`` is correct.
+
+    The previous implementation used a single ``sudo tee <<HEREDOC``
+    shell command sent through the Commander API's query string, which
+    hit nginx's request URI length limit (around 8 KB) for anything
+    bigger than a few KB and silently failed with HTTP 400 - notably
+    the ~25 KB patched ``networkmanager.py``. Chunked base64 keeps each
+    request well under the limit and works for any file size.
 
     Skips the write entirely if the destination already has the same
     content, avoiding unnecessary inotify churn.
+
+    Atomicity caveat: trading ``mv`` for an in-place truncate+rewrite
+    means a reader hitting *path* during the (sub-ms) ``cat`` window
+    could observe a partially-written file. Acceptable for our
+    consumers - ``wifi-manager`` reads its bind-mounted file once at
+    process start; udev and NetworkManager configs are reloaded by
+    explicit signals after this function returns.
     """
     existing = await _read_host_file(path)
     if existing is not None and existing.strip() == content.strip():
@@ -388,17 +415,21 @@ async def _write_host_file(path: str, content: str) -> bool:
             await _run_host_command(f"rm -f {_HOSTFILE_STAGING}")
             return False
 
-    # Atomic install: decode-to-temp, rename, clean up staging. The
-    # redirect must live inside the sudo'd shell so root owns the target.
+    # Install in two steps under one sudo'd shell:
+    #   1. base64 -d into a verified ``.doris.tmp`` (any decode error
+    #      stops here, leaving ``path`` untouched).
+    #   2. cat ``.doris.tmp > path``: ``>`` opens ``path`` with
+    #      O_TRUNC, preserving the inode if the file exists - which
+    #      is what keeps active bind mounts seeing the new content.
     final_cmd = (
         f"sudo bash -c 'base64 -d {_HOSTFILE_STAGING} > {path}.doris.tmp"
-        f" && mv {path}.doris.tmp {path}"
-        f" && rm -f {_HOSTFILE_STAGING}'"
+        f" && cat {path}.doris.tmp > {path}"
+        f" && rm -f {path}.doris.tmp {_HOSTFILE_STAGING}'"
     )
     ok, _ = await _run_host_command(final_cmd)
     if ok:
         logger.info(
-            "Wrote %s on host (%d bytes via %d base64 chunks)",
+            "Wrote %s on host (%d bytes via %d base64 chunks, inode-preserving)",
             path, len(content), total_chunks,
         )
     else:
@@ -578,6 +609,18 @@ async def _install_create_ap_speed_patch() -> None:
     channel) is stripped first via :func:`_strip_doris_patch`, then
     the current canonical block is applied. :func:`_write_host_file`
     short-circuits when the host file already matches.
+
+    Self-healing on existing corruption: if the bind-mounted source we
+    read here is not valid Python, an earlier DORIS extension version
+    (or an interrupted write) must have left a corrupt file on the host.
+    Patching a corrupt source and writing it back would just re-stamp
+    the corruption on every boot - which is exactly how we ended up in
+    a ``SyntaxError`` crash loop for ``wifi-manager`` in May 2026. So
+    we detect that case with :func:`ast.parse`, delete the host
+    override outright, and bail without writing. The next
+    ``blueos-core`` restart re-binds to the stock file from the image,
+    and the *next* :func:`setup_hotspot_radio` reads a clean baseline
+    and re-installs the patch correctly.
     """
     source = await _read_container_file(
         BLUEOS_CORE_CONTAINER, WIFI_OVERRIDE_CONTAINER_PATH
@@ -588,6 +631,23 @@ async def _install_create_ap_speed_patch() -> None:
             WIFI_OVERRIDE_CONTAINER_PATH,
             BLUEOS_CORE_CONTAINER,
         )
+        return
+
+    try:
+        ast.parse(source)
+    except SyntaxError as exc:
+        logger.warning(
+            "Bind-mounted %s is not valid Python (line %s: %s); a prior "
+            "DORIS write was corrupted. Removing host override %s so "
+            "blueos-core falls back to stock wifi-manager networkmanager.py "
+            "on next restart - the next DORIS run will re-patch from the "
+            "clean baseline.",
+            WIFI_OVERRIDE_CONTAINER_PATH,
+            exc.lineno,
+            exc.msg,
+            WIFI_OVERRIDE_HOST_PATH,
+        )
+        await _run_host_command(f"sudo rm -f {WIFI_OVERRIDE_HOST_PATH}")
         return
 
     if _CREATE_AP_ANCHOR not in source:

--- a/extension/backend/tests/test_hotspot_radio.py
+++ b/extension/backend/tests/test_hotspot_radio.py
@@ -1,0 +1,278 @@
+"""Tests for `doris.services.hotspot_radio`.
+
+These exercise the units that have caused field bugs: the legacy-patch
+stripper, the self-heal-on-corrupt-source path in
+``_install_create_ap_speed_patch``, and the inode-preserving write
+command shape in ``_write_host_file``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from doris.services import hotspot_radio
+
+# ---------------------------------------------------------------------
+# _strip_doris_patch: pure function, easy to exercise across the
+# legacy 5 GHz block and the current 2.4 GHz block.
+# ---------------------------------------------------------------------
+
+
+ANCHOR = hotspot_radio._CREATE_AP_ANCHOR
+
+
+def _wrap(payload: str) -> str:
+    """Wrap *payload* in a minimal `wifi-manager` argv list."""
+    return (
+        "argv = [\n"
+        '            "create_ap",\n'
+        f"{ANCHOR}"
+        f"{payload}"
+        '            ssid,\n'
+        '            password,\n'
+        "]\n"
+    )
+
+
+CURRENT_24GHZ_PATCH = (
+    '            "-c", "6",\n'
+    '            "--ieee80211n",\n'
+    '            "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]'
+    '[LDPC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40]",\n'
+    '            "--country", "US",\n'
+)
+
+
+LEGACY_5GHZ_PATCH = (
+    '            "--freq-band", "5",\n'
+    '            "-c", "36",\n'
+    '            "--ieee80211n",\n'
+    '            "--ieee80211ac",\n'
+    '            "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]",\n'
+    '            "--vht_capab", "[SHORT-GI-80][MAX-MPDU-11454]",\n'
+    '            "--country", "US",\n'
+)
+
+
+def test_strip_doris_patch_noop_on_unpatched_source() -> None:
+    src = _wrap("")
+    assert hotspot_radio._strip_doris_patch(src) == src
+
+
+def test_strip_doris_patch_removes_current_24ghz_block() -> None:
+    src = _wrap(CURRENT_24GHZ_PATCH)
+    stripped = hotspot_radio._strip_doris_patch(src)
+    assert stripped == _wrap("")
+    assert "--ht_capab" not in stripped
+
+
+def test_strip_doris_patch_removes_legacy_5ghz_block() -> None:
+    src = _wrap(LEGACY_5GHZ_PATCH)
+    stripped = hotspot_radio._strip_doris_patch(src)
+    assert stripped == _wrap("")
+    assert "--freq-band" not in stripped
+    assert "--vht_capab" not in stripped
+
+
+def test_strip_doris_patch_idempotent() -> None:
+    src = _wrap(CURRENT_24GHZ_PATCH)
+    once = hotspot_radio._strip_doris_patch(src)
+    twice = hotspot_radio._strip_doris_patch(once)
+    assert once == twice
+
+
+def test_strip_doris_patch_does_not_eat_unrelated_args() -> None:
+    """A non-DORIS argv entry after the anchor must be preserved."""
+    unrelated = '            "--something-else", "value",\n'
+    src = _wrap(unrelated)
+    assert hotspot_radio._strip_doris_patch(src) == src
+
+
+# ---------------------------------------------------------------------
+# Self-heal path: when the bind-mounted source we read back is
+# syntactically broken, we must NOT re-write it - we must delete the
+# host override so the next blueos-core restart falls back to the
+# stock baseline.
+# ---------------------------------------------------------------------
+
+
+class _RunHostCommandRecorder:
+    """Stand-in for ``_run_host_command`` that records every call and
+    returns a configurable result per pattern."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.responses: list[tuple[bool, str]] = []
+
+    def respond(self, ok: bool, out: str = "") -> None:
+        self.responses.append((ok, out))
+
+    async def __call__(self, command: str, timeout: float = 30.0) -> tuple[bool, str]:
+        self.calls.append(command)
+        if self.responses:
+            return self.responses.pop(0)
+        return True, ""
+
+
+@pytest.fixture
+def patched_command(monkeypatch: pytest.MonkeyPatch) -> _RunHostCommandRecorder:
+    rec = _RunHostCommandRecorder()
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+    return rec
+
+
+CORRUPT_SOURCE = (
+    "def scan_networks():\n"
+    "    # Same shape of corruption that bit us in May 2026.\n"
+    "    flag_str = f\"[{\\'-\\'.join(set(security_flags))}]\"\n"
+    "    return flag_str\n"
+)
+
+
+CLEAN_SOURCE_WITH_ANCHOR = _wrap("")
+
+
+CLEAN_SOURCE_NO_ANCHOR = (
+    "def scan_networks():\n"
+    "    return []\n"
+)
+
+
+async def test_install_patch_removes_override_when_source_is_corrupt(
+    patched_command: _RunHostCommandRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(container: str, path: str) -> str:
+        return CORRUPT_SOURCE
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+
+    # If we reached _pick_24ghz_channel something is wrong - the
+    # corruption check should bail before it. Trip the test loudly
+    # if it ever does.
+    async def must_not_run() -> int:
+        raise AssertionError(
+            "_pick_24ghz_channel must not run on corrupt source"
+        )
+
+    monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", must_not_run)
+
+    await hotspot_radio._install_create_ap_speed_patch()
+
+    rm_cmds = [c for c in patched_command.calls if "rm -f" in c]
+    assert any(
+        hotspot_radio.WIFI_OVERRIDE_HOST_PATH in c for c in rm_cmds
+    ), (
+        f"expected `rm -f {hotspot_radio.WIFI_OVERRIDE_HOST_PATH}` to be "
+        f"issued; got commands: {patched_command.calls}"
+    )
+    # And we must not have tried to install anything.
+    assert not any(
+        ".doris.tmp" in c for c in patched_command.calls
+    ), "must not write to host while source is corrupt"
+
+
+async def test_install_patch_skips_when_anchor_missing(
+    patched_command: _RunHostCommandRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Upstream BlueOS could re-name the create_ap call; we must not
+    rm the override in that case, just skip."""
+
+    async def fake_read(container: str, path: str) -> str:
+        return CLEAN_SOURCE_NO_ANCHOR
+
+    async def must_not_run() -> int:
+        raise AssertionError("picker should not run if anchor is missing")
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", must_not_run)
+
+    await hotspot_radio._install_create_ap_speed_patch()
+
+    assert not any(
+        hotspot_radio.WIFI_OVERRIDE_HOST_PATH in c and "rm" in c
+        for c in patched_command.calls
+    ), "anchor-missing must not delete the override file"
+
+
+async def test_install_patch_writes_when_source_is_clean(
+    patched_command: _RunHostCommandRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: clean parseable source + anchor present results in
+    a write to the host override path."""
+
+    async def fake_read(container: str, path: str) -> str:
+        return CLEAN_SOURCE_WITH_ANCHOR
+
+    write_calls: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        write_calls.append((path, content))
+        return True
+
+    async def fake_pick() -> int:
+        return 6
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+    monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", fake_pick)
+
+    await hotspot_radio._install_create_ap_speed_patch()
+
+    assert len(write_calls) == 1
+    path, content = write_calls[0]
+    assert path == hotspot_radio.WIFI_OVERRIDE_HOST_PATH
+    assert '"-c", "6"' in content
+    assert "--ht_capab" in content
+
+
+# ---------------------------------------------------------------------
+# _write_host_file: must emit a final command that preserves the
+# destination inode (cat ... > path) rather than the inode-replacing
+# ``mv`` pattern.
+# ---------------------------------------------------------------------
+
+
+async def test_write_host_file_uses_inode_preserving_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _RunHostCommandRecorder()
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+
+    async def fake_read(path: str) -> str | None:
+        return None  # destination doesn't exist yet
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+
+    ok = await hotspot_radio._write_host_file("/tmp/some-dest", "hello world\n")
+    assert ok
+
+    final_cmd = rec.calls[-1]
+    # Must redirect through the destination (preserves existing inode)
+    assert "> /tmp/some-dest" in final_cmd, final_cmd
+    # Must NOT use the inode-breaking `mv` pattern for installing
+    # into the destination.  ``rm -f .doris.tmp`` is fine; what we
+    # are forbidding is a ``mv X /tmp/some-dest`` style install.
+    assert "mv " not in final_cmd or "/tmp/some-dest" not in final_cmd.split("mv ", 1)[1].split()[:2], (
+        f"_write_host_file must not install via `mv`; got: {final_cmd}"
+    )
+
+
+async def test_write_host_file_skips_when_existing_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _RunHostCommandRecorder()
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+
+    async def fake_read(path: str) -> str | None:
+        return "hello world\n"
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+
+    ok = await hotspot_radio._write_host_file("/tmp/some-dest", "hello world\n")
+    assert ok
+    # No host commands should have been issued at all - the
+    # short-circuit must fire before chunked writes start.
+    assert rec.calls == [], rec.calls


### PR DESCRIPTION
## Summary

Two latent bugs in `hotspot_radio` combined to brick a real install in May 2026 and leave the AP unbootable for ~30 min. Both are fixed here, both are tested, both are verified on hardware.

### Bug A — `_install_create_ap_speed_patch` re-stamps pre-existing corruption

`_install_create_ap_speed_patch` does read → strip → patch → write. The "read" comes from the bind-mounted source inside `blueos-core` via Commander. If a *previous* extension version's broken Commander decoder already wrote a file with literal `\'` inside an f-string (and committed it to the override path), the new extension just hands that corrupt source through `_strip_doris_patch` and writes it back verbatim. `wifi-manager` then crash-loops on import with `SyntaxError: f-string expression part cannot include a backslash` and the AP never comes up.

**Fix:** `ast.parse(source)` immediately after the read. On `SyntaxError`, `sudo rm` the host override and bail without writing. The next `blueos-core` restart re-binds to the stock baseline from the image, and the next DORIS run reads a clean source and re-patches correctly.

### Bug B — `_write_host_file`'s `mv` strategy breaks active bind mounts

The final install step used `sudo mv tmp path`. `mv` always allocates a new inode for `path`. But `blueos-core` bind-mounted `/usr/blueos/userdata/wifi-overrides/networkmanager.py` into the container against the **inode** at container start. So after a `mv` the in-container view still resolves through the previous (now-orphaned-but-still-mounted) inode, while `sudo cat` on the host shows fresh content. Inode comparison from the actual incident:

```
before mv: host=997659  container=997659   (same inode, bind healthy)
after  mv: host=997659  container=998161   (different inodes, stale bind!)
```

We wrote a clean fix to the host, `sudo cat` confirmed it was clean, and `wifi-manager` kept crashing. Only a `blueos-core` restart cleared it.

**Fix:** drop the `mv` for an in-place `cat tmp > path`. `>` opens `path` with `O_WRONLY|O_CREAT|O_TRUNC`, which truncates and rewrites the **existing** inode when the file exists. Active bind mounts continue to see the new content immediately. New files are still created cleanly when the destination doesn't exist.

Atomicity caveat: a reader hitting `path` during the (sub-millisecond) `cat` window could observe a partial file. Acceptable for our consumers — `wifi-manager` reads its bind-mounted file once at process start; udev and NetworkManager configs are reloaded by explicit signals after this function returns.

## Tests

`extension/backend/tests/test_hotspot_radio.py` — 10 tests, all passing locally:

- `_strip_doris_patch`: no-op, removes current 2.4 GHz block, removes legacy 5 GHz block, idempotent, doesn't eat unrelated args.
- `_install_create_ap_speed_patch`: self-heal removes override on corrupt source (and doesn't call the channel picker); anchor-missing skips without deleting; happy path writes patch with picked channel + `--ht_capab` flags.
- `_write_host_file`: final command uses inode-preserving redirect (not `mv`); short-circuits when existing content already matches.

## Hardware verification

Both fixes hot-deployed onto the live vehicle and exercised:

**Self-heal:**
```
Staged a deliberately-corrupt override at /usr/blueos/userdata/wifi-overrides/networkmanager.py
Triggered _install_create_ap_speed_patch() in DORIS python:
  -> WARNING: Bind-mounted ... is not valid Python (line 2: f-string expression
              part cannot include a backslash); a prior DORIS write was
              corrupted. Removing host override ...
Result: REMOVED (self-heal worked)
```

**Inode preservation across 3 sequential writes:**
```
Write #1 (12 B):    inode=55154
Write #2 (28 B):    inode=55154   <- same!
Write #3 (5000 B):  inode=55154   <- same!
PASS: inode preserved across 3 writes
```

## Test plan

- [x] All 10 new unit tests pass locally (`pytest tests/test_hotspot_radio.py`)
- [x] Existing 27 tests still pass (`pytest tests/` excluding SITL)
- [x] Ruff lint clean on changed files
- [x] Self-heal exercised on real hardware against a known-corrupt fixture
- [x] Inode preservation verified across 3 writes (12 B / 28 B / 5000 B) on real hardware
- [ ] Install built artifact on the vehicle, power-cycle, confirm AP comes up clean even if the previous build left a corrupt override
