### PR TITLE
ci(deploy): bump deploy-ghcr actions to Node 24 majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,16 +41,16 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Extract metadata for GHCR
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_PREFIX }}${{ env.IMAGE_NAME }}
           tags: |
@@ -68,7 +68,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
 
       - name: Build and push to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./extension
           # See deploy-docker above: arm/v7 is intentionally omitted.


### PR DESCRIPTION
## Summary

CI is emitting GitHub's Node 20 deprecation warning on every `deploy-ghcr` run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `docker/build-push-action@v5`, `docker/login-action@v3`, `docker/metadata-action@v5`, `docker/setup-buildx-action@v3`, `docker/setup-qemu-action@v3`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

(Source: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>)

Bump each affected action in `deploy-ghcr` to its latest major that declares Node 24 as default runtime:

| Action | Current | New |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v5` |
| `docker/setup-qemu-action` | `v3` | `v4` |
| `docker/setup-buildx-action` | `v3` | `v4` |
| `docker/login-action` | `v3` | `v4` |
| `docker/metadata-action` | `v5` | `v6` |
| `docker/build-push-action` | `v5` | `v7` (skips a Node 20 `v6` line) |

All of these majors are pure Node 20 → Node 24 runtime bumps with no breaking changes to the inputs/outputs we use. The only other notable change is `docker/build-push-action@v7` removed the legacy `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` env vars (we don't set either) and switched to ESM internally. Minimum runner version `v2.327.1` is already what `ubuntu-latest` runs.

`deploy-docker` is untouched — it delegates to the third-party `BlueOS-community/Deploy-BlueOS-Extension@main` action, which the warning didn't flag and which we'd ask the upstream maintainer to update separately.

## Test plan

- [x] Diff is a clean 6-line version bump with no other config changes
- [ ] CI green on this PR (the workflow runs on `pull_request`, so opening the PR is itself the test)
- [ ] Verify the deprecation warning is gone from the GitHub Actions log
