### PR TITLE
fix(wifi): self-heal must also remove bind entry from startup.json

### DIFF
--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -143,6 +143,22 @@ its retransmit count dropped from ~14,900/min to ~30/min.
 Note on ``sudo``: the BlueOS Commander API's shell PATH does not include
 ``/sbin`` or ``/usr/sbin``, so ``udevadm`` and friends are only reachable
 through ``sudo`` (which resets the PATH).
+
+Note on the bind-mount + missing-source booby trap: Docker silently
+creates an empty *directory* at any bind-mount source path that doesn't
+exist on the host. So a transient state where ``startup.json`` lists
+``/usr/blueos/userdata/wifi-overrides/networkmanager.py`` as a bind
+source while the host file is missing is fatal - the next
+``blueos-core`` restart turns the missing source into a directory, then
+container init fails with "not a directory" because the target is a
+file, and ``blueos-bootstrap`` falls back to the factory image. We hit
+this on the vehicle in May 2026 after :func:`_install_create_ap_speed
+_patch`'s self-heal ``rm``'d a corrupt override without also removing
+the bind entry. The fix - and the contract every caller in this module
+must honour - is: **never delete the override file while its bind entry
+is still in startup.json**. The self-heal path now removes the bind
+*first*, then the file; :func:`_remove_startup_bind` is the safe
+counterpart to :func:`_ensure_startup_bind` for that purpose.
 """
 
 import ast
@@ -638,15 +654,27 @@ async def _install_create_ap_speed_patch() -> None:
     except SyntaxError as exc:
         logger.warning(
             "Bind-mounted %s is not valid Python (line %s: %s); a prior "
-            "DORIS write was corrupted. Removing host override %s so "
-            "blueos-core falls back to stock wifi-manager networkmanager.py "
-            "on next restart - the next DORIS run will re-patch from the "
-            "clean baseline.",
+            "DORIS write was corrupted. Removing host override %s AND its "
+            "bind-mount entry from %s so blueos-core falls back to stock "
+            "wifi-manager networkmanager.py on next restart - the next "
+            "DORIS run will re-patch from the clean baseline and "
+            "re-install the bind.",
             WIFI_OVERRIDE_CONTAINER_PATH,
             exc.lineno,
             exc.msg,
             WIFI_OVERRIDE_HOST_PATH,
+            BOOTSTRAP_STARTUP_JSON,
         )
+        # Order matters: REMOVE THE BIND ENTRY FIRST, then delete the
+        # file. If we did it the other way and a blueos-core restart
+        # happened in between, Docker would silently create the missing
+        # source as a directory (default behavior for absent bind
+        # sources), then fail the next container start with
+        # "Are you trying to mount a directory onto a file" and
+        # blueos-bootstrap would fall back to the factory image. We hit
+        # exactly this on the vehicle in May 2026, which is why both
+        # steps are non-negotiable here.
+        await _remove_startup_bind()
         await _run_host_command(f"sudo rm -f {WIFI_OVERRIDE_HOST_PATH}")
         return
 
@@ -668,6 +696,63 @@ async def _install_create_ap_speed_patch() -> None:
 
     await _run_host_command(f"sudo mkdir -p {WIFI_OVERRIDE_DIR}")
     await _write_host_file(WIFI_OVERRIDE_HOST_PATH, patched)
+
+
+async def _remove_startup_bind() -> None:
+    """Remove the wifi-override bind from ``startup.json`` if present.
+
+    Counterpart to :func:`_ensure_startup_bind`, used by the self-heal
+    path in :func:`_install_create_ap_speed_patch` when we have to
+    delete the host override.
+
+    Why this exists: Docker silently creates an empty *directory* at
+    any bind-mount source that doesn't exist on the host. So if we
+    delete the host override while ``startup.json`` still lists it as a
+    bind source, the next ``blueos-core`` restart triggers Docker to
+    create a directory at that path, then container init fails with
+    ``not a directory: Are you trying to mount a directory onto a
+    file (or vice-versa)?`` and ``blueos-bootstrap`` falls back to the
+    factory image (silently re-pinning the user away from their
+    chosen blueos-core tag). Removing the bind entry first means the
+    next ``blueos-core`` restart simply doesn't try to mount anything
+    at that path; on a subsequent DORIS run we add the bind back and
+    install a fresh override.
+
+    No-op if the entry isn't present or the JSON can't be parsed -
+    matches the conservative shape of :func:`_ensure_startup_bind`.
+    """
+    raw = await _read_host_file(BOOTSTRAP_STARTUP_JSON)
+    if raw is None:
+        logger.warning(
+            "Could not read %s; skipping bind-mount removal",
+            BOOTSTRAP_STARTUP_JSON,
+        )
+        return
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.warning(
+            "Bootstrap %s is not valid JSON: %s", BOOTSTRAP_STARTUP_JSON, e
+        )
+        return
+
+    binds = data.get("core", {}).get("binds", {})
+    if WIFI_OVERRIDE_HOST_PATH not in binds:
+        logger.info(
+            "No wifi-override bind in %s; nothing to remove",
+            BOOTSTRAP_STARTUP_JSON,
+        )
+        return
+
+    del binds[WIFI_OVERRIDE_HOST_PATH]
+    new_content = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    if await _write_host_file(BOOTSTRAP_STARTUP_JSON, new_content):
+        logger.info(
+            "Removed wifi-override bind from %s; restart blueos-core to "
+            "drop the stale mount",
+            BOOTSTRAP_STARTUP_JSON,
+        )
 
 
 async def _ensure_startup_bind() -> None:

--- a/extension/backend/tests/test_hotspot_radio.py
+++ b/extension/backend/tests/test_hotspot_radio.py
@@ -157,6 +157,13 @@ async def test_install_patch_removes_override_when_source_is_corrupt(
 
     monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", must_not_run)
 
+    remove_bind_called = []
+
+    async def fake_remove_bind() -> None:
+        remove_bind_called.append(True)
+
+    monkeypatch.setattr(hotspot_radio, "_remove_startup_bind", fake_remove_bind)
+
     await hotspot_radio._install_create_ap_speed_patch()
 
     rm_cmds = [c for c in patched_command.calls if "rm -f" in c]
@@ -166,10 +173,55 @@ async def test_install_patch_removes_override_when_source_is_corrupt(
         f"expected `rm -f {hotspot_radio.WIFI_OVERRIDE_HOST_PATH}` to be "
         f"issued; got commands: {patched_command.calls}"
     )
+    # The bind entry MUST be removed too - otherwise Docker creates
+    # a directory at the missing source on next blueos-core restart
+    # and bootstrap falls back to factory (the May 2026 incident).
+    assert remove_bind_called, (
+        "self-heal must also remove the bind from startup.json; "
+        "deleting only the file leaves a booby trap for next "
+        "blueos-core restart"
+    )
     # And we must not have tried to install anything.
     assert not any(
         ".doris.tmp" in c for c in patched_command.calls
     ), "must not write to host while source is corrupt"
+
+
+async def test_install_patch_removes_bind_BEFORE_file_on_corrupt_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ordering matters: removing the bind first prevents Docker from
+    seeing a startup.json entry pointing at a missing source.  If the
+    rm happens first and a blueos-core restart sneaks in before the
+    bind removal lands, Docker auto-creates a directory at the missing
+    source and the next start fails."""
+
+    async def fake_read(container: str, path: str) -> str:
+        return CORRUPT_SOURCE
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+
+    order: list[str] = []
+
+    async def fake_remove_bind() -> None:
+        order.append("remove_bind")
+
+    rec = _RunHostCommandRecorder()
+    original_call = rec.__call__
+
+    async def recording_run_host_command(command: str, timeout: float = 30.0):
+        if "rm -f" in command and hotspot_radio.WIFI_OVERRIDE_HOST_PATH in command:
+            order.append("rm_file")
+        return await original_call(command, timeout)
+
+    monkeypatch.setattr(hotspot_radio, "_remove_startup_bind", fake_remove_bind)
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", recording_run_host_command)
+
+    await hotspot_radio._install_create_ap_speed_patch()
+
+    assert order == ["remove_bind", "rm_file"], (
+        f"expected bind-removal BEFORE file-removal; got: {order}"
+    )
 
 
 async def test_install_patch_skips_when_anchor_missing(
@@ -258,6 +310,119 @@ async def test_write_host_file_uses_inode_preserving_redirect(
     assert "mv " not in final_cmd or "/tmp/some-dest" not in final_cmd.split("mv ", 1)[1].split()[:2], (
         f"_write_host_file must not install via `mv`; got: {final_cmd}"
     )
+
+
+# ---------------------------------------------------------------------
+# _remove_startup_bind: counterpart of _ensure_startup_bind, used by
+# the self-heal path.  Must rewrite startup.json with our bind entry
+# stripped while leaving every other bind untouched.
+# ---------------------------------------------------------------------
+
+
+def _startup_json_with_our_bind() -> str:
+    """A miniature startup.json that contains our wifi-override bind
+    plus an unrelated bind we must not touch."""
+    import json as _json
+
+    return _json.dumps({
+        "core": {
+            "tag": "1.5.0",
+            "binds": {
+                "/dev/": {"bind": "/dev/", "mode": "rw"},
+                hotspot_radio.WIFI_OVERRIDE_HOST_PATH: {
+                    "bind": hotspot_radio.WIFI_OVERRIDE_CONTAINER_PATH,
+                    "mode": "ro",
+                },
+            },
+        }
+    }, indent=2) + "\n"
+
+
+def _startup_json_without_our_bind() -> str:
+    import json as _json
+
+    return _json.dumps({
+        "core": {
+            "tag": "1.5.0",
+            "binds": {
+                "/dev/": {"bind": "/dev/", "mode": "rw"},
+            },
+        }
+    }, indent=2) + "\n"
+
+
+async def test_remove_startup_bind_removes_our_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(path: str) -> str:
+        assert path == hotspot_radio.BOOTSTRAP_STARTUP_JSON
+        return _startup_json_with_our_bind()
+
+    written: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        written.append((path, content))
+        return True
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+
+    await hotspot_radio._remove_startup_bind()
+
+    assert len(written) == 1
+    path, content = written[0]
+    assert path == hotspot_radio.BOOTSTRAP_STARTUP_JSON
+    import json as _json
+
+    parsed = _json.loads(content)
+    binds = parsed["core"]["binds"]
+    assert hotspot_radio.WIFI_OVERRIDE_HOST_PATH not in binds, (
+        "our bind entry must be gone after _remove_startup_bind"
+    )
+    # And unrelated binds must remain untouched.
+    assert "/dev/" in binds
+
+
+async def test_remove_startup_bind_noop_when_entry_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(path: str) -> str:
+        return _startup_json_without_our_bind()
+
+    written: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        written.append((path, content))
+        return True
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+
+    await hotspot_radio._remove_startup_bind()
+    assert written == [], (
+        f"must not rewrite startup.json when our bind isn't there; "
+        f"got writes: {written}"
+    )
+
+
+async def test_remove_startup_bind_handles_unreadable_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(path: str) -> None:
+        return None  # simulate Commander not returning content
+
+    written: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        written.append((path, content))
+        return True
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+
+    # Must not raise even if startup.json can't be read.
+    await hotspot_radio._remove_startup_bind()
+    assert written == []
 
 
 async def test_write_host_file_skips_when_existing_matches(


### PR DESCRIPTION
## Summary

Follow-up to #17 — fixes a real failure mode that surfaced on the vehicle after that PR merged.

The self-heal path added in #17 did `sudo rm -f /usr/blueos/userdata/wifi-overrides/networkmanager.py` while `startup.json` still listed that path as a bind source. On the next `blueos-core` restart, Docker followed its default behaviour for absent bind sources and **auto-created the missing path as a directory**. Container init then tried to mount that directory onto the file path `/home/pi/services/wifi/wifi_handlers/networkmanager/networkmanager.py` inside the container and failed with:

```
OCI runtime create failed: ... not a directory:
Are you trying to mount a directory onto a file (or vice-versa)?
```

`blueos-bootstrap` caught the 400, dropped to `bluerobotics/blueos-core:factory`, and rewrote `startup.json` without our bind entry. The user was silently re-pinned to the factory image with the DORIS wifi patches inert.

## Fix

Add `_remove_startup_bind`, the safe counterpart of `_ensure_startup_bind`, and have the self-heal path call it **before** the `rm`. Ordering matters: if the file is deleted before the bind is removed and a `blueos-core` restart sneaks in between, we're back to the same directory-creation footgun.

The module-level docstring now spells out the invariant every caller in this file has to honour:

> **never delete the override file while its bind entry is still in `startup.json`**

## Tests

- `test_install_patch_removes_override_when_source_is_corrupt` extended to assert `_remove_startup_bind` is also called.
- New `test_install_patch_removes_bind_BEFORE_file_on_corrupt_source` pins the call ordering explicitly.
- New `_remove_startup_bind` tests:
  - removes our entry, leaves unrelated binds alone
  - no-op when our entry isn't present
  - tolerates `_read_host_file` returning `None`

14 tests total in `test_hotspot_radio.py`, all passing locally.

## Test plan

- [x] Unit tests pass (`pytest tests/test_hotspot_radio.py`)
- [x] Pre-existing tests still green
- [x] Ruff lint clean on changed lines
- [ ] Install built artifact on the vehicle, confirm the self-heal path completes without re-triggering a factory revert. Vehicle is currently sitting on factory tag from the #17 fallout — recovery + verification will happen on the build that includes this fix.
