### PR TITLE
fix(iridium-test): buffer STATUSTEXT, gate on GPS fix, and surface failure context

### DIFF
--- a/extension/backend/src/doris/routes/sensors.py
+++ b/extension/backend/src/doris/routes/sensors.py
@@ -153,9 +153,20 @@ def register_sensor_routes(app: Robyn) -> None:
 
     @app.get("/api/v1/tracker/iridium-status")
     async def get_iridium_status(request):
-        """Poll AGT STATUSTEXT for Iridium test result."""
+        """Poll AGT STATUSTEXT messages newer than ``since_id``.
+
+        Returns ``{messages: [...], latest_id: int}`` where each message
+        has ``{id, text, severity, timestamp}``.  The frontend feeds the
+        returned ``latest_id`` back as ``since_id`` on the next call so
+        no STATUSTEXT can be missed even if mavlink2rest's HTTP cache
+        moves on between polls.
+        """
         try:
-            status = await tracker_service.get_iridium_status()
+            try:
+                since_id = int(request.query_params.get("since_id", "0"))
+            except (TypeError, ValueError):
+                since_id = 0
+            status = await tracker_service.get_iridium_status(since_id=since_id)
             return json.dumps(status)
         except Exception as e:
             return Response(

--- a/extension/backend/src/doris/services/tracker.py
+++ b/extension/backend/src/doris/services/tracker.py
@@ -3,14 +3,30 @@
 Detects the SparkFun Artemis Global Tracker by checking for its
 HEARTBEAT on MAVLink component 191 (MAV_COMP_ID_ONBOARD_COMPUTER).
 Reads GPS_RAW_INT from the same component for position data.
-Supports triggering an Iridium test via COMMAND_LONG and polling
-STATUSTEXT for the result.
+
+Iridium test support
+--------------------
+The AGT emits ``IRIDIUM: …`` STATUSTEXT messages while running an
+Iridium SBD test, but the test takes 2-10 minutes and the AGT emits
+unrelated STATUSTEXT messages (``GPS: PVT watchdog reinit`` etc.) in
+between.  mavlink2rest only caches the *latest* STATUSTEXT, so HTTP
+polling regularly loses the ``IRIDIUM: …PASSED/FAILED`` message.
+
+To fix this we subscribe to the mavlink2rest STATUSTEXT WebSocket on
+first use, filter to component 191, and buffer the last 100 messages
+with a monotonic id.  The frontend polls with ``?since_id=<n>`` and
+scans every new message for the test outcome — no STATUSTEXT can be
+missed even if the AGT emits dozens of messages between polls.
 """
 
+import asyncio
+import json
 import logging
-from datetime import datetime
+from collections import deque
+from datetime import datetime, timezone
 
 import httpx
+import websockets
 
 from ..config import blueos_services
 from ..models.sensors import ModuleInfo
@@ -30,9 +46,69 @@ GPS_FIX_TYPE_MAP: dict[str, int] = {
     "GPS_FIX_TYPE_RTK_FIXED": 6,
 }
 
+SEVERITY_MAP: dict[str, int] = {
+    "MAV_SEVERITY_EMERGENCY": 0, "MAV_SEVERITY_ALERT": 1,
+    "MAV_SEVERITY_CRITICAL": 2, "MAV_SEVERITY_ERROR": 3,
+    "MAV_SEVERITY_WARNING": 4, "MAV_SEVERITY_NOTICE": 5,
+    "MAV_SEVERITY_INFO": 6, "MAV_SEVERITY_DEBUG": 7,
+}
+
+STATUSTEXT_BUFFER_SIZE = 100
+WS_RECONNECT_DELAY_S = 2.0
+TRIGGER_POST_TIMEOUT_S = 15.0  # mavlink2rest POST commonly takes 4-5s
+
 
 def _m2r_base() -> str:
     return blueos_services.mavlink2rest
+
+
+def _statustext_ws_url() -> str:
+    base = blueos_services.mavlink2rest
+    ws_base = base.replace("http://", "ws://").replace("https://", "wss://")
+    return f"{ws_base}/ws/mavlink?filter=STATUSTEXT"
+
+
+def _decode_text(raw_text) -> str:
+    """STATUSTEXT.text is sent as a list of single-char strings padded with \\x00."""
+    if isinstance(raw_text, list):
+        raw_text = "".join(c for c in raw_text if c != "\x00")
+    return (raw_text or "").strip()
+
+
+def _decode_severity(raw_severity) -> int:
+    if isinstance(raw_severity, dict):
+        return SEVERITY_MAP.get(raw_severity.get("type", ""), 6)
+    if isinstance(raw_severity, int):
+        return raw_severity
+    return 6
+
+
+class _StatusTextBuffer:
+    """In-memory ring buffer of recent AGT STATUSTEXT messages."""
+
+    def __init__(self, max_size: int = STATUSTEXT_BUFFER_SIZE) -> None:
+        self._messages: deque[dict] = deque(maxlen=max_size)
+        self._next_id: int = 1
+        self._lock = asyncio.Lock()
+
+    async def add(self, text: str, severity: int) -> None:
+        async with self._lock:
+            self._messages.append({
+                "id": self._next_id,
+                "text": text,
+                "severity": severity,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            })
+            self._next_id += 1
+
+    async def since(self, since_id: int) -> tuple[list[dict], int]:
+        async with self._lock:
+            new = [m for m in self._messages if m["id"] > since_id]
+            return new, self._next_id - 1
+
+    async def latest_id(self) -> int:
+        async with self._lock:
+            return self._next_id - 1
 
 
 class ArtemisTrackerService:
@@ -40,6 +116,8 @@ class ArtemisTrackerService:
 
     def __init__(self) -> None:
         self._client: httpx.AsyncClient | None = None
+        self._statustext = _StatusTextBuffer()
+        self._ws_task: asyncio.Task | None = None
 
     @property
     def client(self) -> httpx.AsyncClient:
@@ -151,13 +229,75 @@ class ArtemisTrackerService:
             logger.debug("No Artemis heartbeat: %s", e)
             return None
 
+    # ── STATUSTEXT subscriber ───────────────────────────────────────
+
+    def _ensure_statustext_subscriber(self) -> None:
+        """Lazily start the background WebSocket subscriber."""
+        if self._ws_task is None or self._ws_task.done():
+            self._ws_task = asyncio.create_task(
+                self._statustext_ws_loop(),
+                name="agt-statustext-subscriber",
+            )
+
+    async def _statustext_ws_loop(self) -> None:
+        """Forever-loop that streams STATUSTEXT into the buffer.
+
+        Reconnects on disconnect with a fixed backoff so a transient
+        mavlink2rest restart can't permanently break the iridium UI.
+        """
+        url = _statustext_ws_url()
+        logger.info("AGT STATUSTEXT subscriber starting (%s)", url)
+        while True:
+            try:
+                async with websockets.connect(url, close_timeout=5) as ws:
+                    async for raw in ws:
+                        if isinstance(raw, bytes):
+                            try:
+                                raw = raw.decode("utf-8")
+                            except UnicodeDecodeError:
+                                continue
+                        if not raw.startswith("{"):
+                            continue
+                        try:
+                            data = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+
+                        header = data.get("header", {}) or {}
+                        if header.get("component_id") != ARTEMIS_COMPONENT_ID:
+                            continue
+
+                        msg = data.get("message", {}) or {}
+                        if msg.get("type") != "STATUSTEXT":
+                            continue
+
+                        text = _decode_text(msg.get("text", ""))
+                        if not text:
+                            continue
+                        sev = _decode_severity(msg.get("severity"))
+                        await self._statustext.add(text, sev)
+            except asyncio.CancelledError:
+                logger.info("AGT STATUSTEXT subscriber cancelled")
+                raise
+            except Exception as e:
+                logger.debug(
+                    "AGT STATUSTEXT WS disconnected (%s); reconnecting in %.1fs",
+                    e, WS_RECONNECT_DELAY_S,
+                )
+                await asyncio.sleep(WS_RECONNECT_DELAY_S)
+
     # ── Iridium test ────────────────────────────────────────────────
 
     async def send_iridium_test(self) -> dict:
         """Send COMMAND_LONG (MAV_CMD_USER_4) to trigger Iridium test.
 
-        Returns {"accepted": bool, "error": str|None}.
+        Returns ``{accepted, error, latest_id}`` where ``latest_id`` is
+        the buffer id at the moment the command was sent so the frontend
+        can poll for messages newer than that.
         """
+        self._ensure_statustext_subscriber()
+        baseline_id = await self._statustext.latest_id()
+
         base = _m2r_base()
         post_url = f"{base}/mavlink"
         payload = {
@@ -178,54 +318,42 @@ class ArtemisTrackerService:
             },
         }
         try:
-            resp = await self.client.post(post_url, json=payload)
+            resp = await self.client.post(
+                post_url, json=payload, timeout=TRIGGER_POST_TIMEOUT_S,
+            )
             resp.raise_for_status()
-            logger.info("Iridium test command sent to AGT")
-            return {"accepted": True, "error": None}
+            logger.info("Iridium test command sent to AGT (baseline_id=%d)", baseline_id)
+            return {"accepted": True, "error": None, "latest_id": baseline_id}
         except Exception as e:
             logger.warning("Failed to send Iridium test command: %s", e)
-            return {"accepted": False, "error": str(e)}
+            return {"accepted": False, "error": str(e), "latest_id": baseline_id}
 
-    async def get_iridium_status(self) -> dict:
-        """Poll STATUSTEXT from the AGT for Iridium test result.
+    async def get_iridium_status(self, since_id: int = 0) -> dict:
+        """Return all AGT STATUSTEXT messages newer than ``since_id``.
 
-        Returns {"text": str|None, "severity": int|None, "counter": int}.
+        Response shape::
+
+            {
+              "messages": [
+                {"id": 7, "text": "IRIDIUM: Test starting", "severity": 6,
+                 "timestamp": "..."},
+                ...
+              ],
+              "latest_id": 7
+            }
         """
-        base = _m2r_base()
-        url = f"{base}/mavlink/vehicles/1/components/{ARTEMIS_COMPONENT_ID}/messages/STATUSTEXT"
-        try:
-            resp = await self.client.get(url)
-            if resp.status_code == 404:
-                return {"text": None, "severity": None, "counter": 0}
-            resp.raise_for_status()
-            data = resp.json()
-            msg = data.get("message", {})
-            if msg.get("type") != "STATUSTEXT":
-                return {"text": None, "severity": None, "counter": 0}
-
-            raw_text = msg.get("text", "")
-            if isinstance(raw_text, list):
-                raw_text = "".join(c for c in raw_text if c != "\x00")
-            text = raw_text.strip()
-
-            severity = msg.get("severity", {})
-            if isinstance(severity, dict):
-                sev_type = severity.get("type", "")
-                sev_map = {
-                    "MAV_SEVERITY_EMERGENCY": 0, "MAV_SEVERITY_ALERT": 1,
-                    "MAV_SEVERITY_CRITICAL": 2, "MAV_SEVERITY_ERROR": 3,
-                    "MAV_SEVERITY_WARNING": 4, "MAV_SEVERITY_NOTICE": 5,
-                    "MAV_SEVERITY_INFO": 6, "MAV_SEVERITY_DEBUG": 7,
-                }
-                severity = sev_map.get(sev_type, 6)
-
-            counter = data.get("status", {}).get("time", {}).get("counter", 0)
-            return {"text": text, "severity": severity, "counter": counter}
-        except Exception as e:
-            logger.debug("Failed to read AGT STATUSTEXT: %s", e)
-            return {"text": None, "severity": None, "counter": 0}
+        self._ensure_statustext_subscriber()
+        messages, latest_id = await self._statustext.since(since_id)
+        return {"messages": messages, "latest_id": latest_id}
 
     async def close(self) -> None:
+        if self._ws_task is not None and not self._ws_task.done():
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._ws_task = None
         if self._client is not None and not self._client.is_closed:
             await self._client.aclose()
             self._client = None

--- a/extension/frontend/src/components/SensorConfiguration.vue
+++ b/extension/frontend/src/components/SensorConfiguration.vue
@@ -235,20 +235,46 @@ type IridiumState = 'idle' | 'sending' | 'running' | 'passed' | 'failed'
 interface IridiumMessage {
   id: number
   text: string
-  severity: number
+  severity: number  // MAV_SEVERITY: 0=EMERGENCY .. 3=ERROR, 4=WARNING, 6=INFO
   timestamp: string
 }
 const iridiumState = ref<IridiumState>('idle')
 const iridiumMessage = ref('')
+const iridiumElapsedMs = ref(0)
+// Transcript of messages observed during the current test (IRIDIUM:* and recent GPS/RTC context).
+// Capped at 50 to avoid unbounded growth on a long test.
+const iridiumTranscript = ref<IridiumMessage[]>([])
+const iridiumDetailsOpen = ref(false)
 let iridiumPollInterval: number | undefined
+let iridiumElapsedTimer: number | undefined
 let iridiumLastSeenId = 0
+let iridiumStartedAt = 0
 let iridiumDeadline = 0
 const IRIDIUM_TEST_MAX_MS = 12 * 60 * 1000  // hard cap; AGT should resolve in <10 min
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+function pushTranscript(m: IridiumMessage) {
+  // Only keep IRIDIUM:* and short context (GPS/RTC) so the panel stays useful.
+  if (!/^(IRIDIUM|GPS|RTC):/i.test(m.text)) return
+  iridiumTranscript.value.push(m)
+  if (iridiumTranscript.value.length > 50) {
+    iridiumTranscript.value.splice(0, iridiumTranscript.value.length - 50)
+  }
+}
 
 async function triggerIridiumTest() {
   if (iridiumState.value === 'sending' || iridiumState.value === 'running') return
   iridiumState.value = 'sending'
   iridiumMessage.value = ''
+  iridiumTranscript.value = []
+  iridiumElapsedMs.value = 0
+  iridiumDetailsOpen.value = false
 
   try {
     const resp = await fetch('/api/v1/tracker/iridium-test', { method: 'POST' })
@@ -260,10 +286,12 @@ async function triggerIridiumTest() {
       return
     }
     iridiumLastSeenId = typeof result.latest_id === 'number' ? result.latest_id : 0
-    iridiumDeadline = Date.now() + IRIDIUM_TEST_MAX_MS
+    iridiumStartedAt = Date.now()
+    iridiumDeadline = iridiumStartedAt + IRIDIUM_TEST_MAX_MS
     iridiumState.value = 'running'
     iridiumMessage.value = 'Test starting — this may take 2–10 minutes…'
     startIridiumPolling()
+    startIridiumElapsedTimer()
   } catch {
     iridiumState.value = 'failed'
     iridiumMessage.value = 'Failed to send command'
@@ -279,11 +307,28 @@ function stopIridiumPolling() {
   if (iridiumPollInterval) { clearInterval(iridiumPollInterval); iridiumPollInterval = undefined }
 }
 
+function startIridiumElapsedTimer() {
+  stopIridiumElapsedTimer()
+  iridiumElapsedTimer = setInterval(() => {
+    if (iridiumStartedAt) iridiumElapsedMs.value = Date.now() - iridiumStartedAt
+  }, 1000) as unknown as number
+}
+
+function stopIridiumElapsedTimer() {
+  if (iridiumElapsedTimer) { clearInterval(iridiumElapsedTimer); iridiumElapsedTimer = undefined }
+}
+
+function finishIridiumTest(state: 'passed' | 'failed', summary: string) {
+  if (iridiumStartedAt) iridiumElapsedMs.value = Date.now() - iridiumStartedAt
+  iridiumState.value = state
+  iridiumMessage.value = summary
+  stopIridiumPolling()
+  stopIridiumElapsedTimer()
+}
+
 async function pollIridiumStatus() {
   if (iridiumDeadline && Date.now() > iridiumDeadline) {
-    iridiumState.value = 'failed'
-    iridiumMessage.value = 'Test timed out (no result after 12 min)'
-    stopIridiumPolling()
+    finishIridiumTest('failed', 'Timed out — no AGT result after 12 min')
     return
   }
   try {
@@ -295,31 +340,56 @@ async function pollIridiumStatus() {
       iridiumLastSeenId = data.latest_id
     }
     for (const m of messages) {
+      pushTranscript(m)
       const text = m.text || ''
-      if (text.includes('IRIDIUM')) {
-        if (text.includes('PASSED')) {
-          iridiumState.value = 'passed'
-          iridiumMessage.value = text
-          stopIridiumPolling()
-          return
-        }
-        if (text.includes('FAILED')) {
-          iridiumState.value = 'failed'
-          iridiumMessage.value = text
-          stopIridiumPolling()
-          return
-        }
-        iridiumMessage.value = text
+      if (!text.startsWith('IRIDIUM')) continue
+      // Treat anything emitted at WARNING (4) or worse as a terminal failure;
+      // only PASSED at INFO (6) is success. Everything else (e.g. "Test
+      // starting") is interim progress.
+      if (text.includes('PASSED')) {
+        finishIridiumTest('passed', text)
+        return
       }
+      if (text.includes('FAILED') || (typeof m.severity === 'number' && m.severity <= 4 && !text.includes('starting'))) {
+        finishIridiumTest('failed', text)
+        return
+      }
+      iridiumMessage.value = text
     }
   } catch { /* best effort */ }
 }
 
 function resetIridiumTest() {
   stopIridiumPolling()
+  stopIridiumElapsedTimer()
   iridiumState.value = 'idle'
   iridiumMessage.value = ''
+  iridiumStartedAt = 0
   iridiumDeadline = 0
+  iridiumElapsedMs.value = 0
+  iridiumTranscript.value = []
+  iridiumDetailsOpen.value = false
+}
+
+function severityLabel(sev: number): string {
+  // MAVLink MAV_SEVERITY enum
+  switch (sev) {
+    case 0: return 'EMERG'
+    case 1: return 'ALERT'
+    case 2: return 'CRIT'
+    case 3: return 'ERROR'
+    case 4: return 'WARN'
+    case 5: return 'NOTICE'
+    case 6: return 'INFO'
+    case 7: return 'DEBUG'
+    default: return `sev${sev}`
+  }
+}
+
+function severityColor(sev: number): string {
+  if (sev <= 3) return '#ef4444'      // ERROR or worse — red
+  if (sev === 4) return '#FCD869'     // WARNING — amber
+  return 'rgba(150, 238, 242, 0.7)'   // info/debug — cyan tint
 }
 
 // ── Light test button ───────────────────────────────────────────────
@@ -829,12 +899,38 @@ const getStatusColor = (moduleStatus: string) => {
                 </svg>
                 <span v-if="iridiumState === 'idle'">Iridium Test</span>
                 <span v-else-if="iridiumState === 'sending'">Sending…</span>
-                <span v-else-if="iridiumState === 'running'">Testing…</span>
-                <span v-else-if="iridiumState === 'passed' || iridiumState === 'failed'">{{ iridiumMessage || 'Done' }} — Tap to reset</span>
+                <span v-else-if="iridiumState === 'running'">Testing… {{ formatElapsed(iridiumElapsedMs) }}</span>
+                <span v-else-if="iridiumState === 'passed' || iridiumState === 'failed'">
+                  {{ iridiumMessage || 'Done' }}
+                  <span v-if="iridiumElapsedMs > 0" style="opacity: 0.7"> ({{ formatElapsed(iridiumElapsedMs) }})</span>
+                  — Tap to reset
+                </span>
               </button>
               <p v-if="iridiumState === 'running' && iridiumMessage" class="mt-1 text-xs text-center" style="color: rgba(252, 216, 105, 0.7)">
                 {{ iridiumMessage }}
               </p>
+              <!-- Expandable transcript: useful for diagnosing why a test failed -->
+              <div v-if="iridiumTranscript.length > 0 && (iridiumState === 'failed' || iridiumState === 'passed' || iridiumState === 'running')" class="mt-2">
+                <button
+                  type="button"
+                  class="text-xs underline transition-opacity hover:opacity-100"
+                  style="color: rgba(150, 238, 242, 0.7); opacity: 0.85"
+                  @click="iridiumDetailsOpen = !iridiumDetailsOpen"
+                >
+                  {{ iridiumDetailsOpen ? 'Hide details' : `Show details (${iridiumTranscript.length} message${iridiumTranscript.length === 1 ? '' : 's'})` }}
+                </button>
+                <div
+                  v-if="iridiumDetailsOpen"
+                  class="mt-1 rounded p-2 text-xs font-mono overflow-y-auto"
+                  style="max-height: 12rem; background-color: rgba(0, 0, 0, 0.25); border: 1px solid rgba(65, 185, 195, 0.2)"
+                >
+                  <div v-for="m in iridiumTranscript" :key="m.id" class="py-0.5">
+                    <span style="color: rgba(150, 238, 242, 0.5)">{{ m.timestamp.substring(11, 19) }}</span>
+                    <span class="ml-2 inline-block w-12 text-center rounded text-[10px]" :style="{ color: severityColor(m.severity), border: `1px solid ${severityColor(m.severity)}40` }">{{ severityLabel(m.severity) }}</span>
+                    <span class="ml-2" :style="{ color: severityColor(m.severity) }">{{ m.text }}</span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/extension/frontend/src/components/SensorConfiguration.vue
+++ b/extension/frontend/src/components/SensorConfiguration.vue
@@ -245,6 +245,25 @@ const iridiumElapsedMs = ref(0)
 // Capped at 50 to avoid unbounded growth on a long test.
 const iridiumTranscript = ref<IridiumMessage[]>([])
 const iridiumDetailsOpen = ref(false)
+const iridiumDetailsEl = ref<HTMLElement | null>(null)
+// Push order can interleave (synthetic "triggered" lands first, then async
+// seed back-fills boot/GPS rows that have OLDER timestamps, then live polls
+// append). Sort by timestamp so the panel always reads chronologically.
+const sortedIridiumTranscript = computed(() => {
+  return [...iridiumTranscript.value].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+})
+// AGT firmware fast-fails an SBD attempt with no GPS fix anyway
+// ("IRIDIUM: Test skipped (no GPS fix)"), so block the test up front
+// and tell the user why.  The AGT also uses 2D fix as the threshold.
+const iridiumGpsBlocked = computed(() => {
+  const fix = trackerGps.value?.fix_type ?? 0
+  return fix < 2
+})
+const iridiumButtonDisabled = computed(() => {
+  return iridiumState.value === 'sending'
+    || iridiumState.value === 'running'
+    || (iridiumState.value === 'idle' && iridiumGpsBlocked.value)
+})
 let iridiumPollInterval: number | undefined
 let iridiumElapsedTimer: number | undefined
 let iridiumLastSeenId = 0
@@ -266,6 +285,11 @@ function pushTranscript(m: IridiumMessage) {
   if (iridiumTranscript.value.length > 50) {
     iridiumTranscript.value.splice(0, iridiumTranscript.value.length - 50)
   }
+  // Defer scroll until Vue rerenders the (sorted) list.
+  nextTick(() => {
+    const el = iridiumDetailsEl.value
+    if (el) el.scrollTop = el.scrollHeight
+  })
 }
 
 async function triggerIridiumTest() {
@@ -290,12 +314,37 @@ async function triggerIridiumTest() {
     iridiumDeadline = iridiumStartedAt + IRIDIUM_TEST_MAX_MS
     iridiumState.value = 'running'
     iridiumMessage.value = 'Test starting — this may take 2–10 minutes…'
+    // Seed the transcript with recent context (boot, GPS lock, RTC sync) so
+    // the user can open the details panel immediately. The AGT typically
+    // goes silent during the SBD attempt itself, so without seeding the
+    // panel would stay empty for ~10 minutes.
+    seedTranscriptFromBuffer().catch(() => { /* best effort */ })
+    // Always show at least a "Test triggered" row so the details panel
+    // never appears empty.
+    iridiumTranscript.value.push({
+      id: 0,
+      text: `IRIDIUM: Test triggered from UI`,
+      severity: 6,
+      timestamp: new Date().toISOString(),
+    })
     startIridiumPolling()
     startIridiumElapsedTimer()
   } catch {
     iridiumState.value = 'failed'
     iridiumMessage.value = 'Failed to send command'
   }
+}
+
+async function seedTranscriptFromBuffer() {
+  // Fetch the last ~10 messages currently in the backend buffer and prepend
+  // any IRIDIUM/GPS/RTC ones to the transcript (without advancing
+  // iridiumLastSeenId — the polling loop still owns that).
+  const resp = await fetch('/api/v1/tracker/iridium-status?since_id=0')
+  if (!resp.ok) return
+  const data = await resp.json()
+  const messages: IridiumMessage[] = Array.isArray(data.messages) ? data.messages : []
+  const recent = messages.slice(-10)
+  for (const m of recent) pushTranscript(m)
 }
 
 function startIridiumPolling() {
@@ -873,23 +922,27 @@ const getStatusColor = (moduleStatus: string) => {
             <!-- Iridium test button -->
             <div v-if="mod.type === 'tracker' && mod.connected" class="mt-3">
               <button
-                :disabled="iridiumState === 'sending' || iridiumState === 'running'"
+                :disabled="iridiumButtonDisabled"
+                :title="iridiumState === 'idle' && iridiumGpsBlocked ? 'Waiting for AGT GPS fix — the test would be skipped' : ''"
                 class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm transition-all"
                 :style="{
                   backgroundColor: iridiumState === 'passed' ? 'rgba(34, 197, 94, 0.2)'
                     : iridiumState === 'failed' ? 'rgba(239, 68, 68, 0.2)'
                     : iridiumState === 'running' || iridiumState === 'sending' ? 'rgba(252, 216, 105, 0.15)'
+                    : iridiumGpsBlocked ? 'rgba(14, 36, 70, 0.3)'
                     : 'rgba(14, 36, 70, 0.5)',
                   border: iridiumState === 'passed' ? '1px solid rgba(34, 197, 94, 0.5)'
                     : iridiumState === 'failed' ? '1px solid rgba(239, 68, 68, 0.5)'
                     : iridiumState === 'running' || iridiumState === 'sending' ? '1px solid rgba(252, 216, 105, 0.4)'
+                    : iridiumGpsBlocked ? '1px solid rgba(150, 238, 242, 0.1)'
                     : '1px solid rgba(65, 185, 195, 0.2)',
                   color: iridiumState === 'passed' ? '#22c55e'
                     : iridiumState === 'failed' ? '#ef4444'
                     : iridiumState === 'running' || iridiumState === 'sending' ? '#FCD869'
+                    : iridiumGpsBlocked ? 'rgba(150, 238, 242, 0.4)'
                     : '#96EEF2',
-                  opacity: iridiumState === 'sending' || iridiumState === 'running' ? '0.85' : '1',
-                  cursor: iridiumState === 'sending' || iridiumState === 'running' ? 'not-allowed' : 'pointer',
+                  opacity: iridiumButtonDisabled ? '0.6' : '1',
+                  cursor: iridiumButtonDisabled ? 'not-allowed' : 'pointer',
                 }"
                 @click="iridiumState === 'passed' || iridiumState === 'failed' ? resetIridiumTest() : triggerIridiumTest()"
               >
@@ -897,7 +950,8 @@ const getStatusColor = (moduleStatus: string) => {
                 <svg v-else class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
                   <path :d="mdiSatelliteUplink" />
                 </svg>
-                <span v-if="iridiumState === 'idle'">Iridium Test</span>
+                <span v-if="iridiumState === 'idle' && iridiumGpsBlocked">Iridium Test — waiting for GPS fix</span>
+                <span v-else-if="iridiumState === 'idle'">Iridium Test</span>
                 <span v-else-if="iridiumState === 'sending'">Sending…</span>
                 <span v-else-if="iridiumState === 'running'">Testing… {{ formatElapsed(iridiumElapsedMs) }}</span>
                 <span v-else-if="iridiumState === 'passed' || iridiumState === 'failed'">
@@ -908,6 +962,9 @@ const getStatusColor = (moduleStatus: string) => {
               </button>
               <p v-if="iridiumState === 'running' && iridiumMessage" class="mt-1 text-xs text-center" style="color: rgba(252, 216, 105, 0.7)">
                 {{ iridiumMessage }}
+              </p>
+              <p v-else-if="iridiumState === 'idle' && iridiumGpsBlocked" class="mt-1 text-xs text-center" style="color: rgba(150, 238, 242, 0.5)">
+                AGT has no GPS fix yet ({{ trackerGps?.fix_type_name || 'No GPS' }}, {{ trackerGps?.satellites ?? 0 }} sats). The AGT firmware would skip the test.
               </p>
               <!-- Expandable transcript: useful for diagnosing why a test failed -->
               <div v-if="iridiumTranscript.length > 0 && (iridiumState === 'failed' || iridiumState === 'passed' || iridiumState === 'running')" class="mt-2">
@@ -921,10 +978,11 @@ const getStatusColor = (moduleStatus: string) => {
                 </button>
                 <div
                   v-if="iridiumDetailsOpen"
+                  ref="iridiumDetailsEl"
                   class="mt-1 rounded p-2 text-xs font-mono overflow-y-auto"
                   style="max-height: 12rem; background-color: rgba(0, 0, 0, 0.25); border: 1px solid rgba(65, 185, 195, 0.2)"
                 >
-                  <div v-for="m in iridiumTranscript" :key="m.id" class="py-0.5">
+                  <div v-for="(m, idx) in sortedIridiumTranscript" :key="`${m.id}-${idx}`" class="py-0.5">
                     <span style="color: rgba(150, 238, 242, 0.5)">{{ m.timestamp.substring(11, 19) }}</span>
                     <span class="ml-2 inline-block w-12 text-center rounded text-[10px]" :style="{ color: severityColor(m.severity), border: `1px solid ${severityColor(m.severity)}40` }">{{ severityLabel(m.severity) }}</span>
                     <span class="ml-2" :style="{ color: severityColor(m.severity) }">{{ m.text }}</span>

--- a/extension/frontend/src/components/SensorConfiguration.vue
+++ b/extension/frontend/src/components/SensorConfiguration.vue
@@ -223,22 +223,32 @@ function startTrackerPolling() {
 watch(hasTracker, startTrackerPolling)
 
 // ── Iridium test ─────────────────────────────────────────────────────
+//
+// The AGT runs the SBD test for 2-10 minutes and emits a handful of
+// `IRIDIUM: …` STATUSTEXT messages along the way (`Test starting`,
+// `Test PASSED`, `Test FAILED`, occasional progress).  In between it
+// keeps spamming `GPS: …` warnings, and mavlink2rest only caches the
+// latest STATUSTEXT.  We therefore poll the backend with `since_id`
+// and walk every new buffered AGT message — that way the PASSED/FAILED
+// can never be overwritten before we see it.
 type IridiumState = 'idle' | 'sending' | 'running' | 'passed' | 'failed'
+interface IridiumMessage {
+  id: number
+  text: string
+  severity: number
+  timestamp: string
+}
 const iridiumState = ref<IridiumState>('idle')
 const iridiumMessage = ref('')
 let iridiumPollInterval: number | undefined
-let iridiumBaselineCounter = -1
+let iridiumLastSeenId = 0
+let iridiumDeadline = 0
+const IRIDIUM_TEST_MAX_MS = 12 * 60 * 1000  // hard cap; AGT should resolve in <10 min
 
 async function triggerIridiumTest() {
   if (iridiumState.value === 'sending' || iridiumState.value === 'running') return
   iridiumState.value = 'sending'
   iridiumMessage.value = ''
-
-  const baseline = await fetch('/api/v1/tracker/iridium-status')
-  if (baseline.ok) {
-    const data = await baseline.json()
-    iridiumBaselineCounter = data.counter ?? 0
-  }
 
   try {
     const resp = await fetch('/api/v1/tracker/iridium-test', { method: 'POST' })
@@ -249,6 +259,8 @@ async function triggerIridiumTest() {
       iridiumMessage.value = result.error || 'Command rejected'
       return
     }
+    iridiumLastSeenId = typeof result.latest_id === 'number' ? result.latest_id : 0
+    iridiumDeadline = Date.now() + IRIDIUM_TEST_MAX_MS
     iridiumState.value = 'running'
     iridiumMessage.value = 'Test starting — this may take 2–10 minutes…'
     startIridiumPolling()
@@ -268,23 +280,37 @@ function stopIridiumPolling() {
 }
 
 async function pollIridiumStatus() {
+  if (iridiumDeadline && Date.now() > iridiumDeadline) {
+    iridiumState.value = 'failed'
+    iridiumMessage.value = 'Test timed out (no result after 12 min)'
+    stopIridiumPolling()
+    return
+  }
   try {
-    const resp = await fetch('/api/v1/tracker/iridium-status')
+    const resp = await fetch(`/api/v1/tracker/iridium-status?since_id=${iridiumLastSeenId}`)
     if (!resp.ok) return
     const data = await resp.json()
-    if (!data.text || data.counter <= iridiumBaselineCounter) return
-
-    const text: string = data.text
-    if (text.includes('PASSED')) {
-      iridiumState.value = 'passed'
-      iridiumMessage.value = text
-      stopIridiumPolling()
-    } else if (text.includes('FAILED')) {
-      iridiumState.value = 'failed'
-      iridiumMessage.value = text
-      stopIridiumPolling()
-    } else if (text.includes('IRIDIUM')) {
-      iridiumMessage.value = text
+    const messages: IridiumMessage[] = Array.isArray(data.messages) ? data.messages : []
+    if (typeof data.latest_id === 'number' && data.latest_id > iridiumLastSeenId) {
+      iridiumLastSeenId = data.latest_id
+    }
+    for (const m of messages) {
+      const text = m.text || ''
+      if (text.includes('IRIDIUM')) {
+        if (text.includes('PASSED')) {
+          iridiumState.value = 'passed'
+          iridiumMessage.value = text
+          stopIridiumPolling()
+          return
+        }
+        if (text.includes('FAILED')) {
+          iridiumState.value = 'failed'
+          iridiumMessage.value = text
+          stopIridiumPolling()
+          return
+        }
+        iridiumMessage.value = text
+      }
     }
   } catch { /* best effort */ }
 }
@@ -293,6 +319,7 @@ function resetIridiumTest() {
   stopIridiumPolling()
   iridiumState.value = 'idle'
   iridiumMessage.value = ''
+  iridiumDeadline = 0
 }
 
 // ── Light test button ───────────────────────────────────────────────

--- a/scripts/agt_state_dump.py
+++ b/scripts/agt_state_dump.py
@@ -1,0 +1,42 @@
+"""Dump everything mavlink2rest knows about the AGT (component 191).
+
+Useful for diagnosing a stuck or silent Iridium test: shows the most
+recent message of every type the AGT has emitted plus the COMMAND_ACK
+the AGT sent for the test command.
+"""
+import json
+import sys
+import urllib.request
+
+BASE = "http://blueos-wifi.local:6040"
+
+
+def get(path):
+    with urllib.request.urlopen(f"{BASE}{path}", timeout=10) as r:
+        return json.loads(r.read())
+
+
+def main():
+    data = get("/mavlink/vehicles/1/components/191")
+    msgs = data.get("messages", {})
+    print(f"AGT (component 191) — {len(msgs)} message types cached\n")
+    for name in sorted(msgs):
+        entry = msgs[name]
+        status = entry.get("status", {}).get("time", {})
+        msg = entry.get("message", {})
+        line = f"  {name:<14} counter={status.get('counter', 0):<6} freq={status.get('frequency') or '-':<10} last={status.get('last_update', '?')}"
+        print(line)
+        if name == "STATUSTEXT":
+            text = msg.get("text", "")
+            if isinstance(text, list):
+                text = "".join(c for c in text if c != "\x00")
+            print(f"     text: {text!r}")
+            print(f"     severity: {msg.get('severity')}")
+        if name == "COMMAND_ACK":
+            print(f"     command: {msg.get('command')}")
+            print(f"     result: {msg.get('result')}")
+            print(f"     progress: {msg.get('progress')}")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/scripts/check_doris_state.ps1
+++ b/scripts/check_doris_state.ps1
@@ -1,0 +1,49 @@
+$base = "http://192.168.68.75:6040"
+
+# Read DORIS_STATE param via PARAM_REQUEST_READ + cached PARAM_VALUE
+function Read-Param {
+  param([string]$Name)
+  $body = @{
+    header  = @{ system_id = 255; component_id = 0; sequence = 0 }
+    message = @{
+      type            = "PARAM_REQUEST_READ"
+      target_system   = 1
+      target_component = 1
+      param_id        = ([char[]]$Name.PadRight(16, [char]0))
+      param_index     = -1
+    }
+  } | ConvertTo-Json -Depth 10 -Compress
+  curl.exe -s --max-time 5 -X POST -H "Content-Type: application/json" --data $body "$base/mavlink" | Out-Null
+  Start-Sleep -Milliseconds 600
+  $resp = curl.exe -s --max-time 5 "$base/mavlink/vehicles/1/components/1/messages/PARAM_VALUE"
+  try {
+    $j = $resp | ConvertFrom-Json
+    $id = -join ($j.message.param_id | Where-Object { $_ -ne "`0" })
+    Write-Host ("  {0,-18} = {1}  (cache id={2})" -f $Name, $j.message.param_value, $id)
+  } catch { Write-Host "  $Name read failed: $resp" }
+}
+
+# Latest NAMED_VALUE_FLOAT from autopilot lua
+Write-Host "=== Latest NAMED_VALUE_FLOAT ==="
+$resp = curl.exe -s --max-time 5 "$base/mavlink/vehicles/1/components/1/messages/NAMED_VALUE_FLOAT"
+try {
+  $j = $resp | ConvertFrom-Json
+  $name = -join ($j.message.name | Where-Object { $_ -ne "`0" })
+  Write-Host "  name=$name value=$($j.message.value) freq=$($j.status.time.frequency) Hz last=$($j.status.time.last_update)"
+} catch { Write-Host "  parse failed: $resp" }
+
+Write-Host ""
+Write-Host "=== DORIS params (read-back) ==="
+Read-Param "DORIS_STATE"
+Read-Param "DORIS_START"
+Read-Param "DORIS_PRF_ID"
+Read-Param "DORIS_INJ_LEAK"
+Read-Param "SCR_ENABLE"
+
+Write-Host ""
+Write-Host "=== Autopilot HEARTBEAT ==="
+$resp = curl.exe -s --max-time 5 "$base/mavlink/vehicles/1/components/1/messages/HEARTBEAT"
+try {
+  $j = $resp | ConvertFrom-Json
+  Write-Host "  base_mode bits=$($j.message.base_mode.bits) status=$($j.message.system_status.type) last=$($j.status.time.last_update)"
+} catch { Write-Host "  parse failed: $resp" }

--- a/scripts/check_iridium_deploy.py
+++ b/scripts/check_iridium_deploy.py
@@ -1,0 +1,105 @@
+"""Quick diagnostic: peek inside the running DORIS container to compare
+deployed iridium-test code against the workspace source.
+"""
+import io
+import json
+import sys
+import tarfile
+import urllib.parse
+import urllib.request
+
+DOCKER_API = "http://blueos-wifi.local:2375"
+
+
+def http(method, path, body=None, headers=None, timeout=10):
+    url = f"{DOCKER_API}{path}"
+    data = body.encode() if isinstance(body, str) else body
+    req = urllib.request.Request(url, data=data, method=method)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def find_doris():
+    raw = http("GET", "/containers/json")
+    for c in json.loads(raw):
+        if any("doris" in n.lower() for n in c.get("Names", [])):
+            return c["Id"][:12]
+    raise SystemExit("DORIS container not found")
+
+
+def exec_cmd(cid, cmd):
+    payload = json.dumps({
+        "Cmd": ["sh", "-c", cmd],
+        "AttachStdout": True,
+        "AttachStderr": True,
+    })
+    res = http(
+        "POST", f"/containers/{cid}/exec", payload,
+        headers={"Content-Type": "application/json"},
+    )
+    eid = json.loads(res)["Id"]
+    out = http(
+        "POST", f"/exec/{eid}/start", json.dumps({"Detach": False, "Tty": False}),
+        headers={"Content-Type": "application/json"}, timeout=20,
+    )
+    return strip_docker_stream(out).decode("utf-8", errors="replace")
+
+
+def strip_docker_stream(buf: bytes) -> bytes:
+    """Docker exec start returns multiplexed frames: 8-byte header + payload."""
+    out = bytearray()
+    i = 0
+    while i + 8 <= len(buf):
+        size = int.from_bytes(buf[i + 4:i + 8], "big")
+        i += 8
+        out.extend(buf[i:i + size])
+        i += size
+    return bytes(out)
+
+
+def get_file(cid, path):
+    q = urllib.parse.urlencode({"path": path})
+    raw = http("GET", f"/containers/{cid}/archive?{q}")
+    with tarfile.open(fileobj=io.BytesIO(raw)) as t:
+        m = t.next()
+        return t.extractfile(m).read().decode("utf-8", errors="replace")
+
+
+def main():
+    cid = find_doris()
+    print(f"[DORIS] container={cid}")
+
+    print("\n[1] Listing /app/frontend/dist/assets …")
+    print(exec_cmd(cid, "ls -la /app/frontend/dist/assets 2>&1 | head -30"))
+
+    print("\n[2] Search deployed JS bundles for 'iridium-test' references")
+    print(exec_cmd(
+        cid,
+        "grep -l -i 'iridium' /app/frontend/dist/assets/*.js 2>&1 || echo 'no matches'",
+    ))
+
+    print("\n[3] Snippet of deployed tracker.py (send_iridium_test)")
+    try:
+        src = get_file(cid, "/app/src/doris/services/tracker.py")
+        for line in src.splitlines():
+            if "iridium" in line.lower() or "MAV_CMD_USER_4" in line:
+                print(f"  {line}")
+    except Exception as e:
+        print(f"  (failed to read: {e})")
+
+    print("\n[4] Recent doris logs mentioning iridium")
+    raw = http(
+        "GET",
+        f"/containers/{cid}/logs?stdout=true&stderr=true&tail=400",
+        timeout=10,
+    )
+    body = strip_docker_stream(raw).decode("utf-8", errors="replace")
+    for line in body.splitlines():
+        if "iridium" in line.lower() or "tracker" in line.lower():
+            print(f"  {line}")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/scripts/force_recovery.py
+++ b/scripts/force_recovery.py
@@ -1,0 +1,85 @@
+"""Push DORIS into RECOVERY to see if the AGT firmware reacts.
+
+We do two things in sequence so we can tell which signal (if any) the AGT
+is actually subscribing to:
+
+  1) PARAM_SET DORIS_STATE = 4
+  2) NAMED_VALUE_FLOAT('STATE', 4.0)
+
+The lua script writes DORIS_STATE every 500 ms based on its own internal
+state variable, so step 1 will be overwritten quickly — but it'll
+broadcast a PARAM_VALUE to listeners (including the AGT) before that
+happens.  Step 2 mimics exactly what the lua broadcasts when it
+naturally enters RECOVERY.
+"""
+import json
+import sys
+import urllib.request
+
+M2R = "http://192.168.68.75:6040/mavlink"
+
+
+def post(payload):
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(M2R, data=data, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=15) as r:
+        body = r.read().decode("utf-8", errors="replace")
+        print(f"  -> {r.status} {body or '(no body)'}")
+
+
+def param_set_doris_state(value: float):
+    name = "DORIS_STATE"
+    payload = {
+        "header": {"system_id": 255, "component_id": 0, "sequence": 0},
+        "message": {
+            "type": "PARAM_SET",
+            "target_system": 1,
+            "target_component": 1,  # autopilot owns the param table
+            "param_id": list(name.ljust(16, "\x00")),
+            "param_value": float(value),
+            "param_type": {"type": "MAV_PARAM_TYPE_REAL32"},
+        },
+    }
+    print(f"PARAM_SET {name}={value}")
+    post(payload)
+
+
+def named_value_float_state(value: float):
+    """Broadcast NAMED_VALUE_FLOAT('STATE', value) as if from the autopilot's
+    lua scripting (system_id=1, component_id=1)."""
+    name = "STATE"
+    payload = {
+        "header": {"system_id": 1, "component_id": 1, "sequence": 0},
+        "message": {
+            "type": "NAMED_VALUE_FLOAT",
+            "time_boot_ms": 0,
+            "name": list(name.ljust(10, "\x00")),
+            "value": float(value),
+        },
+    }
+    print(f"NAMED_VALUE_FLOAT name='{name}' value={value}")
+    post(payload)
+
+
+def main():
+    state = 4  # STATE_RECOVERY in doris.lua
+
+    print(">> step 1: PARAM_SET DORIS_STATE = 4")
+    try:
+        param_set_doris_state(state)
+    except Exception as e:
+        print(f"  PARAM_SET failed: {e}")
+
+    print()
+    print(">> step 2: NAMED_VALUE_FLOAT('STATE', 4) — what the lua broadcasts")
+    try:
+        named_value_float_state(state)
+    except Exception as e:
+        print(f"  NAMED_VALUE_FLOAT failed: {e}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hotdeploy_frontend.py
+++ b/scripts/hotdeploy_frontend.py
@@ -1,0 +1,97 @@
+"""Hot-deploy the built Vite frontend into the running DORIS container.
+
+Tars up extension/frontend/dist/ and PUTs it over /app/frontend/dist/
+in the container, then restarts the container so any cached assets
+get re-served.
+"""
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.parse
+from pathlib import Path
+
+DOCKER_API = "http://192.168.68.75:2375"
+REPO = Path(__file__).resolve().parents[1]
+DIST_DIR = REPO / "extension/frontend/dist"
+TARGET_PATH = "/app/frontend"  # tar contains "dist/..." so it lands at /app/frontend/dist/
+
+
+def curl(args, timeout=60):
+    p = subprocess.run(
+        ["curl.exe", "-sS", "--max-time", str(timeout), *args],
+        capture_output=True,
+    )
+    return p.returncode, p.stdout, p.stderr.decode("utf-8", "replace")
+
+
+def find_doris():
+    rc, body, err = curl(["-X", "GET", f"{DOCKER_API}/containers/json"])
+    if rc != 0:
+        raise SystemExit(f"docker ps failed: {err}")
+    for c in json.loads(body):
+        if any("doris" in n.lower() for n in c.get("Names", [])):
+            return c["Id"][:12], c["Names"], c["Image"]
+    raise SystemExit("DORIS container not found")
+
+
+def make_dist_tar() -> bytes:
+    """Tar the dist directory with a top-level 'dist/' so when extracted
+    into /app/frontend/ it lands as /app/frontend/dist/."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(str(DIST_DIR), arcname="dist", recursive=True)
+    return buf.getvalue()
+
+
+def main():
+    if not DIST_DIR.is_dir():
+        raise SystemExit(f"dist not found at {DIST_DIR} — run npm run build first")
+
+    # Default: skip container restart (static dist files don't need it; the
+    # browser just needs a hard-refresh).  Pass --restart to also bounce the
+    # container, which is necessary if you also changed Python backend code.
+    restart = "--restart" in sys.argv
+
+    cid, names, image = find_doris()
+    print(f"[hotdeploy] DORIS container={cid} names={names} image={image}")
+
+    tar_bytes = make_dist_tar()
+    print(f"[hotdeploy] tar size: {len(tar_bytes) / 1024:.1f} KB")
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".tar") as tmp:
+        tmp.write(tar_bytes)
+        tmp_path = tmp.name
+    try:
+        url = f"{DOCKER_API}/containers/{cid}/archive?path={urllib.parse.quote(TARGET_PATH)}"
+        print(f"[hotdeploy] PUT -> {url}")
+        rc, body, err = curl(
+            [
+                "-X", "PUT",
+                "-H", "Content-Type: application/x-tar",
+                "--data-binary", f"@{tmp_path}",
+                url,
+            ],
+            timeout=120,
+        )
+        if rc != 0:
+            raise SystemExit(f"upload failed rc={rc} err={err}")
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if restart:
+        print(f"[hotdeploy] restarting container {cid} ...")
+        rc, body, err = curl(["-X", "POST", f"{DOCKER_API}/containers/{cid}/restart?t=5"], timeout=30)
+        if rc != 0:
+            print(f"[hotdeploy] restart failed: rc={rc} err={err}")
+            return 1
+        print("[hotdeploy] done. Hard-refresh the page (Ctrl+Shift+R).")
+    else:
+        print("[hotdeploy] done (no restart). Hard-refresh the page (Ctrl+Shift+R).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hotdeploy_tracker.py
+++ b/scripts/hotdeploy_tracker.py
@@ -1,0 +1,91 @@
+"""Hot-deploy the updated tracker.py + sensors.py route to the running
+DORIS extension container and restart it.
+
+Mirrors the workflow described in `.cursor/rules/doris-hardware-ops.mdc`:
+build a tar archive in memory, PUT it to the container's /app path, then
+POST a /restart.
+"""
+import io
+import json
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+DOCKER_API = "http://192.168.68.75:2375"  # blueos-wifi.local; mDNS sometimes fails on Windows
+REPO = Path(__file__).resolve().parents[1]
+
+UPLOADS = [
+    (REPO / "extension/backend/src/doris/services/tracker.py", "/app/src/doris/services"),
+    (REPO / "extension/backend/src/doris/routes/sensors.py", "/app/src/doris/routes"),
+]
+
+
+def http(method, path, body=None, headers=None, timeout=30):
+    url = f"{DOCKER_API}{path}"
+    data = body if isinstance(body, bytes) else (body.encode() if body else None)
+    req = urllib.request.Request(url, data=data, method=method)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def find_doris():
+    raw = http("GET", "/containers/json")
+    for c in json.loads(raw):
+        if any("doris" in n.lower() for n in c.get("Names", [])):
+            return c["Id"][:12], c["Names"]
+    raise SystemExit("DORIS container not found")
+
+
+def make_tar(files: list[tuple[str, bytes]]) -> bytes:
+    """files = list of (basename, content_bytes)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = 0o644
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def upload(cid: str, dest_path: str, files: list[tuple[str, bytes]]):
+    tar = make_tar(files)
+    http(
+        "PUT",
+        f"/containers/{cid}/archive?path={urllib.parse.quote(dest_path)}",
+        body=tar,
+        headers={"Content-Type": "application/x-tar"},
+        timeout=30,
+    )
+
+
+def main():
+    import urllib.parse  # noqa: F401  (used inside upload via globals)
+
+    cid, names = find_doris()
+    print(f"[hotdeploy] DORIS container={cid} names={names}")
+
+    # Group by destination path so we PUT each archive once
+    by_dest: dict[str, list[tuple[str, bytes]]] = {}
+    for src, dest in UPLOADS:
+        if not src.is_file():
+            print(f"[hotdeploy]   missing source: {src}")
+            return 1
+        by_dest.setdefault(dest, []).append((src.name, src.read_bytes()))
+        print(f"[hotdeploy]   queued {src} -> {dest}/{src.name}")
+
+    for dest, files in by_dest.items():
+        print(f"[hotdeploy] uploading {len(files)} file(s) to {dest}")
+        upload(cid, dest, files)
+
+    print(f"[hotdeploy] restarting container {cid} …")
+    http("POST", f"/containers/{cid}/restart?t=5", timeout=30)
+    print("[hotdeploy] done.")
+
+
+if __name__ == "__main__":
+    import urllib.parse  # used by upload()
+    sys.exit(main() or 0)

--- a/scripts/hotdeploy_tracker_curl.py
+++ b/scripts/hotdeploy_tracker_curl.py
@@ -1,0 +1,102 @@
+"""Hot-deploy tracker.py + sensors.py route via curl.exe.
+
+urllib was hitting ConnectionResetError on the larger PUT body; curl.exe
+handles it cleanly and is what we use everywhere else for vehicle ops.
+"""
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.parse
+from pathlib import Path
+
+DOCKER_API = "http://192.168.68.75:2375"
+REPO = Path(__file__).resolve().parents[1]
+
+UPLOADS = [
+    (REPO / "extension/backend/src/doris/services/tracker.py", "/app/src/doris/services"),
+    (REPO / "extension/backend/src/doris/routes/sensors.py", "/app/src/doris/routes"),
+]
+
+
+def curl(args, timeout=30):
+    """Run curl.exe and return (rc, stdout_bytes, stderr_str)."""
+    p = subprocess.run(
+        ["curl.exe", "-sS", "--max-time", str(timeout), *args],
+        capture_output=True,
+    )
+    return p.returncode, p.stdout, p.stderr.decode("utf-8", "replace")
+
+
+def find_doris():
+    rc, body, err = curl(["-X", "GET", f"{DOCKER_API}/containers/json"])
+    if rc != 0:
+        raise SystemExit(f"docker ps failed: {err}")
+    for c in json.loads(body):
+        if any("doris" in n.lower() for n in c.get("Names", [])):
+            return c["Id"][:12], c["Names"], c["Image"]
+    raise SystemExit("DORIS container not found")
+
+
+def make_tar(files):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = 0o644
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def upload(cid, dest_path, files):
+    tar = make_tar(files)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".tar") as tmp:
+        tmp.write(tar)
+        tmp_path = tmp.name
+    try:
+        url = f"{DOCKER_API}/containers/{cid}/archive?path={urllib.parse.quote(dest_path)}"
+        rc, body, err = curl(
+            [
+                "-X", "PUT",
+                "-H", "Content-Type: application/x-tar",
+                "--data-binary", f"@{tmp_path}",
+                url,
+            ],
+            timeout=60,
+        )
+        if rc != 0:
+            raise SystemExit(f"upload failed: rc={rc} err={err}")
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def main():
+    cid, names, image = find_doris()
+    print(f"[hotdeploy] DORIS container={cid} names={names} image={image}")
+
+    by_dest = {}
+    for src, dest in UPLOADS:
+        if not src.is_file():
+            print(f"[hotdeploy]   missing source: {src}")
+            return 1
+        by_dest.setdefault(dest, []).append((src.name, src.read_bytes()))
+        print(f"[hotdeploy]   queued {src.name} -> {dest}/{src.name} ({src.stat().st_size} bytes)")
+
+    for dest, files in by_dest.items():
+        print(f"[hotdeploy] uploading {len(files)} file(s) to {dest}")
+        upload(cid, dest, files)
+
+    print(f"[hotdeploy] restarting container {cid} ...")
+    rc, body, err = curl(["-X", "POST", f"{DOCKER_API}/containers/{cid}/restart?t=5"], timeout=30)
+    if rc != 0:
+        print(f"[hotdeploy] restart failed: rc={rc} err={err}")
+        return 1
+    print("[hotdeploy] done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/peek_statustext_ws.py
+++ b/scripts/peek_statustext_ws.py
@@ -1,0 +1,33 @@
+"""Sniff mavlink2rest WebSocket STATUSTEXT frames so we know the schema
+the new tracker service needs to parse.
+"""
+import asyncio
+import json
+import sys
+
+import websockets
+
+URL = "ws://blueos-wifi.local:6040/ws/mavlink?filter=STATUSTEXT"
+
+
+async def main():
+    async with websockets.connect(URL, close_timeout=5) as ws:
+        seen = 0
+        try:
+            async with asyncio.timeout(60):
+                while True:
+                    raw = await ws.recv()
+                    seen += 1
+                    print(f"--- frame {seen} ---")
+                    try:
+                        print(json.dumps(json.loads(raw), indent=2))
+                    except Exception:
+                        print(repr(raw))
+                    if seen >= 3:
+                        break
+        except TimeoutError:
+            print(f"timeout, saw {seen} frames")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/watch_iridium.ps1
+++ b/scripts/watch_iridium.ps1
@@ -1,10 +1,11 @@
-param([int]$MaxMin = 14)
+param([int]$MaxMin = 14, [int]$SinceId = -1)
 
 $base = "http://192.168.68.75:8095"
 $since = 0
 
-# Show what's currently buffered
-$resp = curl.exe -s --max-time 8 "$base/api/v1/tracker/iridium-status?since_id=0"
+# Show what's currently buffered (if no SinceId provided, dump everything)
+$dumpFrom = if ($SinceId -ge 0) { $SinceId } else { 0 }
+$resp = curl.exe -s --max-time 8 "$base/api/v1/tracker/iridium-status?since_id=$dumpFrom"
 $data = $resp | ConvertFrom-Json
 foreach ($m in $data.messages) {
   $ts = $m.timestamp.Substring(11, 8)

--- a/scripts/watch_iridium.ps1
+++ b/scripts/watch_iridium.ps1
@@ -1,0 +1,33 @@
+param([int]$MaxMin = 14)
+
+$base = "http://192.168.68.75:8095"
+$since = 0
+
+# Show what's currently buffered
+$resp = curl.exe -s --max-time 8 "$base/api/v1/tracker/iridium-status?since_id=0"
+$data = $resp | ConvertFrom-Json
+foreach ($m in $data.messages) {
+  $ts = $m.timestamp.Substring(11, 8)
+  Write-Host ("  [{0}] id={1,-3} sev={2} text={3}" -f $ts, $m.id, $m.severity, $m.text)
+}
+$since = $data.latest_id
+Write-Host "-- tailing since id=$since (max ${MaxMin} min) --"
+
+$deadline = (Get-Date).AddMinutes($MaxMin)
+while ((Get-Date) -lt $deadline) {
+  Start-Sleep -Seconds 3
+  $resp = curl.exe -s --max-time 8 "$base/api/v1/tracker/iridium-status?since_id=$since"
+  if (-not $resp) { continue }
+  try { $data = $resp | ConvertFrom-Json } catch { Write-Host "parse error: $resp"; continue }
+  foreach ($m in $data.messages) {
+    $ts = $m.timestamp.Substring(11, 8)
+    Write-Host ("  [{0}] id={1,-3} sev={2} text={3}" -f $ts, $m.id, $m.severity, $m.text)
+    if ($m.text -like "*IRIDIUM*" -and ($m.text -like "*PASSED*" -or $m.text -like "*FAILED*")) {
+      Write-Host "`nresult: $($m.text)"
+      exit 0
+    }
+  }
+  if ($data.messages.Count -gt 0) { $since = $data.latest_id }
+}
+Write-Host "timeout (no PASSED/FAILED)"
+exit 1

--- a/scripts/watch_iridium.py
+++ b/scripts/watch_iridium.py
@@ -1,0 +1,66 @@
+"""Stream STATUSTEXT messages from the new buffered backend until
+PASSED/FAILED or timeout.  Set TRIGGER=1 env to also trigger a fresh
+test before polling.
+"""
+import json
+import os
+import sys
+import time
+import urllib.request
+
+BASE = "http://192.168.68.75:8095"
+
+
+def get(path, timeout=15):
+    with urllib.request.urlopen(f"{BASE}{path}", timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def post(path, timeout=30):
+    req = urllib.request.Request(f"{BASE}{path}", method="POST", data=b"")
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def main():
+    if os.environ.get("TRIGGER") == "1":
+        print("triggering iridium test …")
+        res = post("/api/v1/tracker/iridium-test")
+        print(f"trigger response: {res}")
+        if not res.get("accepted"):
+            return 1
+        since = res.get("latest_id", 0)
+    else:
+        s0 = get("/api/v1/tracker/iridium-status?since_id=0")
+        # Show what's already buffered, then start tailing from the latest id
+        for m in s0.get("messages", []):
+            ts = m.get("timestamp", "")[11:19]
+            print(f"  [{ts}] id={m['id']:<3} sev={m['severity']} text={m['text']!r}")
+        since = s0.get("latest_id", 0)
+        print(f"-- tailing since id={since} --")
+
+    deadline = time.time() + 60 * 14
+    while time.time() < deadline:
+        try:
+            s = get(f"/api/v1/tracker/iridium-status?since_id={since}")
+        except Exception as e:
+            print(f"  poll error: {e}")
+            time.sleep(3)
+            continue
+        msgs = s.get("messages", [])
+        for m in msgs:
+            ts = m.get("timestamp", "")[11:19]
+            print(f"  [{ts}] id={m['id']:<3} sev={m['severity']} text={m['text']!r}")
+            t = m.get("text", "")
+            if "IRIDIUM" in t and ("PASSED" in t or "FAILED" in t):
+                print(f"\nresult: {t!r}")
+                return 0
+        if msgs:
+            since = s.get("latest_id", since)
+        time.sleep(3)
+    print("timeout (no PASSED/FAILED in 14 min)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fix the Iridium test button on the Sensors page. Previously the test would either spin "Testing…" forever or stay stuck after the AGT replied, depending on which other STATUSTEXT happened to land in `mavlink2rest`'s single-message cache between polls. After this PR the test resolves cleanly to PASSED/FAILED/skipped with rich diagnostic context, and the button is gated on the AGT actually having a GPS fix.

Validated end-to-end on the physical AGT (cold boot → GPS lock → trigger → PASSED at 27s; also exercised the firmware's new `Test skipped (no GPS fix)` fast-fail path).

## Changes

**Backend (`tracker.py`, `sensors.py`)**
- `ArtemisTrackerService` now lazily starts a background WebSocket subscriber to `/ws/mavlink?filter=STATUSTEXT`, filters by AGT `component_id` (191), and buffers the last 100 messages with monotonic ids.
- `GET /api/v1/tracker/iridium-status?since_id=N` returns `{messages, latest_id}` so the frontend never loses a STATUSTEXT, even when the AGT emits dozens of `GPS:` warnings between polls.
- `POST /api/v1/tracker/iridium-test` returns `latest_id` as a baseline and uses a 15s POST timeout (mavlink2rest commonly takes 4–5s to inject `COMMAND_LONG`).

**Frontend (`SensorConfiguration.vue`)**
- Severity-aware terminal detection: any `IRIDIUM:` STATUSTEXT at WARNING (4) or worse — except the `Test starting` progress message — terminates the test as failed. Catches the new firmware's `IRIDIUM: Test skipped (no GPS fix)` message which the previous PASSED/FAILED-only check missed (would have hung the button until the 12 min hard timeout).
- Elapsed-time counter: button shows `Testing… 4:06` while running and `FAILED (10:16)` / `PASSED (0:27)` on completion.
- Expandable transcript panel (`Show details`): renders every `IRIDIUM:` / `GPS:` / `RTC:` STATUSTEXT observed during the test, color-coded by `MAV_SEVERITY` (red ≤ ERROR, amber = WARNING, cyan = INFO). Pre-seeds with the last ~10 buffered messages so the panel has context immediately, plus a synthetic `Test triggered from UI` row so it's never empty.
- Transcript sorted by timestamp at render time: synthetic + async seed + live polls are pushed in arbitrary order; sorting by timestamp keeps the panel chronological. Auto-scrolls to bottom on new messages.
- Button greyed out when the AGT has no GPS fix (`fix_type < 2`), with subtitle showing the current state. Threshold matches the AGT firmware so the button only opens when the test would actually be accepted.

**Diagnostic scripts (`scripts/`)**
- `agt_state_dump.py`, `peek_statustext_ws.py`, `watch_iridium.{py,ps1}`, `check_iridium_deploy.py`, `check_doris_state.ps1`, `force_recovery.py` — used to investigate AGT/iridium behavior; useful for future regressions.
- `hotdeploy_tracker.py` / `hotdeploy_tracker_curl.py` — push backend `tracker.py` + `sensors.py` to the running container without a CI cycle (curl variant works around `urllib` `WinError 10054` on Windows for large PUTs).
- `hotdeploy_frontend.py` — tar `extension/frontend/dist/` and PUT it over `/app/frontend/dist/` in the running container. `--restart` optional (default no, since static files don't need a container bounce).

## Validation

| Scenario | Result |
|---|---|
| Backend `iridium-status` returns `{messages, latest_id}` post-deploy | ✓ |
| AGT `STATUSTEXT` captured into buffer via WebSocket | ✓ id=1..N grew across multiple AGT messages |
| `IRIDIUM: Test PASSED` detected and shown as terminal-passed | ✓ at id=9 (T+27s, sev=6) |
| `IRIDIUM: Test FAILED` detected and shown as terminal-failed | ✓ at id=7 (T+10:16, sev=3, indoor SBD timeout) |
| `IRIDIUM: Test skipped (no GPS fix)` detected and shown as terminal-failed | ✓ at id=44 (T+0:01, sev=4, fast-fail) |
| Button disabled when AGT has no GPS fix | ✓ re-enables on fix ≥ 2D |
| Transcript renders chronologically regardless of push order | ✓ synthetic stays at chronological end |

## Open follow-ups (out of scope, noted for context)

- AGT enters a `GPS: PVT watchdog reinit` loop after every successful Iridium TX (~6s cadence) which eventually triggers a cold reboot. Iridium TX is destabilizing the GPS subsystem at the firmware level.
- AGT coin-cell BBR appears unreliable — `Coin cell DEPLETED` is the typical post-reboot reading, so every reboot is effectively a true cold start (slow TTFF).

Both are AGT firmware/hardware issues, not in this PR's scope.

Made-with: Cursor
