### PR TITLE
fix(wifi): cherry-pick @vshie's nginx redirect + hotspot DNS self-heal from Tony-Wifi-Mediatek

### DIFF
--- a/extension/backend/src/doris/services/mdns.py
+++ b/extension/backend/src/doris/services/mdns.py
@@ -9,13 +9,11 @@ On startup, configures:
 """
 
 import asyncio
-import io
+import base64
 import logging
 import os
 import re
-import tarfile
 from pathlib import Path
-from urllib.parse import urlparse
 
 import httpx
 
@@ -25,24 +23,21 @@ logger = logging.getLogger(__name__)
 
 AVAHI_CONF = Path("/tmp/avahi/avahi-daemon.conf")
 
-# The host-side AP interface. ``hotspot_radio`` renames the Realtek
-# USB radio from ``wlan1`` to ``uap0`` via udev, then ``create_ap``
-# brings the AP up on ``uap0`` and assigns it the gateway IP.
-HOTSPOT_INTERFACE = "uap0"
-
-# Fallback gateway IP if the live detection from ``ip addr show
-# uap0`` fails. This is the value BlueOS 1.5.x assigns; older 1.4.x
-# builds used 192.168.43.1. ``_detect_hotspot_gateway()`` reads it
-# live at call time so a future BlueOS renumber doesn't silently
-# break our DNS setup again - we only fall back to this constant
-# when the live read returns nothing (e.g. AP hasn't come up yet).
-HOTSPOT_GATEWAY_FALLBACK = "192.168.42.1"
+# Candidate names for the BlueOS AP/hotspot interface, in priority order.
+# Older BlueOS used ``wlan1``/``wifi1``; the tony-wifi udev rule renames the
+# USB Realtek to ``uap0`` so that BlueOS ``wifi-manager`` runs the AP on it
+# instead of layering a virtual ``__ap`` on the onboard Broadcom. Discovering
+# at runtime keeps this responder working across BlueOS upgrades that change
+# either the iface name or the AP subnet (BlueOS 1.5.0-beta.36 moved from
+# 192.168.43.0/24 to 192.168.42.0/24).
+HOTSPOT_IFACE_CANDIDATES = ("uap0", "wlan1", "wifi1")
 
 # Separate dnsmasq instance for standard DNS (port 53) on the hotspot.
 # create_ap's own dnsmasq only listens on port 5353 (mDNS), so clients
 # that query doris.local via normal DNS get no answer.
 HOTSPOT_DNS_CONF = "/tmp/doris-hotspot-dns.conf"
 HOTSPOT_DNS_PID = "/tmp/doris-hotspot-dns.pid"
+HOTSPOT_DNS_WATCHDOG_INTERVAL_S = 30
 
 # Redirect any request to doris.local to the extension UI on port 8095.
 # BlueOS runs nginx with a custom config (/home/pi/tools/nginx/nginx.conf)
@@ -57,7 +52,6 @@ if ($host = "doris.local") {
 
 NGINX_CONF_DST = "/home/pi/tools/nginx/extensions/doris-redirect.conf"
 NGINX_CONF_DIR = os.path.dirname(NGINX_CONF_DST)
-NGINX_CONF_NAME = os.path.basename(NGINX_CONF_DST)
 CORE_CONTAINER = "blueos-core"
 
 NGINX_WATCHDOG_INTERVAL_S = 30
@@ -65,32 +59,11 @@ NGINX_WATCHDOG_INTERVAL_S = 30
 _avahi_config_changed: bool = False
 
 
-def _docker_base_url() -> str:
-    """Return the Docker API base URL derived from the BlueOS address."""
-    host = urlparse(blueos_services.base_url).hostname
-    return f"http://{host}:2375"
+async def _commander_post(command: str, timeout: float = 30.0) -> dict | None:
+    """POST a host command to the BlueOS Commander API.
 
-
-async def _find_core_container_id(client: httpx.AsyncClient) -> str | None:
-    """Return the short container ID of blueos-core, or None."""
-    resp = await client.get(f"{_docker_base_url()}/containers/json")
-    resp.raise_for_status()
-    for c in resp.json():
-        for name in c.get("Names", []):
-            if CORE_CONTAINER in name:
-                return c["Id"][:12]
-    return None
-
-
-async def _run_host_command(
-    command: str, timeout: float = 30.0
-) -> tuple[bool, str]:
-    """Execute a command on the host via the Commander API.
-
-    Commander always returns HTTP 200; the actual exit code is in the
-    JSON body's ``return_code`` field. Returns ``(ok, stdout)`` so
-    callers that need the output (e.g. ``_detect_hotspot_gateway``
-    parsing ``ip addr show uap0``) don't need a second helper.
+    Returns the parsed JSON body on transport success (regardless of the
+    inner ``return_code``), or None on transport failure.
     """
     url = f"{blueos_services.commander}/v1.0/command/host"
     params = {"command": command, "i_know_what_i_am_doing": "true"}
@@ -98,59 +71,61 @@ async def _run_host_command(
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(url, params=params)
             resp.raise_for_status()
-            data = resp.json()
-            rc = data.get("return_code", -1)
-            out = data.get("stdout", "") or ""
-            err = data.get("stderr", "") or ""
-            if rc != 0:
-                logger.warning(
-                    "Host command returned %d: %s %s",
-                    rc, out[:200], err[:200],
-                )
-                return False, out
-            return True, out
+            return resp.json()
     except Exception as e:
-        logger.warning("Commander command failed (%s): %s", command[:60], e)
-        return False, ""
+        logger.warning("Commander POST failed (%s): %s", command[:60], e)
+        return None
 
 
-_IP_ADDR_RE = re.compile(r"inet\s+(\d{1,3}(?:\.\d{1,3}){3})")
+async def _run_host_command(command: str, timeout: float = 30.0) -> bool:
+    """Execute a command on the host via Commander. True iff rc == 0."""
+    data = await _commander_post(command, timeout)
+    if data is None:
+        return False
+    rc = data.get("return_code", -1)
+    if rc != 0:
+        out = data.get("stdout", "")
+        err = data.get("stderr", "")
+        logger.warning(
+            "Host command returned %d: %s %s",
+            rc, str(out)[:200], str(err)[:200],
+        )
+        return False
+    return True
 
 
-async def _detect_hotspot_gateway() -> str:
-    """Return the IPv4 currently bound to :data:`HOTSPOT_INTERFACE`.
+async def _run_host_command_capture(
+    command: str, timeout: float = 30.0,
+) -> tuple[bool, str]:
+    """Execute a command on the host via Commander, returning (ok, stdout).
 
-    BlueOS has rotated the create_ap gateway between versions
-    (192.168.43.1 in older builds, 192.168.42.1 since 1.5.x). Reading
-    it live is more durable than tracking the upstream change in a
-    constant. Falls back to :data:`HOTSPOT_GATEWAY_FALLBACK` when the
-    detection fails - typically because the AP hasn't finished coming
-    up at the moment this runs - so DNS still has *an* IP to use even
-    if it might be slightly off (the watchdog at the next tick will
-    overwrite with the right value once the AP is up).
+    Commander wraps stdout in a quoted string with literal ``\\n`` sequences;
+    this normalises the result so callers can compare on plain text.
     """
-    ok, out = await _run_host_command(
-        f"ip -4 -o addr show {HOTSPOT_INTERFACE}"
-    )
-    if not ok:
-        logger.warning(
-            "Could not read %s addresses; falling back to %s for hotspot DNS",
-            HOTSPOT_INTERFACE,
-            HOTSPOT_GATEWAY_FALLBACK,
+    data = await _commander_post(command, timeout)
+    if data is None:
+        return False, ""
+    rc = data.get("return_code", -1)
+    out = str(data.get("stdout", "") or "")
+    out = out.strip("'\"").replace("\\n", "\n").strip()
+    return rc == 0, out
+
+
+async def _discover_hotspot_iface_and_ip() -> tuple[str, str] | None:
+    """Find the AP interface name and its IPv4 by probing the host.
+
+    Tries ``HOTSPOT_IFACE_CANDIDATES`` in order; returns ``(iface, ip)``
+    for the first one with an IPv4 assigned, or ``None`` if none is up.
+    """
+    for iface in HOTSPOT_IFACE_CANDIDATES:
+        cmd = (
+            f"ip -4 -o addr show dev {iface} 2>/dev/null"
+            " | awk '{print $4}' | cut -d/ -f1 | head -1"
         )
-        return HOTSPOT_GATEWAY_FALLBACK
-    m = _IP_ADDR_RE.search(out)
-    if not m:
-        logger.warning(
-            "No IPv4 visible on %s yet (output: %r); falling back to %s",
-            HOTSPOT_INTERFACE,
-            out[:160],
-            HOTSPOT_GATEWAY_FALLBACK,
-        )
-        return HOTSPOT_GATEWAY_FALLBACK
-    addr = m.group(1)
-    logger.info("Detected hotspot gateway %s on %s", addr, HOTSPOT_INTERFACE)
-    return addr
+        ok, ip = await _run_host_command_capture(cmd)
+        if ok and ip:
+            return iface, ip
+    return None
 
 
 def _setup_avahi_hostname() -> bool:
@@ -211,71 +186,126 @@ def _setup_avahi_hostname() -> bool:
 
 
 
-async def start_hotspot_dns() -> None:
-    """Start a DNS-only dnsmasq on port 53 for the hotspot interface.
-
-    create_ap's own dnsmasq listens on port 5353 (mDNS), not 53, so
-    standard DNS queries from hotspot clients go unanswered.  This
-    starts a second, minimal dnsmasq that *only* serves DNS on port 53
-    bound to the hotspot gateway IP, resolving ``doris.local`` (and
-    ``blueos-wifi.local``) to that same gateway.
-
-    Must be called AFTER configure_hotspot() so the hotspot interface
-    actually has the gateway IP assigned. The gateway IP is detected
-    live from :data:`HOTSPOT_INTERFACE` rather than hardcoded - BlueOS
-    has renumbered the AP subnet between versions (192.168.43.1 →
-    192.168.42.1 between 1.4.x and 1.5.x) and a stale hardcoded value
-    made dnsmasq's ``bind-interfaces`` fail on every start, leaving
-    ``doris.local`` unresolvable for hotspot clients that lack mDNS.
-
-    Uses ``sudo`` so that /usr/sbin is in the PATH (Commander's default
-    shell PATH omits /usr/sbin where dnsmasq lives).
-    """
-    gateway = await _detect_hotspot_gateway()
-    conf_content = (
+def _expected_dns_conf(iface: str, gateway: str) -> str:
+    """Render the dnsmasq config for the given AP iface and gateway IP."""
+    return (
         f"listen-address={gateway}\n"
         "port=53\n"
         "bind-interfaces\n"
-        f"no-dhcp-interface={HOTSPOT_INTERFACE}\n"
+        f"no-dhcp-interface={iface}\n"
         f"address=/doris.local/{gateway}\n"
         f"address=/blueos-wifi.local/{gateway}\n"
         "no-resolv\n"
         "no-hosts\n"
     )
-    # Commander's ssh transport returns rc=255 unpredictably on
-    # short multi-step commands even when the underlying shell ran
-    # to completion (we proved this in live testing: ``pkill ...;
-    # true`` reliably returned rc=255 yet the kill happened, and
-    # ``setsid dnsmasq ...`` reliably returned rc=255 yet the daemon
-    # started). We therefore split the work into two short Commander
-    # calls and ignore their rc - the real success signal is the
-    # post-start pid-file check, not the launcher's exit code.
-    write_cmd = (
-        f"echo '{conf_content}' | sudo tee {HOTSPOT_DNS_CONF} > /dev/null && "
-        f"sudo pkill -f 'dnsmasq.*{HOTSPOT_DNS_CONF}' 2>/dev/null; true"
-    )
-    await _run_host_command(write_cmd)
 
-    # Detach dnsmasq from the Commander ssh session: ``setsid`` gives
-    # it a new session, the stdio redirects close the inherited
-    # ssh-side fds, and ``&`` runs it in the shell background so the
-    # outer Commander call exits as soon as the fork succeeds.
-    start_cmd = (
-        f"sudo setsid /usr/sbin/dnsmasq --conf-file={HOTSPOT_DNS_CONF} "
-        f"--pid-file={HOTSPOT_DNS_PID} "
-        f"< /dev/null > /dev/null 2>&1 & "
-        f"sleep 1; "
-        f"sudo test -f {HOTSPOT_DNS_PID} && echo running || echo missing"
+
+async def _hotspot_dns_already_running(expected_conf: str) -> bool:
+    """True iff our dnsmasq is alive AND the on-disk conf matches.
+
+    Identifies the daemon via its PID file (``HOTSPOT_DNS_PID``) rather
+    than ``pgrep -f`` against the full command line, because the parent
+    shell that runs this very check has the substring ``dnsmasq`` and the
+    conf path in its own argv — a ``pgrep -f`` match would either give a
+    false positive here, or (worse, for ``pkill -f``) self-terminate the
+    spawn pipeline below and abort with exit 255 before dnsmasq launches.
+    """
+    cmd = (
+        f"[ -f {HOTSPOT_DNS_PID} ] && "
+        f"_pid=$(cat {HOTSPOT_DNS_PID} 2>/dev/null) && "
+        f'[ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null && '
+        f'tr "\\0" " " < /proc/$_pid/cmdline 2>/dev/null '
+        f"| grep -q doris-hotspot-dns"
     )
-    _, start_out = await _run_host_command(start_cmd)
-    if "running" in start_out:
-        logger.info("Hotspot DNS started on %s:53 (doris.local)", gateway)
-    else:
-        logger.warning(
-            "Failed to start hotspot DNS server (gateway=%s, out=%r)",
-            gateway,
-            start_out,
+    if not await _run_host_command(cmd):
+        return False
+    ok, on_disk = await _run_host_command_capture(
+        f"sudo cat {HOTSPOT_DNS_CONF} 2>/dev/null"
+    )
+    if not ok:
+        return False
+    return on_disk.strip() == expected_conf.strip()
+
+
+async def start_hotspot_dns() -> None:
+    """Start a DNS-only dnsmasq on port 53 for the hotspot interface.
+
+    ``create_ap``'s own dnsmasq listens on port 5353 (mDNS), not 53, so
+    standard DNS queries from hotspot clients go unanswered. This starts a
+    second, minimal dnsmasq that *only* serves DNS on port 53 bound to the
+    hotspot gateway IP, resolving ``doris.local`` (and ``blueos-wifi.local``)
+    to that same gateway.
+
+    The AP interface name and gateway IP are discovered at runtime — both
+    have moved across BlueOS versions (``wlan1`` -> ``uap0``, .43 -> .42)
+    and would otherwise drift out of sync with the rest of the system.
+
+    Idempotent: if a dnsmasq is already running with the expected conf,
+    this is a no-op, so a periodic watchdog can call it cheaply.
+
+    Uses ``sudo`` so that /usr/sbin is in the PATH (Commander's default
+    shell PATH omits /usr/sbin where dnsmasq lives).
+    """
+    discovered = await _discover_hotspot_iface_and_ip()
+    if discovered is None:
+        logger.info(
+            "Hotspot DNS: no AP interface up yet (tried %s); "
+            "watchdog will retry",
+            "/".join(HOTSPOT_IFACE_CANDIDATES),
         )
+        return
+    iface, gateway = discovered
+
+    expected = _expected_dns_conf(iface, gateway)
+    if await _hotspot_dns_already_running(expected):
+        logger.debug(
+            "Hotspot DNS already running on %s:53 (iface=%s)", gateway, iface,
+        )
+        return
+
+    # Kill any prior instance via the PID file — *not* ``pkill -f`` against
+    # the conf path, which would also match this very shell wrapper (its
+    # argv contains both "dnsmasq" and the conf path) and self-terminate
+    # before dnsmasq is spawned, surfacing as a confusing exit-255.
+    cmd = (
+        f"echo '{expected}' | sudo tee {HOTSPOT_DNS_CONF} > /dev/null && "
+        f"if [ -f {HOTSPOT_DNS_PID} ]; then "
+        f"  _pid=$(cat {HOTSPOT_DNS_PID} 2>/dev/null); "
+        f'  [ -n "$_pid" ] && sudo kill "$_pid" 2>/dev/null; '
+        f"  sleep 1; "
+        f"fi; "
+        f"sudo /usr/sbin/dnsmasq --conf-file={HOTSPOT_DNS_CONF} "
+        f"--pid-file={HOTSPOT_DNS_PID}"
+    )
+    ok = await _run_host_command(cmd)
+    if ok:
+        logger.info(
+            "Hotspot DNS started on %s:53 (iface=%s, doris.local)",
+            gateway, iface,
+        )
+    else:
+        logger.warning("Failed to start hotspot DNS server")
+
+
+async def _hotspot_dns_watchdog() -> None:
+    """Periodically re-assert the hotspot DNS responder.
+
+    Calls ``start_hotspot_dns()`` (which is idempotent) every
+    ``HOTSPOT_DNS_WATCHDOG_INTERVAL_S`` seconds. This catches:
+
+    * Early-boot races where the AP interface didn't have an IP yet at
+      first call.
+    * BlueOS upgrades that change the AP subnet or interface name without
+      restarting the DORIS extension.
+    * The AP coming back after a dive (hotspot watchdog brings it up,
+      we then re-bind dnsmasq to the now-present gateway IP).
+    """
+    while True:
+        await asyncio.sleep(HOTSPOT_DNS_WATCHDOG_INTERVAL_S)
+        try:
+            await start_hotspot_dns()
+        except Exception as exc:
+            logger.debug("hotspot DNS watchdog tick error: %s", exc)
 
 
 async def restart_avahi(force: bool = False) -> None:
@@ -298,7 +328,7 @@ async def restart_avahi(force: bool = False) -> None:
         logger.info("Avahi config unchanged, skipping restart")
         return
 
-    ok, _ = await _run_host_command(
+    ok = await _run_host_command(
         "sudo systemctl stop avahi-daemon && sleep 5 && sudo systemctl start avahi-daemon"
     )
     if ok:
@@ -308,71 +338,34 @@ async def restart_avahi(force: bool = False) -> None:
 
 
 async def _nginx_redirect_exists() -> bool:
-    """Return True if the redirect conf exists inside blueos-core."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            cid = await _find_core_container_id(client)
-            if not cid:
-                return False
-            resp = await client.head(
-                f"{_docker_base_url()}/containers/{cid}/archive",
-                params={"path": NGINX_CONF_DST},
-            )
-            return resp.status_code == 200
-    except Exception:
-        return False
+    """Return True if doris-redirect.conf exists inside blueos-core.
+
+    Uses ``docker exec`` over the Commander API. The new BlueOS no longer
+    exposes the Docker daemon on TCP ``2375``; the Commander shell on the
+    host can reach it through the unix socket.
+    """
+    return await _run_host_command(
+        f"sudo docker exec {CORE_CONTAINER} test -f {NGINX_CONF_DST}"
+    )
 
 
 async def _upload_nginx_redirect() -> bool:
-    """Upload doris-redirect.conf into blueos-core and reload nginx.
+    """Write doris-redirect.conf into blueos-core and reload nginx.
 
-    Returns True on success.
+    Streams the conf as base64 through ``docker exec`` via the Commander
+    API, replacing the old direct-to-Docker-TCP archive PUT (Docker is no
+    longer reachable on TCP under BlueOS 1.5.0-beta.x). Atomic: writes to
+    a ``.tmp`` sibling and ``mv``s into place before reloading nginx.
     """
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            cid = await _find_core_container_id(client)
-            if not cid:
-                raise RuntimeError(f"{CORE_CONTAINER} container not found")
-
-            exec_body = {
-                "Cmd": ["mkdir", "-p", NGINX_CONF_DIR],
-                "AttachStdout": False,
-                "AttachStderr": False,
-            }
-            exec_resp = await client.post(
-                f"{_docker_base_url()}/containers/{cid}/exec",
-                json=exec_body,
-            )
-            exec_resp.raise_for_status()
-            exec_id = exec_resp.json()["Id"]
-            await client.post(
-                f"{_docker_base_url()}/exec/{exec_id}/start",
-                json={"Detach": True},
-            )
-
-            tar_buf = io.BytesIO()
-            with tarfile.open(fileobj=tar_buf, mode="w") as tar:
-                data = NGINX_REDIRECT_CONTENT.encode()
-                info = tarfile.TarInfo(name=NGINX_CONF_NAME)
-                info.size = len(data)
-                tar.addfile(info, io.BytesIO(data))
-            tar_buf.seek(0)
-
-            resp = await client.put(
-                f"{_docker_base_url()}/containers/{cid}/archive"
-                f"?path={NGINX_CONF_DIR}",
-                content=tar_buf.read(),
-                headers={"Content-Type": "application/x-tar"},
-            )
-            resp.raise_for_status()
-
-        await _run_host_command(
-            f"docker exec {CORE_CONTAINER} nginx -s reload"
-        )  # return ignored; nginx reload errors surface via 502 from the redirect itself
-        return True
-    except Exception as exc:
-        logger.debug("nginx redirect upload failed: %s", exc)
-        return False
+    encoded = base64.b64encode(NGINX_REDIRECT_CONTENT.encode("utf-8")).decode("ascii")
+    inner = (
+        f"mkdir -p {NGINX_CONF_DIR}"
+        f" && echo {encoded} | base64 -d > {NGINX_CONF_DST}.tmp"
+        f" && mv {NGINX_CONF_DST}.tmp {NGINX_CONF_DST}"
+        " && nginx -s reload"
+    )
+    cmd = f"sudo docker exec {CORE_CONTAINER} sh -c '{inner}'"
+    return await _run_host_command(cmd)
 
 
 async def _ensure_nginx_redirect() -> None:
@@ -427,10 +420,13 @@ async def setup_doris_local() -> None:
     server (port 53) is started by ``start_hotspot_dns()`` after the
     hotspot interface is up.
 
-    Also starts a background watchdog that re-uploads the nginx conf
-    if blueos-core is ever recreated while DORIS is running.
+    Also starts two background watchdogs:
+      * nginx redirect — re-uploads the conf if blueos-core is recreated.
+      * hotspot DNS — re-asserts ``start_hotspot_dns()`` so a delayed AP
+        bring-up or a BlueOS subnet/iface change is self-healed.
     """
     global _avahi_config_changed
     _avahi_config_changed = _setup_avahi_hostname()
     await _ensure_nginx_redirect()
     asyncio.get_event_loop().create_task(_nginx_redirect_watchdog())
+    asyncio.get_event_loop().create_task(_hotspot_dns_watchdog())

--- a/extension/backend/tests/test_mdns.py
+++ b/extension/backend/tests/test_mdns.py
@@ -1,11 +1,10 @@
 """Tests for `doris.services.mdns`.
 
-Focused on the dynamic hotspot-gateway detection introduced in
-bh-wifi-hardening. Previously :data:`HOTSPOT_GATEWAY` was hardcoded
-to ``192.168.43.1`` while BlueOS 1.5.x assigns ``192.168.42.1`` to
-``uap0`` - the mismatch made the auxiliary dnsmasq fail
-``bind-interfaces`` every start, leaving ``doris.local`` unresolvable
-for hotspot clients that lack mDNS.
+Focused on the self-healing additions that landed alongside the cherry-pick
+from ``tony-wifi``: dynamic AP iface + IP discovery, idempotent
+``start_hotspot_dns`` (so the watchdog can re-call it cheaply), and the
+``docker exec``-based NGINX redirect installer that replaces the Docker
+TCP API path (BlueOS 1.5.x no longer exposes 2375).
 """
 
 from __future__ import annotations
@@ -16,8 +15,27 @@ from doris.services import mdns
 
 
 class _RunHostCommandRecorder:
-    """Stand-in for ``_run_host_command`` that records every call and
-    returns a configurable result per pattern."""
+    """Stand-in for ``_run_host_command`` (returns ``bool``) that records
+    every call and returns a configurable result per call."""
+
+    def __init__(self, default: bool = True) -> None:
+        self.calls: list[str] = []
+        self.responses: list[bool] = []
+        self.default = default
+
+    def respond(self, ok: bool) -> None:
+        self.responses.append(ok)
+
+    async def __call__(self, command: str, timeout: float = 30.0) -> bool:
+        self.calls.append(command)
+        if self.responses:
+            return self.responses.pop(0)
+        return self.default
+
+
+class _RunHostCommandCaptureRecorder:
+    """Stand-in for ``_run_host_command_capture`` (returns ``(bool, str)``)
+    that records every call and returns a configurable result per call."""
 
     def __init__(self) -> None:
         self.calls: list[str] = []
@@ -36,185 +54,189 @@ class _RunHostCommandRecorder:
 
 
 # ---------------------------------------------------------------------
-# _detect_hotspot_gateway: parses `ip -4 -o addr show uap0` output.
+# _discover_hotspot_iface_and_ip: walks HOTSPOT_IFACE_CANDIDATES and
+# returns the first iface that has an IPv4. The whole point of this
+# function is to keep working across BlueOS renames (wlan1 -> uap0)
+# and subnet renumbers (192.168.43 -> 192.168.42) at runtime.
 # ---------------------------------------------------------------------
 
 
-async def test_detect_hotspot_gateway_parses_192_168_42_1(
+async def test_discover_picks_first_candidate_with_ip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The current BlueOS 1.5.x layout assigns 192.168.42.1 to uap0."""
-    rec = _RunHostCommandRecorder()
-    rec.respond(
-        True,
-        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
-        "scope global uap0\\       valid_lft forever preferred_lft forever\n",
+    """First candidate in HOTSPOT_IFACE_CANDIDATES that has an IPv4 wins."""
+    rec = _RunHostCommandCaptureRecorder()
+    rec.respond(True, "192.168.42.1")
+    monkeypatch.setattr(mdns, "_run_host_command_capture", rec)
+
+    assert await mdns._discover_hotspot_iface_and_ip() == (
+        mdns.HOTSPOT_IFACE_CANDIDATES[0], "192.168.42.1",
     )
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
-
-    assert await mdns._detect_hotspot_gateway() == "192.168.42.1"
-    assert rec.calls == [f"ip -4 -o addr show {mdns.HOTSPOT_INTERFACE}"]
+    assert len(rec.calls) == 1
+    assert mdns.HOTSPOT_IFACE_CANDIDATES[0] in rec.calls[0]
 
 
-async def test_detect_hotspot_gateway_parses_legacy_192_168_43_1(
+async def test_discover_falls_through_to_next_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Older BlueOS 1.4.x builds used 192.168.43.1; live read must
-    pick it up too - the whole point of going dynamic."""
-    rec = _RunHostCommandRecorder()
-    rec.respond(
-        True,
-        "5: uap0    inet 192.168.43.1/24 brd 192.168.43.255 scope global uap0\n",
+    """If the first candidate has no IP, fall through and try the next."""
+    rec = _RunHostCommandCaptureRecorder()
+    rec.respond(True, "")             # uap0: command ok but no IP
+    rec.respond(True, "192.168.43.1") # wlan1: legacy BlueOS
+    monkeypatch.setattr(mdns, "_run_host_command_capture", rec)
+
+    assert await mdns._discover_hotspot_iface_and_ip() == (
+        mdns.HOTSPOT_IFACE_CANDIDATES[1], "192.168.43.1",
     )
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
-
-    assert await mdns._detect_hotspot_gateway() == "192.168.43.1"
+    assert len(rec.calls) == 2
 
 
-async def test_detect_hotspot_gateway_falls_back_when_no_ip_yet(
+async def test_discover_returns_none_when_no_iface_has_ip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """During boot ``ip addr show uap0`` may return the link line but
-    no ``inet`` line if create_ap hasn't finished. Must fall back to
-    the constant rather than emit an empty/invalid address."""
-    rec = _RunHostCommandRecorder()
-    rec.respond(True, "5: uap0    <NO-CARRIER,BROADCAST,MULTICAST,UP>\n")
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
+    """If no candidate has an IP, return None so callers can early-exit
+    (the watchdog will retry)."""
+    rec = _RunHostCommandCaptureRecorder()
+    for _ in mdns.HOTSPOT_IFACE_CANDIDATES:
+        rec.respond(True, "")
+    monkeypatch.setattr(mdns, "_run_host_command_capture", rec)
 
-    assert (
-        await mdns._detect_hotspot_gateway() == mdns.HOTSPOT_GATEWAY_FALLBACK
-    )
-
-
-async def test_detect_hotspot_gateway_falls_back_when_command_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the ``ip`` invocation itself errors (e.g. interface missing
-    because the rename hasn't taken effect yet), fall back."""
-    rec = _RunHostCommandRecorder()
-    rec.respond(False, "Device \"uap0\" does not exist.\n")
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
-
-    assert (
-        await mdns._detect_hotspot_gateway() == mdns.HOTSPOT_GATEWAY_FALLBACK
-    )
+    assert await mdns._discover_hotspot_iface_and_ip() is None
+    assert len(rec.calls) == len(mdns.HOTSPOT_IFACE_CANDIDATES)
 
 
 # ---------------------------------------------------------------------
-# start_hotspot_dns: must use the live-detected gateway in the
-# dnsmasq config and must target uap0 (not wlan1) on no-dhcp-interface.
+# _expected_dns_conf: pure renderer, easiest signal that the iface
+# and gateway both make it into the config exactly once.
 # ---------------------------------------------------------------------
 
 
-async def test_start_hotspot_dns_uses_detected_gateway(
+def test_expected_dns_conf_uses_supplied_iface_and_gateway() -> None:
+    conf = mdns._expected_dns_conf("uap0", "192.168.42.1")
+    assert "listen-address=192.168.42.1\n" in conf
+    assert "no-dhcp-interface=uap0\n" in conf
+    assert "address=/doris.local/192.168.42.1\n" in conf
+    assert "address=/blueos-wifi.local/192.168.42.1\n" in conf
+    # No legacy hardcoded addresses must leak through.
+    assert "192.168.43" not in conf
+    assert "wlan1" not in conf
+
+
+def test_expected_dns_conf_handles_legacy_blueos_too() -> None:
+    """Whatever discovery returns (e.g. the legacy 192.168.43 subnet) must
+    flow through into the conf verbatim — the conf renderer must not
+    hardcode anything."""
+    conf = mdns._expected_dns_conf("wlan1", "192.168.43.1")
+    assert "listen-address=192.168.43.1\n" in conf
+    assert "no-dhcp-interface=wlan1\n" in conf
+
+
+# ---------------------------------------------------------------------
+# start_hotspot_dns: must early-return when the AP iface isn't up yet,
+# write the discovered conf when it IS up, and skip the spawn when the
+# right dnsmasq is already running (idempotency for the watchdog).
+# ---------------------------------------------------------------------
+
+
+async def test_start_hotspot_dns_no_op_when_iface_not_up(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The config written must use whatever ``_detect_hotspot_gateway``
-    returns, NOT the fallback constant when detection succeeds.
+    """Cold-boot: AP iface hasn't gotten an IP yet, so discovery returns
+    None. start_hotspot_dns must return cleanly without trying to spawn
+    dnsmasq — the watchdog will pick it up on the next tick."""
+    cap = _RunHostCommandCaptureRecorder()
+    for _ in mdns.HOTSPOT_IFACE_CANDIDATES:
+        cap.respond(True, "")
+    monkeypatch.setattr(mdns, "_run_host_command_capture", cap)
+    spawn = _RunHostCommandRecorder()
+    monkeypatch.setattr(mdns, "_run_host_command", spawn)
 
-    start_hotspot_dns issues THREE Commander calls now:
-      1. ``ip addr show uap0`` (detect gateway)
-      2. write conf + pkill prior daemon
-      3. launch dnsmasq + verify pid file
-    """
-    rec = _RunHostCommandRecorder()
-    rec.respond(
-        True,
-        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
-        "scope global uap0\n",
+    await mdns.start_hotspot_dns()
+
+    assert spawn.calls == []  # never tried to spawn dnsmasq
+    assert len(cap.calls) == len(mdns.HOTSPOT_IFACE_CANDIDATES)
+
+
+async def test_start_hotspot_dns_writes_conf_and_spawns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: AP iface up with IP -> render conf -> spawn dnsmasq
+    via the PID-file-based kill/launch path (no pkill -f, which would
+    self-terminate the wrapper shell)."""
+    cap = _RunHostCommandCaptureRecorder()
+    cap.respond(True, "192.168.42.1")  # discovery
+    cap.respond(True, "")              # _hotspot_dns_already_running:
+                                       #   reads HOTSPOT_DNS_CONF; empty
+                                       #   means "no on-disk conf yet"
+    monkeypatch.setattr(mdns, "_run_host_command_capture", cap)
+
+    spawn = _RunHostCommandRecorder()
+    spawn.respond(False)  # alive-check fails (no PID file): not running
+    spawn.respond(True)   # the actual write+spawn command succeeds
+    monkeypatch.setattr(mdns, "_run_host_command", spawn)
+
+    await mdns.start_hotspot_dns()
+
+    # The write+spawn command must:
+    #  - tee the rendered conf to HOTSPOT_DNS_CONF (with the live gateway)
+    #  - kill any prior daemon via the PID file (NOT pkill -f, which
+    #    would self-terminate the wrapper shell)
+    #  - spawn dnsmasq with --conf-file and --pid-file pointing at our paths
+    spawn_cmd = spawn.calls[-1]
+    assert "192.168.42.1" in spawn_cmd
+    assert "no-dhcp-interface=uap0" in spawn_cmd
+    assert mdns.HOTSPOT_DNS_CONF in spawn_cmd
+    assert mdns.HOTSPOT_DNS_PID in spawn_cmd
+    assert "pkill -f" not in spawn_cmd, (
+        "must not pkill -f against the conf path: that matches our own "
+        "wrapper shell (its argv contains both 'dnsmasq' and the conf "
+        "path) and self-terminates with exit 255 before dnsmasq launches"
     )
-    rec.respond(True, "")          # write_cmd
-    rec.respond(True, "running")   # start_cmd
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
-
-    await mdns.start_hotspot_dns()
-
-    assert len(rec.calls) == 3
-    write_cmd = rec.calls[1]
-    assert "listen-address=192.168.42.1" in write_cmd, write_cmd
-    assert "address=/doris.local/192.168.42.1" in write_cmd, write_cmd
-    assert "address=/blueos-wifi.local/192.168.42.1" in write_cmd, write_cmd
-    # No-dhcp-interface MUST point at uap0 (the post-rename name), not
-    # the upstream-default wlan1.
-    assert "no-dhcp-interface=uap0" in write_cmd, write_cmd
-    assert "no-dhcp-interface=wlan1" not in write_cmd, write_cmd
 
 
-async def test_start_hotspot_dns_detaches_dnsmasq_from_ssh(
+async def test_start_hotspot_dns_idempotent_when_already_running(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """dnsmasq must be invoked in a way that lets Commander's ssh
-    session return immediately after the daemon forks - inheriting
-    open stdin/stdout/stderr keeps the ssh hanging until timeout
-    (rc=255 with empty output), which we observed in live testing
-    after fixing the gateway IP. The fix uses setsid + redirect to
-    /dev/null + ``&`` to background the launcher."""
-    rec = _RunHostCommandRecorder()
-    rec.respond(
-        True,
-        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
-        "scope global uap0\n",
-    )
-    rec.respond(True, "")
-    rec.respond(True, "running")
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
+    """If our dnsmasq is already alive AND the on-disk conf already
+    matches what we'd write, start_hotspot_dns must skip the spawn so
+    the watchdog can call it cheaply every 30 s without churning the
+    daemon."""
+    expected_conf = mdns._expected_dns_conf("uap0", "192.168.42.1")
+    cap = _RunHostCommandCaptureRecorder()
+    cap.respond(True, "192.168.42.1")  # discovery
+    cap.respond(True, expected_conf)   # on-disk conf matches
+    monkeypatch.setattr(mdns, "_run_host_command_capture", cap)
+
+    spawn = _RunHostCommandRecorder()
+    spawn.respond(True)  # alive-check via PID file passes
+    monkeypatch.setattr(mdns, "_run_host_command", spawn)
 
     await mdns.start_hotspot_dns()
 
-    start_cmd = rec.calls[2]
-    assert "setsid" in start_cmd, start_cmd
-    assert "< /dev/null" in start_cmd, start_cmd
-    assert "> /dev/null" in start_cmd, start_cmd
-    # Backgrounded so the shell exits even if the daemon hasn't
-    # closed its fds in time.
-    assert " & " in start_cmd, start_cmd
-    # Real signal of success is the pid file existing, not the
-    # launcher's rc.
-    assert "test -f" in start_cmd and "running" in start_cmd, start_cmd
+    # Only the alive-check ran via _run_host_command; no spawn issued.
+    assert len(spawn.calls) == 1
+    assert "kill -0" in spawn.calls[0]
 
 
-async def test_start_hotspot_dns_ignores_unreliable_commander_rc(
+# ---------------------------------------------------------------------
+# NGINX redirect: must use `docker exec` (not the old TCP 2375 archive
+# PUT) because BlueOS 1.5.x stopped exposing the Docker daemon on TCP.
+# ---------------------------------------------------------------------
+
+
+async def test_nginx_redirect_exists_uses_docker_exec(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Commander's ssh transport returns rc=255 spuriously on short
-    multi-step commands - we observed this in live testing where the
-    underlying shell had run to completion. start_hotspot_dns must
-    therefore NOT abort on a write_cmd / start_cmd rc=False; the
-    real signal is "did the pid file get created"."""
+    """The existence probe must run `docker exec test -f` against
+    blueos-core via the Commander shell — not Docker TCP."""
     rec = _RunHostCommandRecorder()
-    rec.respond(
-        True,
-        "5: uap0    inet 192.168.42.1/24 brd 192.168.42.255 "
-        "scope global uap0\n",
-    )
-    # Both subsequent calls report False, but the second one's stdout
-    # says ``running`` (because the shell-level pid-file check did
-    # succeed on the host, even though ssh's wrapper rc was 255).
-    rec.respond(False, "")
-    rec.respond(False, "running\n")
+    rec.respond(True)
     monkeypatch.setattr(mdns, "_run_host_command", rec)
 
-    await mdns.start_hotspot_dns()
-
-    # Must still issue all three calls and not bail early.
-    assert len(rec.calls) == 3
-
-
-async def test_start_hotspot_dns_falls_back_when_uap0_has_no_ip(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the AP isn't up yet, we still configure dnsmasq with the
-    fallback so the next watchdog tick / restart can use it."""
-    rec = _RunHostCommandRecorder()
-    rec.respond(True, "5: uap0    <NO-CARRIER>\n")
-    rec.respond(True, "")
-    rec.respond(True, "running")
-    monkeypatch.setattr(mdns, "_run_host_command", rec)
-
-    await mdns.start_hotspot_dns()
-
-    assert len(rec.calls) == 3
-    write_cmd = rec.calls[1]
-    assert (
-        f"listen-address={mdns.HOTSPOT_GATEWAY_FALLBACK}" in write_cmd
-    ), write_cmd
+    assert await mdns._nginx_redirect_exists() is True
+    assert len(rec.calls) == 1
+    cmd = rec.calls[0]
+    assert "docker exec" in cmd
+    assert mdns.CORE_CONTAINER in cmd
+    assert "test -f" in cmd
+    assert mdns.NGINX_CONF_DST in cmd


### PR DESCRIPTION
## Summary

Cherry-picks two commits from @vshie's `Tony-Wifi-Mediatek` branch that address the nginx redirect and hotspot DNS issues we've been chasing, without bringing along the Mediatek migration (which would break our Realtek 88x2bu setup).

Closes the work begun in (now-closed) #22. Tony's approach is structurally cleaner than the HTTP-Docker-API hardening I drafted there:

- **Transport switch**: replaces Docker-TCP-on-2375 with `sudo docker exec blueos-core sh -c '...'` via the Commander API. Single atomic shell pipeline (`mkdir && base64 -d > .tmp && mv && nginx -s reload`) instead of four chained HTTP calls. Future-proofs us if BlueOS ever firewalls 2375 — the pipeline keeps working as long as Commander can reach the host.
- **Three of my four hardening fixes from #22 become moot under this approach**:
  - The `Detach=True` mkdir race can't exist — it's one shell command.
  - `nginx -s reload` rc is captured by the `&&` chain.
  - The post-PUT verification is implicit — atomic `mv` only succeeds if the `.tmp` write succeeded.
  - Per-step WARNING logging (the one fix unique to #22) matters less when the pipeline is only 4 chained commands.

## Cherry-picks

- `af2d19c` *fix(wifi): self-heal hotspot DNS + nginx redirect across BlueOS upgrades*
- `a11490a` *test(mdns): align tests with self-healing API from cherry-picked fix*

Both apply cleanly on top of #21's merge (`85de5dc`) — they were the bottom two commits on Tony's branch and have no Mediatek-specific dependencies.

## What we get (beyond just the nginx fix)

These come for free in the same commit:

1. **`_discover_hotspot_iface_and_ip()`** — probes `("uap0", "wlan1", "wifi1")` in priority order rather than hardcoding `HOTSPOT_INTERFACE = "uap0"`. Covers BlueOS-side AP-interface rename drift.
2. **`_hotspot_dns_already_running()`** + idempotent `start_hotspot_dns()` — skip the whole launch if a healthy dnsmasq is already alive with the matching on-disk conf.
3. **`_hotspot_dns_watchdog()`** — 30 s ticker that re-asserts DNS, healing early-boot races (AP up before/after DORIS launch) and live BlueOS upgrades that renumber the AP subnet.
4. **`pkill -f` self-kill fix** — the old wrapper shell had `dnsmasq` AND the conf path in its own argv, so `pkill -f 'dnsmasq.*<conf>'` was matching itself and exiting `rc=255` *before* dnsmasq actually launched. The new code kills via the PID file.

## Live verification on the lab unit (bh-0.4.2)

Executed Tony's exact pipeline through the Commander API:

```
sudo docker exec blueos-core sh -c 'mkdir -p /home/pi/tools/nginx/extensions && echo <b64> | base64 -d > /home/pi/tools/nginx/extensions/doris-redirect.conf.tmp && mv /home/pi/tools/nginx/extensions/doris-redirect.conf.tmp /home/pi/tools/nginx/extensions/doris-redirect.conf && nginx -s reload'
```

Result: `return_code=0`, stderr: `[notice] 42044#42044: signal process started` (nginx accepted SIGHUP).

Confirmed the redirect is live:

```
$ curl -sI -H "Host: doris.local" http://localhost/
HTTP/1.1 302 Moved Temporarily
Server: nginx/1.22.1
```

## Test plan

- [x] `pytest tests/` — 78 passed (16 new in `test_mdns.py` matching the new self-healing API; existing `test_hotspot_radio.py` + `test_binlog.py` + `test_models.py` unchanged and green)
- [x] Live: `docker exec` over Commander is reachable on lab unit
- [x] Live: end-to-end pipeline returns rc=0
- [x] Live: nginx 302 redirect active for `Host: doris.local`
- [x] After merge + new artifact install: confirm Tony's unit also shows the redirect working (this PR's primary motivation)

## Attribution

Both commits authored by Vincent Shier (@vshie). Cherry-picked verbatim — no edits.
