### PR TITLE
fix(iridium-test): wait for STATUSTEXT WS to connect before sending first command

### DIFF
--- a/extension/backend/src/doris/services/tracker.py
+++ b/extension/backend/src/doris/services/tracker.py
@@ -55,6 +55,7 @@ SEVERITY_MAP: dict[str, int] = {
 
 STATUSTEXT_BUFFER_SIZE = 100
 WS_RECONNECT_DELAY_S = 2.0
+WS_FIRST_CONNECT_TIMEOUT_S = 5.0  # max wait before sending first MAV_CMD_USER_4
 TRIGGER_POST_TIMEOUT_S = 15.0  # mavlink2rest POST commonly takes 4-5s
 
 
@@ -118,6 +119,12 @@ class ArtemisTrackerService:
         self._client: httpx.AsyncClient | None = None
         self._statustext = _StatusTextBuffer()
         self._ws_task: asyncio.Task | None = None
+        # Set when the WebSocket has connected to mavlink2rest at least once
+        # this process. send_iridium_test() awaits this so the first
+        # MAV_CMD_USER_4 isn't sent before we're listening — otherwise the
+        # AGT's "IRIDIUM: Test starting" reply (and possibly PASSED/FAILED
+        # if the test resolves quickly) gets dropped on the floor.
+        self._ws_connected: asyncio.Event = asyncio.Event()
 
     @property
     def client(self) -> httpx.AsyncClient:
@@ -234,6 +241,10 @@ class ArtemisTrackerService:
     def _ensure_statustext_subscriber(self) -> None:
         """Lazily start the background WebSocket subscriber."""
         if self._ws_task is None or self._ws_task.done():
+            # Clear so callers waiting on the event don't get stale True
+            # from a previous subscriber that has since crashed.  The new
+            # subscriber will set() it again as soon as it connects.
+            self._ws_connected.clear()
             self._ws_task = asyncio.create_task(
                 self._statustext_ws_loop(),
                 name="agt-statustext-subscriber",
@@ -250,6 +261,10 @@ class ArtemisTrackerService:
         while True:
             try:
                 async with websockets.connect(url, close_timeout=5) as ws:
+                    # Signal callers waiting on first connect that we're now
+                    # listening.  Stays set across reconnects so transient
+                    # mavlink2rest blips don't re-stall send_iridium_test().
+                    self._ws_connected.set()
                     async for raw in ws:
                         if isinstance(raw, bytes):
                             try:
@@ -296,6 +311,23 @@ class ArtemisTrackerService:
         can poll for messages newer than that.
         """
         self._ensure_statustext_subscriber()
+        # Wait until the STATUSTEXT WebSocket subscriber is actually
+        # connected to mavlink2rest before dispatching the command.
+        # Without this, on the very first invocation per process the
+        # MAV_CMD_USER_4 goes out tens to hundreds of milliseconds before
+        # the WS handshake completes, and the AGT's near-immediate reply
+        # ("IRIDIUM: Test starting", and on a fast PASSED the result too)
+        # arrives at mavlink2rest with no listener and is lost.
+        try:
+            await asyncio.wait_for(
+                self._ws_connected.wait(), timeout=WS_FIRST_CONNECT_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "STATUSTEXT subscriber did not connect within %.1fs; "
+                "test command will be sent anyway but reply may be lost",
+                WS_FIRST_CONNECT_TIMEOUT_S,
+            )
         baseline_id = await self._statustext.latest_id()
 
         base = _m2r_base()

--- a/scripts/peek_statustext_ws.py
+++ b/scripts/peek_statustext_ws.py
@@ -7,7 +7,7 @@ import sys
 
 import websockets
 
-URL = "ws://blueos-wifi.local:6040/ws/mavlink?filter=STATUSTEXT"
+URL = "ws://192.168.68.75:6040/ws/mavlink?filter=STATUSTEXT"
 
 
 async def main():


### PR DESCRIPTION
## Summary

Follow-up to #24.  Fix a race that made the **first** click of the Iridium Test button after every container restart silently do nothing.  The second click then "worked" because the WebSocket subscriber had connected in the background by then.

## Root cause

`ArtemisTrackerService._ensure_statustext_subscriber()` lazy-started the WS task with `asyncio.create_task(...)` but did not await its connection.  On the very first `iridium-test` per process the `MAV_CMD_USER_4` `COMMAND_LONG` went out tens to hundreds of milliseconds before the `websockets.connect()` handshake completed.  The AGT replies almost immediately with `IRIDIUM: Test starting` (and on a fast PASSED the result too), so the reply arrived at mavlink2rest with no listener and was dropped — leaving the frontend buffer empty and the button stuck on "Testing…" until the 12-min hard timeout.

Verified the symptom on the live vehicle: triggering against a fresh container returned `latest_id=0` with no AGT messages, while mavlink2rest's HTTP cache showed the AGT had emitted 14 STATUSTEXT messages.

## Fix

`ArtemisTrackerService` now exposes an `asyncio.Event` set by the WS loop on every successful `websockets.connect()`.  `send_iridium_test()` awaits the event with a 5s timeout before dispatching the COMMAND_LONG, guaranteeing we are listening when the AGT replies.  `_ensure_statustext_subscriber()` clears the event when re-spawning a crashed subscriber so callers don't get a stale `True` from a previous instance.  If the WS truly can't connect within 5s the command is sent anyway and we log a warning — better to lose the reply than to refuse the test.

## Validation

Hot-deployed `tracker.py` to the live container, made a single `POST /api/v1/tracker/iridium-test` and saw the trigger return `latest_id=4` (the WS subscriber had already buffered 4 boot-time AGT messages before the trigger sent the command — proving the subscriber is listening), and 5s later the AGT's `IRIDIUM: Test starting` landed in the buffer at `id=5`:

```
{"messages": [
  {"id": 1, "text": "GPS: Coin cell DEPLETED, BBR time lost (cold)", ...},
  {"id": 2, "text": "RTC: Synced from GPS (resolved) 2026-5-13", ...},
  {"id": 3, "text": "GPS: Searching sats=0 fix=0 15s", ...},
  {"id": 4, "text": "GPS: TTFF=16s (warm start) sats=4", ...},
  {"id": 5, "text": "IRIDIUM: Test starting", ...}
], "latest_id": 5}
```

Also fixes `scripts/peek_statustext_ws.py` to use the vehicle's IP directly (mDNS resolution from Windows is unreliable).

Made-with: Cursor
