### PR TITLE
fix(wifi): drop HT40+ from create_ap ht_capab, advertise HT20-only

### DIFF
--- a/extension/backend/src/doris/services/hotspot_radio.py
+++ b/extension/backend/src/doris/services/hotspot_radio.py
@@ -45,8 +45,7 @@ module inside ``blueos-core`` to add::
 
     "-c", "<auto-picked: 1 or 6>",
     "--ieee80211n",
-    "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40][LDPC][RX-STBC1]"
-                  "[MAX-AMSDU-7935][DSSS_CCK-40]",
+    "--ht_capab", "[SHORT-GI-20][LDPC][RX-STBC1][MAX-AMSDU-7935]",
     "--country", "US",
 
 right before the SSID/password arguments. The patched module is written
@@ -57,17 +56,26 @@ re-reads ``startup.json`` on every boot, so the override survives
 ``blueos-core`` recreations and BlueOS upgrades that don't touch the
 target file.
 
-Even though the ht_capab line asks for ``[HT40+]``, hostapd is allowed
-(and required by 802.11n on 2.4 GHz) to fall back to HT20 if its OBSS
-coexistence scan finds neighbouring BSSes overlapping the would-be 40
-MHz band - this gives us "try HT40, fall back to HT20" for free. In
-practice the bundled ``88x2bu`` driver also silently downgrades HT40
-to HT20 in AP mode even in a clean OBSS environment (see the inline
-comment on :data:`_CREATE_AP_24GHZ_FLAGS_TEMPLATE` below for the
-empirical proof), so we always end up running HT20-with-full-caps -
-still about 3x stock throughput because the rich ``ht_capab`` flags
-add SHORT-GI, LDPC, RX-STBC, MAX-AMSDU and DSSS/CCK aggregation on
-top of the bare HT20 ``wifi-manager`` ships.
+The ht_capab line explicitly declares HT20-only capabilities. An
+earlier revision of this patch asked for ``[HT40+]`` on the theory
+that hostapd's "try HT40, OBSS-coex fall back to HT20" logic would
+get us the wider channel for free in clean RF environments and a
+graceful downgrade otherwise. In practice the bundled
+``morrownr/88x2bu-20210702`` driver's AP-mode firmware path cannot
+keep an HT40 BSS up: in a busy 2.4 GHz environment hostapd's OBSS
+scan downgrades to HT20 before the driver ever sees the request and
+things look fine, but in a clean RF environment hostapd actually
+issues the HT40 BSS request, the driver rejects it, and the BSS
+cycles ``INTERFACE-ENABLED`` → ``INTERFACE-DISABLED`` (end-user
+symptom: "AP shows up, you connect, it disappears, you lose
+connection"; ``iw dev uap0 info`` shows ``txpower -100.00 dBm`` and
+no ``channel/width/center`` line). Confirmed in field reports May
+2026 on a unit with no 2.4 GHz neighbours on the picker-chosen
+channel. Asking for HT20 directly removes the failure mode at the
+cost of nothing - the driver was downgrading to HT20 every time it
+actually completed a BSS bring-up anyway. The other capabilities
+(LDPC, SHORT-GI-20, RX-STBC1, MAX-AMSDU-7935) still lift real TCP
+throughput from ~25 Mbps (stock) to ~80 Mbps on this radio.
 
 Channel auto-selection
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -228,31 +236,50 @@ _CREATE_AP_ANCHOR_RE = re.compile(
 # :data:`_CREATE_AP_ANCHOR_RE` so the inserted lines line up with the
 # surrounding argv entries regardless of upstream indentation choice.
 #
-# Why HT20 and not HT40?  The ``morrownr/88x2bu-20210702`` driver
-# advertises HT40 in ``iw phy phy1 info`` but its AP-mode firmware path
-# silently downgrades any HT40 BSS to HT20.  Confirmed on May 2026 with
-# a deliberately-cleaned RF environment (test owner moved all 2.4 GHz
-# neighbours out of ch 11 HT40-'s affected band of 2442-2482 MHz, then
-# hot-deployed ``-c 11 --ht_capab [HT40-]`` straight into the live
-# wifi-manager).  hostapd reached ``state=ENABLED`` cleanly but reported
-# ``secondary_channel=0`` and ``iw dev uap0 info`` showed
-# ``width: 20 MHz`` - i.e. the downgrade is happening below hostapd's
-# OBSS coexistence check, in the driver itself.  Same class of
-# AP-mode firmware-path issue as the 5 GHz failure noted in the module
-# docstring ("Why no 5 GHz mode" section).
+# Why HT20 explicitly and not HT40?  The ``morrownr/88x2bu-20210702``
+# driver advertises HT40 capability but its AP-mode firmware path
+# cannot keep an HT40 BSS up.  May 2026 lab testing on a deliberately
+# cleaned RF environment (test owner moved all 2.4 GHz neighbours out
+# of ch 11 HT40-'s affected 2442-2482 MHz band, then hot-deployed
+# ``-c 11 --ht_capab [HT40-]`` into the live wifi-manager) showed
+# hostapd reach ``state=ENABLED`` but report ``secondary_channel=0``
+# and ``iw dev uap0 info`` come back with ``width: 20 MHz`` - i.e.
+# when things "worked" the driver was silently dropping us to HT20
+# below hostapd's state machine, inside the driver/firmware seam.
 #
-# We still ask for ``[HT40+]`` in the ht_capab line because (a) it
-# advertises the wider capability to clients that might benefit if a
-# future driver fixes this, and (b) hostapd's standard "try HT40, fall
-# back to HT20 if OBSS coexistence scan finds neighbours" logic remains
-# in effect for free.  The other capabilities (LDPC, both SGI rates,
-# RX-STBC1, MAX-AMSDU-7935, DSSS/CCK in HT40) all stick at HT20 and
-# lift real TCP throughput from ~25 Mbps (stock) to ~80 Mbps.
+# An earlier revision of this patch asked for ``[HT40+]`` anyway,
+# betting on (a) "the driver downgrades for us" and (b) "hostapd's
+# OBSS coex scan downgrades to HT20 if any 2.4 GHz neighbour overlaps
+# the secondary 40 MHz band, so HT40+ falls back gracefully for free."
+# A field report in May 2026 broke that bet: a unit with no 2.4 GHz
+# neighbours on the auto-picked channel saw hostapd actually issue
+# the HT40 BSS request (no OBSS neighbours to coex-downgrade off of),
+# the driver rejected it inside the firmware path, and the BSS
+# entered an ``INTERFACE-ENABLED`` -> ``INTERFACE-DISABLED`` cycle
+# on every client association attempt.  The user-visible signature
+# is "AP appears, you connect, it disappears, you lose connection"
+# and ``iw dev uap0 info`` shows ``txpower -100.00 dBm`` (the
+# firmware-unset sentinel) with no ``channel/width/center`` line -
+# distinct from the "stable HT20" signature where the same command
+# reports ``channel <N>, width: 20 MHz, txpower 20.00 dBm`` cleanly.
+#
+# Same class of AP-mode firmware-path issue as the 5 GHz failure
+# noted in the module docstring ("Why no 5 GHz mode" section): the
+# driver advertises a capability it cannot actually sustain.
+#
+# We therefore advertise HT20 only.  This costs nothing: every unit
+# that "worked" with the previous patch was running HT20 internally
+# already (per the lab measurement above).  The ht_capab caps we
+# keep - SHORT-GI-20, LDPC, RX-STBC1, MAX-AMSDU-7935 - are all
+# HT20-valid and lift real TCP throughput from ~25 Mbps stock to
+# ~80 Mbps.  The HT40-specific caps ([HT40+], SHORT-GI-40,
+# DSSS_CCK-40) are removed both because they would be ignored at
+# HT20 and to make sure hostapd has no path back to attempting an
+# HT40 BSS.
 _CREATE_AP_24GHZ_FLAGS_TEMPLATE = (
     '{indent}"-c", "{channel}",\n'
     '{indent}"--ieee80211n",\n'
-    '{indent}"--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]'
-    '[LDPC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40]",\n'
+    '{indent}"--ht_capab", "[SHORT-GI-20][LDPC][RX-STBC1][MAX-AMSDU-7935]",\n'
     '{indent}"--country", "US",\n'
 )
 

--- a/extension/backend/tests/test_hotspot_radio.py
+++ b/extension/backend/tests/test_hotspot_radio.py
@@ -48,6 +48,17 @@ def _wrap(payload: str, *, anchor: str = CANONICAL_ANCHOR_LINE) -> str:
 CURRENT_24GHZ_PATCH = (
     '            "-c", "6",\n'
     '            "--ieee80211n",\n'
+    '            "--ht_capab", "[SHORT-GI-20][LDPC][RX-STBC1][MAX-AMSDU-7935]",\n'
+    '            "--country", "US",\n'
+)
+
+
+# The previous shipped revision asked for HT40+. We keep it as test
+# data so the strip path can prove it still cleans up old overrides
+# on units that installed bh-0.4.x before the HT20-only change.
+LEGACY_24GHZ_HT40_PATCH = (
+    '            "-c", "1",\n'
+    '            "--ieee80211n",\n'
     '            "--ht_capab", "[HT40+][SHORT-GI-20][SHORT-GI-40]'
     '[LDPC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40]",\n'
     '            "--country", "US",\n'
@@ -75,6 +86,19 @@ def test_strip_doris_patch_removes_current_24ghz_block() -> None:
     stripped = hotspot_radio._strip_doris_patch(src)
     assert stripped == _wrap("")
     assert "--ht_capab" not in stripped
+
+
+def test_strip_doris_patch_removes_legacy_ht40_block() -> None:
+    """A unit upgrading from a previous bh-0.4.x release will still
+    have an HT40+ override on disk. The strip pass at install time
+    must recognise and remove it so the fresh HT20-only block is
+    written cleanly on top, with no stacked flags."""
+    src = _wrap(LEGACY_24GHZ_HT40_PATCH)
+    stripped = hotspot_radio._strip_doris_patch(src)
+    assert stripped == _wrap("")
+    assert "[HT40+]" not in stripped
+    assert "SHORT-GI-40" not in stripped
+    assert "DSSS_CCK-40" not in stripped
 
 
 def test_strip_doris_patch_removes_legacy_5ghz_block() -> None:
@@ -309,6 +333,74 @@ async def test_install_patch_writes_when_source_is_clean(
     assert path == hotspot_radio.WIFI_OVERRIDE_HOST_PATH
     assert '"-c", "6"' in content
     assert "--ht_capab" in content
+
+
+async def test_install_patch_emits_ht20_only_caps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the May 2026 field report: an earlier revision
+    of this patch asked for ``[HT40+]`` and a field unit with a clean
+    RF environment hit a morrownr 88x2bu AP-mode firmware bug, cycling
+    the BSS INTERFACE-ENABLED/DISABLED on every client association.
+    The fix is to advertise HT20 only so hostapd has no path to ever
+    request an HT40 BSS. Asserts both the positive (HT20 caps present,
+    correct order) and the negative (none of the HT40-specific caps
+    are emitted, regardless of channel)."""
+    captured: dict[str, str] = {}
+
+    async def fake_read(_c: str, _p: str) -> str | None:
+        return _wrap("")
+
+    async def fake_write(_path: str, content: str) -> bool:
+        captured["content"] = content
+        return True
+
+    async def fake_pick() -> int:
+        # Channel 1 is the case that broke in the field - HT40+ on
+        # ch 1 was the specific failure trigger - so we exercise it
+        # here to make sure HT20-only is emitted for that channel
+        # too, not just the docstring's example channel 6.
+        return 1
+
+    monkeypatch.setattr(hotspot_radio, "_read_container_file", fake_read)
+    monkeypatch.setattr(hotspot_radio, "_write_host_file", fake_write)
+    monkeypatch.setattr(hotspot_radio, "_pick_24ghz_channel", fake_pick)
+
+    result = await hotspot_radio._install_create_ap_speed_patch()
+    assert result is True
+
+    content = captured["content"]
+    # HT20-valid caps we keep
+    assert "[SHORT-GI-20]" in content
+    assert "[LDPC]" in content
+    assert "[RX-STBC1]" in content
+    assert "[MAX-AMSDU-7935]" in content
+    # HT40-specific caps that broke Tony's unit. Each one is checked
+    # individually so a regression that brings back just one of them
+    # fails with a specific message.
+    assert "[HT40+]" not in content, (
+        "HT40+ must not be re-introduced - it caused INTERFACE-DISABLED "
+        "cycling on the morrownr 88x2bu AP-mode firmware path on units "
+        "with clean RF environments. See May 2026 field report."
+    )
+    assert "[HT40-]" not in content, "HT40- has the same driver issue as HT40+"
+    assert "SHORT-GI-40" not in content, (
+        "SHORT-GI-40 only applies inside an HT40 BSS; emitting it "
+        "implies an HT40 path we explicitly removed."
+    )
+    assert "DSSS_CCK-40" not in content, (
+        "DSSS_CCK-40 only applies inside an HT40 BSS; same reason."
+    )
+    # Channel and country must also be present and correct for the
+    # picked channel.
+    assert '"-c", "1"' in content
+    assert '"--country", "US"' in content
+    assert '"--ieee80211n"' in content
+    # And nothing about ac/VHT should sneak in - that's the 5 GHz
+    # path we deliberately abandoned.
+    assert "--ieee80211ac" not in content
+    assert "--vht_capab" not in content
+    assert "--freq-band" not in content
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Drops `[HT40+]` and the HT40-specific caps (`SHORT-GI-40`, `DSSS_CCK-40`) from the `create_ap` patch's `--ht_capab` and advertises HT20-only caps explicitly. The `morrownr/88x2bu-20210702` driver's AP-mode firmware path cannot keep an HT40 BSS up, and on a clean RF environment hostapd actually issues the HT40 request (no OBSS neighbours to coex-downgrade off of) and the driver rejects it, cycling the BSS `INTERFACE-ENABLED` → `INTERFACE-DISABLED` on every client knock.

The lab unit that we developed bh-0.4.x against happens to live in a busy 2.4 GHz environment, so hostapd's OBSS coex scan always downgraded to HT20 before the driver ever saw the HT40 request — we never reproduced the failure. A field report on a unit with no neighbours on the auto-picked channel surfaced it as **"AP shows up, you connect, it disappears, you lose connection"** with `iw dev uap0 info` reporting `txpower -100.00 dBm` (firmware-unset sentinel) and no `channel/width/center` line.

This change costs **nothing** on units that previously worked — they were already running HT20 internally per our prior lab measurement of `secondary_channel=0` / `width: 20 MHz` with `--ht_capab [HT40-]` deployed. Same ~80 Mbps real TCP, no HT40 BSS path the driver can blow up on.

## Test plan

- [x] All 77 backend tests green locally.
- [x] New `test_install_patch_emits_ht20_only_caps` exercises channel 1 (the failure-case channel) and asserts both presence of the HT20-valid caps (`[SHORT-GI-20]`, `[LDPC]`, `[RX-STBC1]`, `[MAX-AMSDU-7935]`) and explicit absence of every HT40-specific cap and any leftover 5 GHz/VHT flags, each with a specific failure message.
- [x] New `test_strip_doris_patch_removes_legacy_ht40_block` confirms units upgrading from bh-0.4.x will have their old HT40+ override correctly stripped before the new HT20-only block is written, so no flag-stacking on the override file.
- [x] Existing strip / install / idempotency tests updated to the new canonical patch shape via the `CURRENT_24GHZ_PATCH` fixture.
- [ ] Field unit installs the resulting artifact and confirms a stable AP with `iw dev uap0 info` showing `channel <N>`, `width: 20 MHz`, `txpower 20.00 dBm` and clients no longer dropping on association.
- [ ] Lab unit (busy 2.4 GHz) re-runs `iperf3 -c <gateway> -p 5201 -t 20 -P 4` and confirms no throughput regression from the prior ~80 Mbps.
