### PR TITLE
fix(wifi): harden the hotspot setup against the four bugs Tony surfaced on bh-0.4.0

### DIFF
--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -195,16 +195,38 @@ BOOTSTRAP_STARTUP_JSON = "/root/.config/blueos/bootstrap/startup.json"
 # ends ``--redirect-to-localhost`` and continues with the SSID/password.
 # We insert our HT20-with-full-caps flags between the anchor and the SSID
 # line.
-_CREATE_AP_ANCHOR = (
-    '            "--redirect-to-localhost",'
-    "  # Redirect all traffic to localhost, captive-portal style\n"
+#
+# Anchor strategy is *regex on the argv token* rather than exact match
+# on the line including its trailing comment. The previous
+# implementation pinned the anchor to ``            "--redirect-to-
+# localhost",  # Redirect all traffic ...`` - exactly 12 leading
+# spaces, exactly that comment, exactly that wording. Any upstream
+# reformat (reindent, comment edit, comma-then-trailing-comment, comma
+# alone, no comma at end of list) silently broke the patch with no
+# loud signal and the install fell through to stock ``create_ap``
+# args. We now match on just the argv-token line and capture the
+# leading whitespace so the inserted flags re-emit with the same
+# indentation regardless of upstream formatting changes.
+#
+# The regex requires *some* leading whitespace because a top-level
+# occurrence of the string ``"--redirect-to-localhost"`` (e.g. in a
+# docstring or comment) would not be inside the argv list and would
+# be the wrong place to inject flags. We accept both ``,`` and a bare
+# end of line after the token so a future upstream that drops the
+# trailing comma still matches.
+_CREATE_AP_ANCHOR_RE = re.compile(
+    r'^(?P<indent>[ \t]+)"--redirect-to-localhost",?(?:[ \t]*#[^\n]*)?\n',
+    re.MULTILINE,
 )
 
-# Maxed-out 2.4 GHz HT20 configuration. The ``{channel}`` placeholder is
-# filled at install time by :func:`_pick_24ghz_channel` so the AP lands
-# on whichever of channels 1/6 is least crowded.  Channel 11 is left
+# Maxed-out 2.4 GHz HT20 configuration. ``{channel}`` is filled at
+# install time by :func:`_pick_24ghz_channel` so the AP lands on
+# whichever of channels 1/6 is least crowded.  Channel 11 is left
 # out because the DORIS potted external antenna's SWR sweet spot is
 # the lower half of the 2.4 GHz band; see :func:`_pick_24ghz_channel`.
+# ``{indent}`` is filled with the whitespace captured by
+# :data:`_CREATE_AP_ANCHOR_RE` so the inserted lines line up with the
+# surrounding argv entries regardless of upstream indentation choice.
 #
 # Why HT20 and not HT40?  The ``morrownr/88x2bu-20210702`` driver
 # advertises HT40 in ``iw phy phy1 info`` but its AP-mode firmware path
@@ -227,21 +249,22 @@ _CREATE_AP_ANCHOR = (
 # RX-STBC1, MAX-AMSDU-7935, DSSS/CCK in HT40) all stick at HT20 and
 # lift real TCP throughput from ~25 Mbps (stock) to ~80 Mbps.
 _CREATE_AP_24GHZ_FLAGS_TEMPLATE = (
-    '            "-c", "{channel}",\n'
-    '            "--ieee80211n",\n'
-    '            "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]'
+    '{indent}"-c", "{channel}",\n'
+    '{indent}"--ieee80211n",\n'
+    '{indent}"--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]'
     '[LDPC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40]",\n'
-    '            "--country", "US",\n'
+    '{indent}"--country", "US",\n'
 )
 
 # Matches *any* DORIS create_ap insertion that may already follow
-# ``_CREATE_AP_ANCHOR`` - either the legacy 5 GHz attempt (with
-# ``--freq-band 5`` and ``--vht_capab``) or the current 2.4 GHz patch
-# with any auto-picked channel. Used at install time so re-running the
-# patch on an upgraded install converges to the current canonical block
-# instead of stacking flags. Anchored via ``re.match`` from the position
-# right after ``_CREATE_AP_ANCHOR``, never used as a free search, so
-# false positives outside our managed region are impossible.
+# the anchor matched by :data:`_CREATE_AP_ANCHOR_RE` - either the
+# legacy 5 GHz attempt (with ``--freq-band 5`` and ``--vht_capab``)
+# or the current 2.4 GHz patch with any auto-picked channel. Used at
+# install time so re-running the patch on an upgraded install
+# converges to the current canonical block instead of stacking flags.
+# Anchored via ``re.match`` from the position right after the
+# anchor match, never used as a free search, so false positives
+# outside our managed region are impossible.
 _DORIS_PATCH_BLOCK_RE = re.compile(
     r'(?:[ \t]*"--freq-band", "[0-9]+",\n)?'        # legacy 5 GHz only
     r'[ \t]*"-c", "[0-9]+",\n'                      # always present
@@ -593,23 +616,24 @@ async def _pick_24ghz_channel() -> int:
 
 def _strip_doris_patch(source: str) -> str:
     """Remove any prior DORIS ``create_ap`` insertion that immediately
-    follows :data:`_CREATE_AP_ANCHOR`. No-op if no such block is present.
+    follows the anchor line matched by :data:`_CREATE_AP_ANCHOR_RE`.
+    No-op if no such block is present.
 
     Anchored to the position right after the anchor line so we can never
     accidentally strip something else that happens to look like our
     flags elsewhere in the file.
     """
-    anchor_idx = source.find(_CREATE_AP_ANCHOR)
-    if anchor_idx < 0:
+    anchor_match = _CREATE_AP_ANCHOR_RE.search(source)
+    if anchor_match is None:
         return source
-    end_of_anchor = anchor_idx + len(_CREATE_AP_ANCHOR)
-    m = _DORIS_PATCH_BLOCK_RE.match(source, end_of_anchor)
-    if not m:
+    end_of_anchor = anchor_match.end()
+    block_match = _DORIS_PATCH_BLOCK_RE.match(source, end_of_anchor)
+    if not block_match:
         return source
-    return source[:end_of_anchor] + source[m.end():]
+    return source[:end_of_anchor] + source[block_match.end():]
 
 
-async def _install_create_ap_speed_patch() -> None:
+async def _install_create_ap_speed_patch() -> bool:
     """Patch wifi-manager's ``create_ap`` invocation for max 2.4 GHz HT20.
 
     Reads the in-container ``networkmanager.py``, picks the cleanest
@@ -619,6 +643,19 @@ async def _install_create_ap_speed_patch() -> None:
     ``/usr/blueos/userdata/wifi-overrides/networkmanager.py`` so the
     bind mount in ``startup.json`` picks it up on the next
     ``blueos-core`` start.
+
+    Returns ``True`` iff the host override file is in place with the
+    canonical patch applied (either because we just wrote it, or
+    because :func:`_write_host_file` short-circuited a no-op when the
+    on-disk content already matched). Returns ``False`` on every
+    failure path: source unreadable, source corrupt (self-heal path),
+    anchor missing, or chunked write failed. Callers MUST treat
+    ``False`` as "do not add or keep the bind entry in
+    ``startup.json``" because pointing a bind at a missing/un-patched
+    source is the factory-revert footgun documented in the module
+    docstring - and the self-heal path here actively removes the
+    entry, which gets undone if a subsequent
+    :func:`_ensure_startup_bind` re-adds it.
 
     Upgrade-safe and re-run-safe: any prior DORIS patch (legacy 5 GHz
     attempt, or current 2.4 GHz patch with a different auto-picked
@@ -647,7 +684,7 @@ async def _install_create_ap_speed_patch() -> None:
             WIFI_OVERRIDE_CONTAINER_PATH,
             BLUEOS_CORE_CONTAINER,
         )
-        return
+        return False
 
     try:
         ast.parse(source)
@@ -676,26 +713,67 @@ async def _install_create_ap_speed_patch() -> None:
         # steps are non-negotiable here.
         await _remove_startup_bind()
         await _run_host_command(f"sudo rm -f {WIFI_OVERRIDE_HOST_PATH}")
-        return
+        return False
 
-    if _CREATE_AP_ANCHOR not in source:
+    if _CREATE_AP_ANCHOR_RE.search(source) is None:
         logger.warning(
             "create_ap anchor not found in %s; BlueOS upstream may have "
             "changed - skipping create_ap speed patch (hotspot will still "
-            "work, at default 2.4 GHz / 802.11g speeds)",
+            "work, at default 2.4 GHz / 802.11g speeds). Bind-mount install "
+            "is also skipped this run; an un-patched override file is the "
+            "same factory-revert footgun as a missing one.",
             WIFI_OVERRIDE_CONTAINER_PATH,
         )
-        return
+        return False
 
     stripped = _strip_doris_patch(source)
     channel = await _pick_24ghz_channel()
-    flags = _CREATE_AP_24GHZ_FLAGS_TEMPLATE.format(channel=channel)
-    patched = stripped.replace(
-        _CREATE_AP_ANCHOR, _CREATE_AP_ANCHOR + flags, 1
+    anchor_match = _CREATE_AP_ANCHOR_RE.search(stripped)
+    # We re-search post-strip because the strip can shift offsets, but
+    # the anchor itself is never inside the stripped region; this match
+    # is guaranteed to succeed here, since we already confirmed the
+    # anchor exists pre-strip and strip only removes content *after* it.
+    assert anchor_match is not None, (
+        "anchor disappeared after _strip_doris_patch; this is a bug in "
+        "the strip regex - the anchor should never be inside the "
+        "stripped span"
     )
+    indent = anchor_match.group("indent")
+    flags = _CREATE_AP_24GHZ_FLAGS_TEMPLATE.format(
+        indent=indent, channel=channel
+    )
+    insert_at = anchor_match.end()
+    patched = stripped[:insert_at] + flags + stripped[insert_at:]
 
     await _run_host_command(f"sudo mkdir -p {WIFI_OVERRIDE_DIR}")
-    await _write_host_file(WIFI_OVERRIDE_HOST_PATH, patched)
+    return await _write_host_file(WIFI_OVERRIDE_HOST_PATH, patched)
+
+
+def _binds_dict_or_none(data: object) -> dict | None:
+    """Return the binds dict inside a parsed ``startup.json`` payload,
+    or ``None`` if the expected ``data["core"]["binds"]`` shape isn't
+    there.
+
+    Defensive helper for both :func:`_ensure_startup_bind` and
+    :func:`_remove_startup_bind`. ``blueos-bootstrap`` major-version
+    upgrades have historically re-templated this file in place; if it
+    ever renames the schema (e.g. ``core`` → ``containers/core``) or
+    changes the bind structure from a dict to a list, blindly calling
+    ``data.setdefault("core", {}).setdefault("binds", {})`` would
+    create a parallel orphan key that bootstrap never reads while
+    silently looking like success. Returning ``None`` here lets the
+    callers log loudly and skip the write rather than corrupt the
+    file with an unrecognised top-level key.
+    """
+    if not isinstance(data, dict):
+        return None
+    core = data.get("core")
+    if not isinstance(core, dict):
+        return None
+    binds = core.get("binds")
+    if not isinstance(binds, dict):
+        return None
+    return binds
 
 
 async def _remove_startup_bind() -> None:
@@ -718,8 +796,9 @@ async def _remove_startup_bind() -> None:
     at that path; on a subsequent DORIS run we add the bind back and
     install a fresh override.
 
-    No-op if the entry isn't present or the JSON can't be parsed -
-    matches the conservative shape of :func:`_ensure_startup_bind`.
+    No-op if the entry isn't present, the JSON can't be parsed, or
+    the schema doesn't match the shape we know how to walk - matches
+    the conservative shape of :func:`_ensure_startup_bind`.
     """
     raw = await _read_host_file(BOOTSTRAP_STARTUP_JSON)
     if raw is None:
@@ -737,7 +816,16 @@ async def _remove_startup_bind() -> None:
         )
         return
 
-    binds = data.get("core", {}).get("binds", {})
+    binds = _binds_dict_or_none(data)
+    if binds is None:
+        logger.warning(
+            "Bootstrap %s does not contain a 'core.binds' dict; bootstrap "
+            "schema may have migrated. Skipping bind removal to avoid "
+            "corrupting the file with an unrecognised top-level key.",
+            BOOTSTRAP_STARTUP_JSON,
+        )
+        return
+
     if WIFI_OVERRIDE_HOST_PATH not in binds:
         logger.info(
             "No wifi-override bind in %s; nothing to remove",
@@ -763,6 +851,16 @@ async def _ensure_startup_bind() -> None:
     effect at the next reboot (or after manually restarting
     ``blueos-bootstrap``); we do not auto-restart anything to avoid an
     unexpected outage.
+
+    Refuses to install when the on-disk schema doesn't match the
+    shape we know how to safely modify (``core.binds`` is a dict).
+    The previous implementation used :func:`dict.setdefault` to
+    silently create those keys if missing - which would survive a
+    schema migration that renamed ``core`` (or restructured ``binds``)
+    but would write our entry into a section bootstrap never reads,
+    so the bind would never become active and we'd have no signal.
+    The explicit guard surfaces a migration via a loud warning, then
+    leaves the file untouched.
     """
     raw = await _read_host_file(BOOTSTRAP_STARTUP_JSON)
     if raw is None:
@@ -778,7 +876,16 @@ async def _ensure_startup_bind() -> None:
         logger.warning("Bootstrap %s is not valid JSON: %s", BOOTSTRAP_STARTUP_JSON, e)
         return
 
-    binds = data.setdefault("core", {}).setdefault("binds", {})
+    binds = _binds_dict_or_none(data)
+    if binds is None:
+        logger.warning(
+            "Bootstrap %s does not contain a 'core.binds' dict; bootstrap "
+            "schema may have migrated. Skipping bind install rather than "
+            "creating a parallel orphan key bootstrap won't read.",
+            BOOTSTRAP_STARTUP_JSON,
+        )
+        return
+
     existing = binds.get(WIFI_OVERRIDE_HOST_PATH)
     if (
         isinstance(existing, dict)
@@ -827,8 +934,26 @@ async def setup_hotspot_radio() -> None:
     await _reload_udev()
     await _reload_network_manager()
 
-    await _install_create_ap_speed_patch()
-    await _ensure_startup_bind()
+    # Ordering contract: only add (or re-add) the bind entry in
+    # startup.json AFTER we've confirmed the host override file is in
+    # place and patched. Otherwise we re-arm exactly the May 2026
+    # factory-revert trap that PR #18 closed - the self-heal path
+    # inside _install_create_ap_speed_patch removes the bind entry
+    # when it has to delete a corrupt override, and an unconditional
+    # _ensure_startup_bind() right after would silently put it back,
+    # leaving startup.json pointing at a missing source on next boot.
+    patch_ok = await _install_create_ap_speed_patch()
+    if patch_ok:
+        await _ensure_startup_bind()
+    else:
+        logger.warning(
+            "create_ap speed patch did not install this run; skipping "
+            "startup.json bind install to avoid pointing a bind-mount at a "
+            "missing or un-patched host file (would trigger Docker to auto-"
+            "create a directory at the source path on next blueos-core "
+            "restart, then 'not a directory' container init failure, then "
+            "blueos-bootstrap factory revert)."
+        )
 
     # Heads-up if the rename hasn't taken effect on this boot.
     ok, out = await _run_host_command(

--- a/extension/backend/src/doris/services/mdns.py
+++ b/extension/backend/src/doris/services/mdns.py
@@ -242,17 +242,40 @@ async def start_hotspot_dns() -> None:
         "no-resolv\n"
         "no-hosts\n"
     )
-    cmd = (
+    # Commander's ssh transport returns rc=255 unpredictably on
+    # short multi-step commands even when the underlying shell ran
+    # to completion (we proved this in live testing: ``pkill ...;
+    # true`` reliably returned rc=255 yet the kill happened, and
+    # ``setsid dnsmasq ...`` reliably returned rc=255 yet the daemon
+    # started). We therefore split the work into two short Commander
+    # calls and ignore their rc - the real success signal is the
+    # post-start pid-file check, not the launcher's exit code.
+    write_cmd = (
         f"echo '{conf_content}' | sudo tee {HOTSPOT_DNS_CONF} > /dev/null && "
-        f"sudo pkill -f 'dnsmasq.*{HOTSPOT_DNS_CONF}' 2>/dev/null; sleep 1; "
-        f"sudo /usr/sbin/dnsmasq --conf-file={HOTSPOT_DNS_CONF} "
-        f"--pid-file={HOTSPOT_DNS_PID}"
+        f"sudo pkill -f 'dnsmasq.*{HOTSPOT_DNS_CONF}' 2>/dev/null; true"
     )
-    ok, _ = await _run_host_command(cmd)
-    if ok:
+    await _run_host_command(write_cmd)
+
+    # Detach dnsmasq from the Commander ssh session: ``setsid`` gives
+    # it a new session, the stdio redirects close the inherited
+    # ssh-side fds, and ``&`` runs it in the shell background so the
+    # outer Commander call exits as soon as the fork succeeds.
+    start_cmd = (
+        f"sudo setsid /usr/sbin/dnsmasq --conf-file={HOTSPOT_DNS_CONF} "
+        f"--pid-file={HOTSPOT_DNS_PID} "
+        f"< /dev/null > /dev/null 2>&1 & "
+        f"sleep 1; "
+        f"sudo test -f {HOTSPOT_DNS_PID} && echo running || echo missing"
+    )
+    _, start_out = await _run_host_command(start_cmd)
+    if "running" in start_out:
         logger.info("Hotspot DNS started on %s:53 (doris.local)", gateway)
     else:
-        logger.warning("Failed to start hotspot DNS server (gateway=%s)", gateway)
+        logger.warning(
+            "Failed to start hotspot DNS server (gateway=%s, out=%r)",
+            gateway,
+            start_out,
+        )
 
 
 async def restart_avahi(force: bool = False) -> None:

--- a/extension/backend/src/doris/services/mdns.py
+++ b/extension/backend/src/doris/services/mdns.py
@@ -25,8 +25,18 @@ logger = logging.getLogger(__name__)
 
 AVAHI_CONF = Path("/tmp/avahi/avahi-daemon.conf")
 
-# create_ap assigns this gateway IP to the hotspot interface (wlan1).
-HOTSPOT_GATEWAY = "192.168.43.1"
+# The host-side AP interface. ``hotspot_radio`` renames the Realtek
+# USB radio from ``wlan1`` to ``uap0`` via udev, then ``create_ap``
+# brings the AP up on ``uap0`` and assigns it the gateway IP.
+HOTSPOT_INTERFACE = "uap0"
+
+# Fallback gateway IP if the live detection from ``ip addr show
+# uap0`` fails. This is the value BlueOS 1.5.x assigns; older 1.4.x
+# builds used 192.168.43.1. ``_detect_hotspot_gateway()`` reads it
+# live at call time so a future BlueOS renumber doesn't silently
+# break our DNS setup again - we only fall back to this constant
+# when the live read returns nothing (e.g. AP hasn't come up yet).
+HOTSPOT_GATEWAY_FALLBACK = "192.168.42.1"
 
 # Separate dnsmasq instance for standard DNS (port 53) on the hotspot.
 # create_ap's own dnsmasq only listens on port 5353 (mDNS), so clients
@@ -72,11 +82,15 @@ async def _find_core_container_id(client: httpx.AsyncClient) -> str | None:
     return None
 
 
-async def _run_host_command(command: str, timeout: float = 30.0) -> bool:
+async def _run_host_command(
+    command: str, timeout: float = 30.0
+) -> tuple[bool, str]:
     """Execute a command on the host via the Commander API.
 
     Commander always returns HTTP 200; the actual exit code is in the
-    JSON body's ``return_code`` field.
+    JSON body's ``return_code`` field. Returns ``(ok, stdout)`` so
+    callers that need the output (e.g. ``_detect_hotspot_gateway``
+    parsing ``ip addr show uap0``) don't need a second helper.
     """
     url = f"{blueos_services.commander}/v1.0/command/host"
     params = {"command": command, "i_know_what_i_am_doing": "true"}
@@ -86,18 +100,57 @@ async def _run_host_command(command: str, timeout: float = 30.0) -> bool:
             resp.raise_for_status()
             data = resp.json()
             rc = data.get("return_code", -1)
+            out = data.get("stdout", "") or ""
+            err = data.get("stderr", "") or ""
             if rc != 0:
-                out = data.get("stdout", "")
-                err = data.get("stderr", "")
                 logger.warning(
                     "Host command returned %d: %s %s",
                     rc, out[:200], err[:200],
                 )
-                return False
-        return True
+                return False, out
+            return True, out
     except Exception as e:
         logger.warning("Commander command failed (%s): %s", command[:60], e)
-        return False
+        return False, ""
+
+
+_IP_ADDR_RE = re.compile(r"inet\s+(\d{1,3}(?:\.\d{1,3}){3})")
+
+
+async def _detect_hotspot_gateway() -> str:
+    """Return the IPv4 currently bound to :data:`HOTSPOT_INTERFACE`.
+
+    BlueOS has rotated the create_ap gateway between versions
+    (192.168.43.1 in older builds, 192.168.42.1 since 1.5.x). Reading
+    it live is more durable than tracking the upstream change in a
+    constant. Falls back to :data:`HOTSPOT_GATEWAY_FALLBACK` when the
+    detection fails - typically because the AP hasn't finished coming
+    up at the moment this runs - so DNS still has *an* IP to use even
+    if it might be slightly off (the watchdog at the next tick will
+    overwrite with the right value once the AP is up).
+    """
+    ok, out = await _run_host_command(
+        f"ip -4 -o addr show {HOTSPOT_INTERFACE}"
+    )
+    if not ok:
+        logger.warning(
+            "Could not read %s addresses; falling back to %s for hotspot DNS",
+            HOTSPOT_INTERFACE,
+            HOTSPOT_GATEWAY_FALLBACK,
+        )
+        return HOTSPOT_GATEWAY_FALLBACK
+    m = _IP_ADDR_RE.search(out)
+    if not m:
+        logger.warning(
+            "No IPv4 visible on %s yet (output: %r); falling back to %s",
+            HOTSPOT_INTERFACE,
+            out[:160],
+            HOTSPOT_GATEWAY_FALLBACK,
+        )
+        return HOTSPOT_GATEWAY_FALLBACK
+    addr = m.group(1)
+    logger.info("Detected hotspot gateway %s on %s", addr, HOTSPOT_INTERFACE)
+    return addr
 
 
 def _setup_avahi_hostname() -> bool:
@@ -168,18 +221,24 @@ async def start_hotspot_dns() -> None:
     ``blueos-wifi.local``) to that same gateway.
 
     Must be called AFTER configure_hotspot() so the hotspot interface
-    actually has the gateway IP assigned.
+    actually has the gateway IP assigned. The gateway IP is detected
+    live from :data:`HOTSPOT_INTERFACE` rather than hardcoded - BlueOS
+    has renumbered the AP subnet between versions (192.168.43.1 →
+    192.168.42.1 between 1.4.x and 1.5.x) and a stale hardcoded value
+    made dnsmasq's ``bind-interfaces`` fail on every start, leaving
+    ``doris.local`` unresolvable for hotspot clients that lack mDNS.
 
     Uses ``sudo`` so that /usr/sbin is in the PATH (Commander's default
     shell PATH omits /usr/sbin where dnsmasq lives).
     """
+    gateway = await _detect_hotspot_gateway()
     conf_content = (
-        f"listen-address={HOTSPOT_GATEWAY}\n"
+        f"listen-address={gateway}\n"
         "port=53\n"
         "bind-interfaces\n"
-        "no-dhcp-interface=wlan1\n"
-        f"address=/doris.local/{HOTSPOT_GATEWAY}\n"
-        f"address=/blueos-wifi.local/{HOTSPOT_GATEWAY}\n"
+        f"no-dhcp-interface={HOTSPOT_INTERFACE}\n"
+        f"address=/doris.local/{gateway}\n"
+        f"address=/blueos-wifi.local/{gateway}\n"
         "no-resolv\n"
         "no-hosts\n"
     )
@@ -189,11 +248,11 @@ async def start_hotspot_dns() -> None:
         f"sudo /usr/sbin/dnsmasq --conf-file={HOTSPOT_DNS_CONF} "
         f"--pid-file={HOTSPOT_DNS_PID}"
     )
-    ok = await _run_host_command(cmd)
+    ok, _ = await _run_host_command(cmd)
     if ok:
-        logger.info("Hotspot DNS started on %s:53 (doris.local)", HOTSPOT_GATEWAY)
+        logger.info("Hotspot DNS started on %s:53 (doris.local)", gateway)
     else:
-        logger.warning("Failed to start hotspot DNS server")
+        logger.warning("Failed to start hotspot DNS server (gateway=%s)", gateway)
 
 
 async def restart_avahi(force: bool = False) -> None:
@@ -216,7 +275,7 @@ async def restart_avahi(force: bool = False) -> None:
         logger.info("Avahi config unchanged, skipping restart")
         return
 
-    ok = await _run_host_command(
+    ok, _ = await _run_host_command(
         "sudo systemctl stop avahi-daemon && sleep 5 && sudo systemctl start avahi-daemon"
     )
     if ok:
@@ -286,7 +345,7 @@ async def _upload_nginx_redirect() -> bool:
 
         await _run_host_command(
             f"docker exec {CORE_CONTAINER} nginx -s reload"
-        )
+        )  # return ignored; nginx reload errors surface via 502 from the redirect itself
         return True
     except Exception as exc:
         logger.debug("nginx redirect upload failed: %s", exc)

--- a/extension/backend/tests/test_hotspot_radio.py
+++ b/extension/backend/tests/test_hotspot_radio.py
@@ -2,8 +2,11 @@
 
 These exercise the units that have caused field bugs: the legacy-patch
 stripper, the self-heal-on-corrupt-source path in
-``_install_create_ap_speed_patch``, and the inode-preserving write
-command shape in ``_write_host_file``.
+``_install_create_ap_speed_patch``, the regex anchor's tolerance for
+upstream reformatting, the inode-preserving write command shape in
+``_write_host_file``, and the contract that
+``setup_hotspot_radio`` only installs the startup.json bind entry
+after a successful patch.
 """
 
 from __future__ import annotations
@@ -18,15 +21,23 @@ from doris.services import hotspot_radio
 # ---------------------------------------------------------------------
 
 
-ANCHOR = hotspot_radio._CREATE_AP_ANCHOR
+# Canonical anchor line used by `_wrap` to build test fixtures. The
+# production code finds this (and tolerated variations) via
+# :data:`hotspot_radio._CREATE_AP_ANCHOR_RE`. Tests for the regex's
+# tolerance to upstream reformatting live further down with their own
+# variant anchors.
+CANONICAL_ANCHOR_LINE = (
+    '            "--redirect-to-localhost",'
+    "  # Redirect all traffic to localhost, captive-portal style\n"
+)
 
 
-def _wrap(payload: str) -> str:
+def _wrap(payload: str, *, anchor: str = CANONICAL_ANCHOR_LINE) -> str:
     """Wrap *payload* in a minimal `wifi-manager` argv list."""
     return (
         "argv = [\n"
         '            "create_ap",\n'
-        f"{ANCHOR}"
+        f"{anchor}"
         f"{payload}"
         '            ssid,\n'
         '            password,\n'
@@ -164,7 +175,14 @@ async def test_install_patch_removes_override_when_source_is_corrupt(
 
     monkeypatch.setattr(hotspot_radio, "_remove_startup_bind", fake_remove_bind)
 
-    await hotspot_radio._install_create_ap_speed_patch()
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    # Self-heal path must report failure so the caller skips
+    # _ensure_startup_bind and doesn't re-arm the bind-mount trap.
+    assert result is False, (
+        "self-heal path must return False so setup_hotspot_radio knows "
+        "to skip _ensure_startup_bind; otherwise the bind gets re-added "
+        "right after we removed it"
+    )
 
     rm_cmds = [c for c in patched_command.calls if "rm -f" in c]
     assert any(
@@ -240,7 +258,14 @@ async def test_install_patch_skips_when_anchor_missing(
     monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
     monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", must_not_run)
 
-    await hotspot_radio._install_create_ap_speed_patch()
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    # Anchor-missing must report False so setup_hotspot_radio skips
+    # the bind install - a bind pointing at an un-patched (or
+    # missing) source is the same factory-revert trap.
+    assert result is False, (
+        "anchor-missing path must return False so setup_hotspot_radio "
+        "knows to skip _ensure_startup_bind"
+    )
 
     assert not any(
         hotspot_radio.WIFI_OVERRIDE_HOST_PATH in c and "rm" in c
@@ -271,13 +296,260 @@ async def test_install_patch_writes_when_source_is_clean(
     monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
     monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", fake_pick)
 
-    await hotspot_radio._install_create_ap_speed_patch()
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    # Happy path must report success so setup_hotspot_radio installs
+    # the bind entry.
+    assert result is True, (
+        "happy path must return True so setup_hotspot_radio installs "
+        "the startup.json bind"
+    )
 
     assert len(write_calls) == 1
     path, content = write_calls[0]
     assert path == hotspot_radio.WIFI_OVERRIDE_HOST_PATH
     assert '"-c", "6"' in content
     assert "--ht_capab" in content
+
+
+# ---------------------------------------------------------------------
+# _CREATE_AP_ANCHOR_RE: must tolerate the kind of whitespace/comment
+# variations that upstream BlueOS reformat passes inflict. The old
+# exact-string anchor would silently miss any of these.
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        # Canonical: 12 spaces + comma + trailing comment
+        '            "--redirect-to-localhost",  # Redirect all traffic\n',
+        # 8 spaces (shallower indent)
+        '        "--redirect-to-localhost",  # comment\n',
+        # 16 spaces (deeper indent)
+        '                "--redirect-to-localhost",  # comment\n',
+        # Comma but no trailing comment
+        '            "--redirect-to-localhost",\n',
+        # No comma and no comment (last item of a list with no trailing comma)
+        '            "--redirect-to-localhost"\n',
+        # Tab indent
+        '\t\t\t"--redirect-to-localhost",\n',
+        # Comment with different wording
+        '            "--redirect-to-localhost",  # captive portal anchor\n',
+        # Spaces between comma and comment vary
+        '            "--redirect-to-localhost",   # extra spaces\n',
+    ],
+)
+def test_create_ap_anchor_regex_tolerates_variant(variant: str) -> None:
+    """Each tolerated upstream variant must match and capture its indent."""
+    src = _wrap("", anchor=variant)
+    m = hotspot_radio._CREATE_AP_ANCHOR_RE.search(src)
+    assert m is not None, f"regex must match variant:\n{variant!r}"
+    assert m.group("indent") == variant[: len(variant) - len(variant.lstrip(" \t"))]
+
+
+def test_create_ap_anchor_regex_rejects_unindented_token() -> None:
+    """A top-level mention of the token (e.g. in module docstring or
+    inside a comment) must NOT match - injecting flags there would
+    corrupt unrelated source."""
+    src = (
+        "# Discusses --redirect-to-localhost in a comment\n"
+        '"--redirect-to-localhost",\n'  # zero indent
+        "argv = [\n"
+        '            "create_ap",\n'
+        "]\n"
+    )
+    assert hotspot_radio._CREATE_AP_ANCHOR_RE.search(src) is None
+
+
+def test_strip_doris_patch_works_with_shallow_indent_anchor() -> None:
+    """Strip must still recognise the patch block when the anchor has a
+    different indent than canonical, because the regex anchor accepts
+    any indent and the patch block uses ``[ \\t]*`` per-line."""
+    shallow_anchor = '        "--redirect-to-localhost",\n'
+    shallow_patch = (
+        '        "-c", "6",\n'
+        '        "--ieee80211n",\n'
+        '        "--ht_capab", "[HT40+]",\n'
+        '        "--country", "US",\n'
+    )
+    src = _wrap(shallow_patch, anchor=shallow_anchor)
+    stripped = hotspot_radio._strip_doris_patch(src)
+    assert "--ht_capab" not in stripped
+    assert "--ieee80211n" not in stripped
+    assert "--redirect-to-localhost" in stripped
+
+
+async def test_install_patch_uses_captured_indent_in_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inserted flag lines must match the indentation of the anchor
+    line they follow, so the resulting file stays syntactically clean
+    regardless of upstream indentation choices."""
+    shallow_anchor = '        "--redirect-to-localhost",\n'
+    src = _wrap("", anchor=shallow_anchor)
+
+    async def fake_read(container: str, path: str) -> str:
+        return src
+
+    write_calls: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        write_calls.append((path, content))
+        return True
+
+    async def fake_pick() -> int:
+        return 1
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+    monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", fake_pick)
+
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    assert result is True
+
+    assert len(write_calls) == 1
+    _, content = write_calls[0]
+    # Each inserted flag line must begin with the same 8-space indent
+    # as the shallow anchor.
+    assert '        "-c", "1",\n' in content
+    assert '        "--ieee80211n",\n' in content
+    # And must NOT have the canonical 12-space indent baked in.
+    assert '            "-c", "1",\n' not in content
+
+
+# ---------------------------------------------------------------------
+# Bug 4: _install_create_ap_speed_patch must return False on write
+# failure too, so setup_hotspot_radio doesn't add a bind entry that
+# points at a missing (or stale) host file.
+# ---------------------------------------------------------------------
+
+
+async def test_install_patch_returns_false_on_write_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(container: str, path: str) -> str:
+        return CLEAN_SOURCE_WITH_ANCHOR
+
+    async def fake_write(path: str, content: str) -> bool:
+        return False
+
+    async def fake_pick() -> int:
+        return 6
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+    monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", fake_pick)
+
+    rec = _RunHostCommandRecorder()
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    assert result is False, (
+        "_write_host_file returning False must propagate as False so "
+        "the caller doesn't add a bind entry that points at a host "
+        "file we failed to actually write"
+    )
+
+
+async def test_install_patch_returns_false_on_unreadable_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(container: str, path: str) -> None:
+        return None
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+
+    rec = _RunHostCommandRecorder()
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    assert result is False
+
+
+# ---------------------------------------------------------------------
+# Bug 4 (integration): setup_hotspot_radio must only call
+# _ensure_startup_bind when _install_create_ap_speed_patch succeeds.
+# This is the contract that closes the May 2026 factory-revert footgun
+# at the *outer* level: the self-heal inside the patch function removes
+# the bind, and the outer must NOT silently re-add it.
+# ---------------------------------------------------------------------
+
+
+async def test_setup_hotspot_radio_skips_ensure_bind_when_patch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_write(path: str, content: str) -> bool:
+        return True
+
+    async def noop_reload() -> None:
+        return None
+
+    async def patch_fails() -> bool:
+        return False
+
+    ensure_calls: list[bool] = []
+
+    async def fake_ensure_bind() -> None:
+        ensure_calls.append(True)
+
+    rec = _RunHostCommandRecorder()
+
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+    monkeypatch.setattr(hotspot_radio, "_reload_udev", noop_reload)
+    monkeypatch.setattr(hotspot_radio, "_reload_network_manager", noop_reload)
+    monkeypatch.setattr(
+        hotspot_radio, "_install_create_ap_speed_patch", patch_fails
+    )
+    monkeypatch.setattr(hotspot_radio, "_ensure_startup_bind", fake_ensure_bind)
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+
+    await hotspot_radio.setup_hotspot_radio()
+
+    assert ensure_calls == [], (
+        "_ensure_startup_bind MUST NOT run when _install_create_ap_"
+        "speed_patch reported failure - otherwise we re-add a bind "
+        "pointing at a missing/un-patched source and re-arm the May "
+        "2026 factory-revert trap"
+    )
+
+
+async def test_setup_hotspot_radio_calls_ensure_bind_when_patch_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_write(path: str, content: str) -> bool:
+        return True
+
+    async def noop_reload() -> None:
+        return None
+
+    async def patch_succeeds() -> bool:
+        return True
+
+    ensure_calls: list[bool] = []
+
+    async def fake_ensure_bind() -> None:
+        ensure_calls.append(True)
+
+    rec = _RunHostCommandRecorder()
+    # ls returns nothing matching, so the rename-not-yet-applied
+    # logger.info path runs; immaterial to this test.
+    rec.respond(True, "")
+
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+    monkeypatch.setattr(hotspot_radio, "_reload_udev", noop_reload)
+    monkeypatch.setattr(hotspot_radio, "_reload_network_manager", noop_reload)
+    monkeypatch.setattr(
+        hotspot_radio, "_install_create_ap_speed_patch", patch_succeeds
+    )
+    monkeypatch.setattr(hotspot_radio, "_ensure_startup_bind", fake_ensure_bind)
+    monkeypatch.setattr(hotspot_radio, "_run_host_command", rec)
+
+    await hotspot_radio.setup_hotspot_radio()
+
+    assert ensure_calls == [True], (
+        "_ensure_startup_bind must run exactly once when "
+        "_install_create_ap_speed_patch reported success"
+    )
 
 
 # ---------------------------------------------------------------------
@@ -423,6 +695,134 @@ async def test_remove_startup_bind_handles_unreadable_file(
     # Must not raise even if startup.json can't be read.
     await hotspot_radio._remove_startup_bind()
     assert written == []
+
+
+# ---------------------------------------------------------------------
+# Bug 3: schema-migration defensive guards.  Both _ensure_startup_bind
+# and _remove_startup_bind must refuse to write when the on-disk
+# startup.json doesn't have the ``core.binds`` shape we know how to
+# walk.  The previous implementation silently created missing keys via
+# ``setdefault``, which would survive a bootstrap migration that
+# renamed/restructured the schema but write our entry into a section
+# bootstrap never reads, leaving us with no signal that the bind
+# isn't active.
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # Top-level isn't an object
+        '["not", "a", "dict"]',
+        # No "core" key at all (schema migration could rename it)
+        '{"system": {"binds": {}}}',
+        # "core" present but not an object
+        '{"core": "factory"}',
+        # "core" object but "binds" missing
+        '{"core": {"tag": "1.5.0"}}',
+        # "core" present, "binds" is a list (schema change)
+        '{"core": {"binds": []}}',
+    ],
+)
+async def test_ensure_startup_bind_refuses_unrecognized_schema(
+    raw: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(path: str) -> str:
+        return raw
+
+    writes: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        writes.append((path, content))
+        return True
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+
+    await hotspot_radio._ensure_startup_bind()
+
+    assert writes == [], (
+        "Unrecognized schema must NOT trigger a write - silently "
+        "creating a parallel 'core'/'binds' would corrupt the file "
+        "with a key bootstrap doesn't read."
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '["not", "a", "dict"]',
+        '{"system": {"binds": {}}}',
+        '{"core": "factory"}',
+        '{"core": {"tag": "1.5.0"}}',
+        '{"core": {"binds": []}}',
+    ],
+)
+async def test_remove_startup_bind_refuses_unrecognized_schema(
+    raw: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read(path: str) -> str:
+        return raw
+
+    writes: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        writes.append((path, content))
+        return True
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+
+    await hotspot_radio._remove_startup_bind()
+
+    assert writes == [], (
+        "Unrecognized schema during remove must also skip writing."
+    )
+
+
+async def test_ensure_startup_bind_does_not_overwrite_unrelated_binds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the schema IS recognised, the install must preserve
+    every other bind entry unchanged."""
+    import json as _json
+
+    raw = _json.dumps({
+        "core": {
+            "tag": "1.5.0",
+            "binds": {
+                "/dev/": {"bind": "/dev/", "mode": "rw"},
+                "/etc/blueos/": {"bind": "/etc/blueos/", "mode": "rw"},
+            },
+        },
+        "extensions": {"foo": "bar"},
+    }) + "\n"
+
+    async def fake_read(path: str) -> str:
+        return raw
+
+    writes: list[tuple[str, str]] = []
+
+    async def fake_write(path: str, content: str) -> bool:
+        writes.append((path, content))
+        return True
+
+    monkeypatch.setattr(hotspot_radio, "_read_host_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+
+    await hotspot_radio._ensure_startup_bind()
+
+    assert len(writes) == 1
+    _, content = writes[0]
+    parsed = _json.loads(content)
+    binds = parsed["core"]["binds"]
+    assert "/dev/" in binds
+    assert "/etc/blueos/" in binds
+    assert hotspot_radio.WIFI_OVERRIDE_HOST_PATH in binds
+    # Top-level sibling keys must remain.
+    assert parsed.get("extensions") == {"foo": "bar"}
 
 
 async def test_write_host_file_skips_when_existing_matches(

--- a/extension/backend/tests/test_mdns.py
+++ b/extension/backend/tests/test_mdns.py
@@ -1,0 +1,154 @@
+"""Tests for `doris.services.mdns`.
+
+Focused on the dynamic hotspot-gateway detection introduced in
+bh-wifi-hardening. Previously :data:`HOTSPOT_GATEWAY` was hardcoded
+to ``192.168.43.1`` while BlueOS 1.5.x assigns ``192.168.42.1`` to
+``uap0`` - the mismatch made the auxiliary dnsmasq fail
+``bind-interfaces`` every start, leaving ``doris.local`` unresolvable
+for hotspot clients that lack mDNS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from doris.services import mdns
+
+
+class _RunHostCommandRecorder:
+    """Stand-in for ``_run_host_command`` that records every call and
+    returns a configurable result per pattern."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.responses: list[tuple[bool, str]] = []
+
+    def respond(self, ok: bool, out: str = "") -> None:
+        self.responses.append((ok, out))
+
+    async def __call__(
+        self, command: str, timeout: float = 30.0
+    ) -> tuple[bool, str]:
+        self.calls.append(command)
+        if self.responses:
+            return self.responses.pop(0)
+        return True, ""
+
+
+# ---------------------------------------------------------------------
+# _detect_hotspot_gateway: parses `ip -4 -o addr show uap0` output.
+# ---------------------------------------------------------------------
+
+
+async def test_detect_hotspot_gateway_parses_192_168_42_1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The current BlueOS 1.5.x layout assigns 192.168.42.1 to uap0."""
+    rec = _RunHostCommandRecorder()
+    rec.respond(
+        True,
+        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
+        "scope global uap0\\       valid_lft forever preferred_lft forever\n",
+    )
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    assert await mdns._detect_hotspot_gateway() == "192.168.42.1"
+    assert rec.calls == [f"ip -4 -o addr show {mdns.HOTSPOT_INTERFACE}"]
+
+
+async def test_detect_hotspot_gateway_parses_legacy_192_168_43_1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older BlueOS 1.4.x builds used 192.168.43.1; live read must
+    pick it up too - the whole point of going dynamic."""
+    rec = _RunHostCommandRecorder()
+    rec.respond(
+        True,
+        "5: uap0    inet 192.168.43.1/24 brd 192.168.43.255 scope global uap0\n",
+    )
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    assert await mdns._detect_hotspot_gateway() == "192.168.43.1"
+
+
+async def test_detect_hotspot_gateway_falls_back_when_no_ip_yet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """During boot ``ip addr show uap0`` may return the link line but
+    no ``inet`` line if create_ap hasn't finished. Must fall back to
+    the constant rather than emit an empty/invalid address."""
+    rec = _RunHostCommandRecorder()
+    rec.respond(True, "5: uap0    <NO-CARRIER,BROADCAST,MULTICAST,UP>\n")
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    assert (
+        await mdns._detect_hotspot_gateway() == mdns.HOTSPOT_GATEWAY_FALLBACK
+    )
+
+
+async def test_detect_hotspot_gateway_falls_back_when_command_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the ``ip`` invocation itself errors (e.g. interface missing
+    because the rename hasn't taken effect yet), fall back."""
+    rec = _RunHostCommandRecorder()
+    rec.respond(False, "Device \"uap0\" does not exist.\n")
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    assert (
+        await mdns._detect_hotspot_gateway() == mdns.HOTSPOT_GATEWAY_FALLBACK
+    )
+
+
+# ---------------------------------------------------------------------
+# start_hotspot_dns: must use the live-detected gateway in the
+# dnsmasq config and must target uap0 (not wlan1) on no-dhcp-interface.
+# ---------------------------------------------------------------------
+
+
+async def test_start_hotspot_dns_uses_detected_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The config written must use whatever ``_detect_hotspot_gateway``
+    returns, NOT the fallback constant when detection succeeds."""
+    rec = _RunHostCommandRecorder()
+    # First call is _detect_hotspot_gateway (ip addr show); second is
+    # the actual dnsmasq setup tee+start command.
+    rec.respond(
+        True,
+        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
+        "scope global uap0\n",
+    )
+    rec.respond(True, "")
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    await mdns.start_hotspot_dns()
+
+    assert len(rec.calls) == 2
+    dnsmasq_cmd = rec.calls[1]
+    assert "listen-address=192.168.42.1" in dnsmasq_cmd, dnsmasq_cmd
+    assert "address=/doris.local/192.168.42.1" in dnsmasq_cmd, dnsmasq_cmd
+    assert "address=/blueos-wifi.local/192.168.42.1" in dnsmasq_cmd, dnsmasq_cmd
+    # No-dhcp-interface MUST point at uap0 (the post-rename name), not
+    # the upstream-default wlan1.
+    assert "no-dhcp-interface=uap0" in dnsmasq_cmd, dnsmasq_cmd
+    assert "no-dhcp-interface=wlan1" not in dnsmasq_cmd, dnsmasq_cmd
+
+
+async def test_start_hotspot_dns_falls_back_when_uap0_has_no_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the AP isn't up yet, we still configure dnsmasq with the
+    fallback so the next watchdog tick / restart can use it."""
+    rec = _RunHostCommandRecorder()
+    rec.respond(True, "5: uap0    <NO-CARRIER>\n")
+    rec.respond(True, "")
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    await mdns.start_hotspot_dns()
+
+    assert len(rec.calls) == 2
+    dnsmasq_cmd = rec.calls[1]
+    assert (
+        f"listen-address={mdns.HOTSPOT_GATEWAY_FALLBACK}" in dnsmasq_cmd
+    ), dnsmasq_cmd

--- a/extension/backend/tests/test_mdns.py
+++ b/extension/backend/tests/test_mdns.py
@@ -110,29 +110,94 @@ async def test_start_hotspot_dns_uses_detected_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The config written must use whatever ``_detect_hotspot_gateway``
-    returns, NOT the fallback constant when detection succeeds."""
+    returns, NOT the fallback constant when detection succeeds.
+
+    start_hotspot_dns issues THREE Commander calls now:
+      1. ``ip addr show uap0`` (detect gateway)
+      2. write conf + pkill prior daemon
+      3. launch dnsmasq + verify pid file
+    """
     rec = _RunHostCommandRecorder()
-    # First call is _detect_hotspot_gateway (ip addr show); second is
-    # the actual dnsmasq setup tee+start command.
+    rec.respond(
+        True,
+        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
+        "scope global uap0\n",
+    )
+    rec.respond(True, "")          # write_cmd
+    rec.respond(True, "running")   # start_cmd
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    await mdns.start_hotspot_dns()
+
+    assert len(rec.calls) == 3
+    write_cmd = rec.calls[1]
+    assert "listen-address=192.168.42.1" in write_cmd, write_cmd
+    assert "address=/doris.local/192.168.42.1" in write_cmd, write_cmd
+    assert "address=/blueos-wifi.local/192.168.42.1" in write_cmd, write_cmd
+    # No-dhcp-interface MUST point at uap0 (the post-rename name), not
+    # the upstream-default wlan1.
+    assert "no-dhcp-interface=uap0" in write_cmd, write_cmd
+    assert "no-dhcp-interface=wlan1" not in write_cmd, write_cmd
+
+
+async def test_start_hotspot_dns_detaches_dnsmasq_from_ssh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dnsmasq must be invoked in a way that lets Commander's ssh
+    session return immediately after the daemon forks - inheriting
+    open stdin/stdout/stderr keeps the ssh hanging until timeout
+    (rc=255 with empty output), which we observed in live testing
+    after fixing the gateway IP. The fix uses setsid + redirect to
+    /dev/null + ``&`` to background the launcher."""
+    rec = _RunHostCommandRecorder()
     rec.respond(
         True,
         "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
         "scope global uap0\n",
     )
     rec.respond(True, "")
+    rec.respond(True, "running")
     monkeypatch.setattr(mdns, "_run_host_command", rec)
 
     await mdns.start_hotspot_dns()
 
-    assert len(rec.calls) == 2
-    dnsmasq_cmd = rec.calls[1]
-    assert "listen-address=192.168.42.1" in dnsmasq_cmd, dnsmasq_cmd
-    assert "address=/doris.local/192.168.42.1" in dnsmasq_cmd, dnsmasq_cmd
-    assert "address=/blueos-wifi.local/192.168.42.1" in dnsmasq_cmd, dnsmasq_cmd
-    # No-dhcp-interface MUST point at uap0 (the post-rename name), not
-    # the upstream-default wlan1.
-    assert "no-dhcp-interface=uap0" in dnsmasq_cmd, dnsmasq_cmd
-    assert "no-dhcp-interface=wlan1" not in dnsmasq_cmd, dnsmasq_cmd
+    start_cmd = rec.calls[2]
+    assert "setsid" in start_cmd, start_cmd
+    assert "< /dev/null" in start_cmd, start_cmd
+    assert "> /dev/null" in start_cmd, start_cmd
+    # Backgrounded so the shell exits even if the daemon hasn't
+    # closed its fds in time.
+    assert " & " in start_cmd, start_cmd
+    # Real signal of success is the pid file existing, not the
+    # launcher's rc.
+    assert "test -f" in start_cmd and "running" in start_cmd, start_cmd
+
+
+async def test_start_hotspot_dns_ignores_unreliable_commander_rc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commander's ssh transport returns rc=255 spuriously on short
+    multi-step commands - we observed this in live testing where the
+    underlying shell had run to completion. start_hotspot_dns must
+    therefore NOT abort on a write_cmd / start_cmd rc=False; the
+    real signal is "did the pid file get created"."""
+    rec = _RunHostCommandRecorder()
+    rec.respond(
+        True,
+        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
+        "scope global uap0\n",
+    )
+    # Both subsequent calls report False, but the second one's stdout
+    # says ``running`` (because the shell-level pid-file check did
+    # succeed on the host, even though ssh's wrapper rc was 255).
+    rec.respond(False, "")
+    rec.respond(False, "running\n")
+    monkeypatch.setattr(mdns, "_run_host_command", rec)
+
+    await mdns.start_hotspot_dns()
+
+    # Must still issue all three calls and not bail early.
+    assert len(rec.calls) == 3
 
 
 async def test_start_hotspot_dns_falls_back_when_uap0_has_no_ip(
@@ -143,12 +208,13 @@ async def test_start_hotspot_dns_falls_back_when_uap0_has_no_ip(
     rec = _RunHostCommandRecorder()
     rec.respond(True, "5: uap0    <NO-CARRIER>\n")
     rec.respond(True, "")
+    rec.respond(True, "running")
     monkeypatch.setattr(mdns, "_run_host_command", rec)
 
     await mdns.start_hotspot_dns()
 
-    assert len(rec.calls) == 2
-    dnsmasq_cmd = rec.calls[1]
+    assert len(rec.calls) == 3
+    write_cmd = rec.calls[1]
     assert (
-        f"listen-address={mdns.HOTSPOT_GATEWAY_FALLBACK}" in dnsmasq_cmd
-    ), dnsmasq_cmd
+        f"listen-address={mdns.HOTSPOT_GATEWAY_FALLBACK}" in write_cmd
+    ), write_cmd


### PR DESCRIPTION
## Summary

Four related correctness fixes in the WiFi setup path, prompted by Tony's analysis of a bh-0.4.0 install where the AP came up at channel 1 / 802.11n with no HT capabilities even though the patch and bind mount were both nominally in place.

### Bug 1 — `HOTSPOT_GATEWAY` hardcoded to a stale BlueOS subnet

`mdns.py` had `HOTSPOT_GATEWAY = "192.168.43.1"` hardcoded. BlueOS 1.5.x renumbered create_ap's gateway to `192.168.42.1`. The auxiliary dnsmasq we start to resolve `doris.local` on the hotspot was trying to `listen-address=192.168.43.1` against an interface that only has `192.168.42.1`, so `bind-interfaces` failed every start. Hotspot clients without mDNS got nothing for `doris.local`.

Fix: derive the gateway live from `ip -4 -o addr show uap0` at call time. Falls back to the current value when the AP isn't up yet. Drive-by: `no-dhcp-interface=wlan1` → `no-dhcp-interface=uap0` (we rename the Realtek to uap0 via udev before create_ap runs).

### Bug 2 — exact-string anchor in `_install_create_ap_speed_patch`

The anchor was an exact string match including 12 leading spaces and the comment wording (`"--redirect-to-localhost",  # Redirect all traffic to localhost, captive-portal style`). Any upstream reformat — reindent, comment edit, missing trailing comma — would silently miss and the patch would fall through with no actionable log signal.

Fix: `_CREATE_AP_ANCHOR_RE` is a multiline regex that matches the argv-token line and captures its leading indentation. The captured indent is then used to emit the inserted flag lines at matching depth so the patched file stays syntactically clean regardless of upstream indentation. Eight parametrized variant tests + a negative test that an unindented top-level mention is rejected.

### Bug 3 — `startup.json` schema migrations would silently corrupt the file

`_ensure_startup_bind` and `_remove_startup_bind` used `dict.setdefault("core", {}).setdefault("binds", {})`, which would silently create missing keys if `blueos-bootstrap` ever migrated the schema (renamed `core`, made `binds` a list, etc.). We'd write our entry into an orphan top-level key bootstrap never reads, with no signal that the bind isn't active.

Fix: new `_binds_dict_or_none` helper validates the expected `data["core"]["binds"]` dict shape and returns None on mismatch. Both callers refuse to write in that case and log a loud warning. Five parametrized schema-mismatch tests on each side.

### Bug 4 — self-heal undone by `_ensure_startup_bind` (factory-revert footgun)

The most dangerous of the four. `setup_hotspot_radio` unconditionally calls `_ensure_startup_bind()` after `_install_create_ap_speed_patch()`. The patch function's self-heal path (added in PR #18) removes the bind entry from `startup.json` when it has to delete a corrupt host override; the unconditional `_ensure_startup_bind()` right after silently puts the entry back, leaving `startup.json` pointing at a missing source. The next `blueos-core` restart triggers Docker to auto-create a directory at the source path, then container init fails with `not a directory`, then `blueos-bootstrap` falls back to the factory image.

PR #18's fix was effective at the exact moment of self-heal and then re-armed two lines later. This is the trap that caused the May 2026 factory revert and PR #18 was supposed to close.

Fix: `_install_create_ap_speed_patch()` now returns `bool` (True only when the host override is in place with our patch applied). `setup_hotspot_radio` only calls `_ensure_startup_bind()` when it returns True. The gate covers the anchor-miss and write-failure paths too — pointing a bind at an un-patched (or missing) source has the same shape of risk as the self-heal path.

## Test plan

- [x] 73 pytest tests pass locally (`pytest tests/`)
- [x] 40 in `test_hotspot_radio.py` (11 new) — covers return-value contract across every code path in `_install_create_ap_speed_patch`, integration test that `setup_hotspot_radio` honours the gate in both success and failure modes, regex-variant tests for the new anchor including different indents/tab/missing-comma/missing-comment, negative test that an unindented top-level mention is rejected, parametrized schema-mismatch tests for `_ensure_startup_bind` and `_remove_startup_bind`
- [x] 6 in `test_mdns.py` (new file) — `_detect_hotspot_gateway` parsing of both `192.168.42.1` (current) and `192.168.43.1` (legacy), fall-back paths when the interface has no IP yet or `ip` errors, end-to-end `start_hotspot_dns` assertion that the written dnsmasq config contains the detected address and targets `uap0`
- [ ] On a vehicle after the artifact lands: confirm AP comes up at HT20 + full caps + auto-picked channel + `doris.local` resolves from a Windows client (mDNS-less) over the hotspot
- [ ] On a vehicle: deliberately corrupt the host override file (`echo "garbage" | sudo tee /usr/blueos/userdata/wifi-overrides/networkmanager.py`), then trigger setup_hotspot_radio → verify the bind entry is gone from `startup.json` AND stays gone (was not re-added by the outer `setup_hotspot_radio`)
