### PR TITLE
Recording: timestamped MP4s, first-frame gating, per-dive stream logging + GPS timesync hardening

### DIFF
--- a/extension/backend/scripts/doris.lua
+++ b/extension/backend/scripts/doris.lua
@@ -70,6 +70,14 @@ local MAV_SEVERITY = {
 local UPDATE_INTERVAL_MS = 500
 local ARM_RETRY_MS       = 2000
 
+-- VIDEO_INTERVAL first-frame gating: after ipcam_start the record clock
+-- does not begin counting until the extension reports frames are
+-- actually landing on disk (RTSP connect + jitter-buffer fill can take
+-- anywhere from <1 s to ~15 s on this camera).  If the readiness signal
+-- can't be confirmed within this many ms we start the clock anyway so a
+-- status-endpoint outage can never hang a record cycle.
+local IPCAM_FIRST_FRAME_TIMEOUT_MS = 30000
+
 local surface_pressure = baro:get_pressure() or 101325
 
 -- ArduSub SITL exposes SIM_BUOYANCY; used for depth fallback and relay tests.
@@ -348,6 +356,17 @@ local ipcam_btm_started      = false
 local ipcam_state = {
     cycle_start_ms  = 0,
     cycle_is_record = false,
+    -- VIDEO_INTERVAL first-frame gating.  ``cycle_started`` flips true
+    -- once the duty cycle has begun for the current bottom visit (so the
+    -- inaugural record window is only kicked off once).
+    -- ``cycle_awaiting_frames`` is true between issuing ipcam_start and
+    -- confirming frames are on disk; while true the record clock
+    -- (``cycle_start_ms``) is held at 0 and not counted.
+    -- ``cycle_wait_start_ms`` stamps when the wait began so the safety
+    -- timeout can fire.
+    cycle_started        = false,
+    cycle_awaiting_frames = false,
+    cycle_wait_start_ms  = 0,
     last_snap_ms    = 0,
     -- Timelapse: ``next_snap_ms`` is the absolute millis when the
     -- next snapshot should fire; the dispatcher sets it to ``now +
@@ -726,6 +745,44 @@ local function ipcam_http_send(first_line, host, port)
     sock:send(req, string.len(req))
     sock:close()
     return true
+end
+
+-- Bounded HTTP GET that DOES read the response (unlike the fire-and-
+-- forget ipcam_http_send above).  Returns the raw response text
+-- (headers + body) or nil on any failure.  Kept deliberately small and
+-- non-blocking-friendly: a single ``pollin`` with a short timeout so it
+-- never stalls the dive update loop (which also services failsafes).
+-- Only used to poll /rec/status during the brief first-frame wait.
+local function ipcam_http_get(path, host, port)
+    local sock = Socket(0)
+    if not sock then return nil end
+    if not sock:bind("0.0.0.0", 0) then sock:close(); return nil end
+    if not sock:connect(host, port) then sock:close(); return nil end
+    local req = string.format(
+        "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", path, host)
+    sock:send(req, string.len(req))
+    local body = nil
+    -- Localhost replies in <few ms; cap the wait at 100 ms.  The status
+    -- payload is small and ``frames_flowing`` sits near the front of the
+    -- JSON, so a single recv of the first chunk is sufficient.
+    if sock:pollin(100) then
+        local data = sock:recv(4096)
+        if data and #data > 0 then body = data end
+    end
+    sock:close()
+    return body
+end
+
+-- Query the recorder's readiness.  Returns true if frames are confirmed
+-- on disk, false if the recorder explicitly reports not-yet, and nil if
+-- the status couldn't be read / parsed (caller treats nil as "keep
+-- waiting" up to the safety timeout).
+local function ipcam_frames_flowing()
+    local body = ipcam_http_get("/rec/status", "127.0.0.1", 8095)
+    if not body then return nil end
+    if body:find('"frames_flowing"%s*:%s*true') then return true end
+    if body:find('"frames_flowing"%s*:%s*false') then return false end
+    return nil
 end
 
 local function ipcam_http_start(host, port, seg_s, phase)
@@ -1133,10 +1190,13 @@ function update()
                 ipcam_btm_started = false
                 -- Reset interval/timelapse timers so the on_bottom
                 -- loop below can establish its own cadence.
-                ipcam_state.cycle_start_ms  = 0
-                ipcam_state.cycle_is_record = false
-                ipcam_state.last_snap_ms    = 0
-                ipcam_state.next_snap_ms    = 0
+                ipcam_state.cycle_start_ms       = 0
+                ipcam_state.cycle_is_record      = false
+                ipcam_state.cycle_started        = false
+                ipcam_state.cycle_awaiting_frames = false
+                ipcam_state.cycle_wait_start_ms  = 0
+                ipcam_state.last_snap_ms         = 0
+                ipcam_state.next_snap_ms         = 0
                 -- For CONTINUOUS bottom mode with no camera delay we do
                 -- a zero-gap rotate-or-start right now so the moment
                 -- the vehicle settles, the first "on_bottom" .ts starts.
@@ -1225,17 +1285,52 @@ function update()
                 ipcam_btm_started = ipcam_recording
             end
         elseif ipcam_cfg.btm_cmod == 2 then
-            -- VIDEO_INTERVAL: duty-cycle record for btm_rec_ms, pause btm_pau_ms.
+            -- VIDEO_INTERVAL: duty-cycle record for btm_rec_ms, pause
+            -- btm_pau_ms.  The record clock is gated on first-frame: the
+            -- window only starts counting once the extension confirms
+            -- frames are on disk, so a slow RTSP connect (observed up to
+            -- ~15 s) no longer eats into the recorded clip length.
             if cam_delay_done and ipcam_cfg.btm_rec_ms > 0
                and ipcam_cfg.btm_pau_ms > 0 then
-                if ipcam_state.cycle_start_ms == 0 then
-                    ipcam_state.cycle_start_ms  = now_ms
-                    ipcam_state.cycle_is_record = true
+                if not ipcam_state.cycle_started then
+                    -- Inaugural record window for this bottom visit: kick
+                    -- off the recorder, then wait for frames before the
+                    -- clock starts.
+                    ipcam_state.cycle_started         = true
+                    ipcam_state.cycle_is_record       = true
+                    ipcam_state.cycle_awaiting_frames = true
+                    ipcam_state.cycle_wait_start_ms   = now_ms
+                    ipcam_state.cycle_start_ms        = 0
                     ipcam_begin_phase(true, "on_bottom")
                     ipcam_btm_started = ipcam_recording
                     gcs:send_text(MAV_SEVERITY.INFO,
                         string.format("DIVE: IPcam interval start (rec %ds)",
                             math.floor(ipcam_cfg.btm_rec_ms / 1000)))
+                elseif ipcam_state.cycle_awaiting_frames then
+                    -- Hold the record clock until frames are confirmed on
+                    -- disk (or the safety timeout fires).
+                    local ff = ipcam_frames_flowing()
+                    local waited = now_ms - ipcam_state.cycle_wait_start_ms
+                    if ff == true then
+                        ipcam_state.cycle_awaiting_frames = false
+                        ipcam_state.cycle_start_ms        = now_ms
+                        gcs:send_text(MAV_SEVERITY.INFO,
+                            string.format(
+                                "DIVE: IPcam frames flowing after %.1fs, "
+                                .. "recording %ds",
+                                waited / 1000.0,
+                                math.floor(ipcam_cfg.btm_rec_ms / 1000)))
+                    elseif waited >= IPCAM_FIRST_FRAME_TIMEOUT_MS then
+                        -- Fail-safe: never hang a cycle on a missing
+                        -- readiness signal -- start the clock anyway.
+                        ipcam_state.cycle_awaiting_frames = false
+                        ipcam_state.cycle_start_ms        = now_ms
+                        gcs:send_text(MAV_SEVERITY.WARNING,
+                            string.format(
+                                "DIVE: IPcam first-frame wait timed out "
+                                .. "(%.0fs), starting clock anyway",
+                                waited / 1000.0))
+                    end
                 else
                     local cycle_elapsed = now_ms - ipcam_state.cycle_start_ms
                     if ipcam_state.cycle_is_record
@@ -1248,8 +1343,13 @@ function update()
                                 math.floor(ipcam_cfg.btm_pau_ms / 1000)))
                     elseif (not ipcam_state.cycle_is_record)
                        and cycle_elapsed >= ipcam_cfg.btm_pau_ms then
-                        ipcam_state.cycle_is_record = true
-                        ipcam_state.cycle_start_ms  = now_ms
+                        -- Begin the next record window: start the
+                        -- recorder, then re-enter the first-frame wait so
+                        -- this window's clock is gated too.
+                        ipcam_state.cycle_is_record       = true
+                        ipcam_state.cycle_awaiting_frames = true
+                        ipcam_state.cycle_wait_start_ms   = now_ms
+                        ipcam_state.cycle_start_ms        = 0
                         if not ipcam_recording then
                             ipcam_start("on_bottom")
                         end

--- a/extension/backend/src/doris/services/dive_finalize.py
+++ b/extension/backend/src/doris/services/dive_finalize.py
@@ -57,12 +57,13 @@ import json
 import logging
 import os
 import re
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
 from ..config import settings
 from . import ip_camera_recorder as iprec
-from . import usb_storage
+from . import persistent_log, usb_storage
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,47 @@ async def _ffprobe_duration_s(path: Path) -> float | None:
     except Exception:
         logger.exception("ffprobe failed for %s", path)
         return None
+
+
+def _copy_diagnostic_logs(rec_dir: Path) -> dict:
+    """Copy the persistent doris/dmesg logs into ``<dive_dir>/logs/``.
+
+    The canonical logs live on *internal* storage
+    (``persistent_log.LOG_DIR``), but the recordings (and thus this dive
+    folder) frequently live on a USB stick the operator pulls -- so the
+    logs are otherwise easy to miss.  Copying ``doris.log*`` and
+    ``dmesg.log*`` here makes the whole diagnostic bundle travel with the
+    recordings.
+
+    Synchronous (runs in an executor); strictly best-effort -- a copy
+    failure is logged and summarised but never raises into finalize.
+    Returns a small summary dict for the manifest.
+    """
+    src_dir = persistent_log.LOG_DIR
+    out: dict = {"source": str(src_dir), "copied": [], "errors": []}
+    try:
+        if not src_dir.is_dir():
+            out["skipped"] = "log_dir_missing"
+            return out
+        logs_dir = rec_dir / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        for src in sorted(src_dir.iterdir()):
+            if not src.is_file():
+                continue
+            if not (src.name.startswith("doris.log")
+                    or src.name.startswith("dmesg.log")):
+                continue
+            try:
+                shutil.copy2(src, logs_dir / src.name)
+                out["copied"].append(src.name)
+            except OSError as e:
+                logger.warning("FINALIZE log copy failed for %s: %s", src.name, e)
+                out["errors"].append(f"{src.name}: {e}")
+        out["dest"] = str(logs_dir)
+    except Exception as e:
+        logger.exception("FINALIZE log copy step failed: %s", e)
+        out["errors"].append(str(e))
+    return out
 
 
 async def _concat_phase(
@@ -770,6 +812,14 @@ async def finalize_dive(
     # Reset the snapshot sequence counters so the next dive starts from seq=1.
     iprec.clear_snapshot_state()
 
+    # Copy the persistent doris/dmesg logs into <dive_dir>/logs/ so the
+    # diagnostic bundle rides along with the recordings (which usually
+    # live on the operator's USB stick, separate from the internal log
+    # dir).  Runs in an executor since it's blocking file I/O.
+    logs_summary = await asyncio.get_event_loop().run_in_executor(
+        None, _copy_diagnostic_logs, rec_dir,
+    )
+
     finished_at = datetime.now(tz=timezone.utc).isoformat()
     bottom_mode_label = {
         1: "continuous",
@@ -785,6 +835,7 @@ async def finalize_dive(
         "bottom_mode_id": bottom_mode,
         "phases": phase_results,
         "snapshots": snapshot_results,
+        "logs": logs_summary,
         "success": all(p["success"] for p in phase_results) if phase_results else True,
     }
 

--- a/extension/backend/src/doris/services/dive_finalize.py
+++ b/extension/backend/src/doris/services/dive_finalize.py
@@ -15,10 +15,9 @@ Bottom-phase output depends on the bottom camera mode
   ignore the raw layout entirely and run a two-pass lossless ffmpeg
   pipeline: concat every bottom ``.ts`` into a staging
   ``.bottom_full.ts``, then ``-f segment -segment_time 300
-  -reset_timestamps 1`` to slice it into clean 5-minute MP4 chunks
-  ``dive_<stamp>_on_bottom_chunkNN.mp4``.  Chunk count is therefore
-  proportional to dive duration (one chunk per ~5 minutes), not to
-  RTSP stability.
+  -reset_timestamps 1`` to slice it into clean 5-minute MP4 chunks.
+  Chunk count is therefore proportional to dive duration (one chunk
+  per ~5 minutes), not to RTSP stability.
 * INTERVAL (2): each ipcam start/stop cycle should yield one MP4,
   even if the cycle's recording was split across several ``.ts``
   files by mid-cycle RTSP rebuilds.  Cycles are identified
@@ -27,24 +26,27 @@ Bottom-phase output depends on the bottom camera mode
   ``ipcam_start`` and stays constant through every watchdog rebuild
   inside that cycle).  No timing heuristic is involved -- pause
   length, reconnect duration, restart count: irrelevant.  All ``.ts``
-  files sharing one ``<CC>`` are lossless-concatenated to one MP4
-  ``dive_<stamp>_on_bottom_videoNN.mp4`` where ``<NN>`` is the
-  chronological 1-based cycle index (so ``video01`` is the earliest
-  cycle that produced bottom .ts, regardless of the underlying
-  ``<CC>`` value).  Pre-upgrade dives whose ``.ts`` files lack the
-  ``<CC>`` tag fall back to the historical ``part<NN>`` grouping
-  with a ``legacy_`` prefix on the output filename so the operator
-  can spot the bridge case.
+  files sharing one ``<CC>`` are lossless-concatenated to one MP4.
+  Pre-upgrade dives whose ``.ts`` files lack the ``<CC>`` tag fall
+  back to the historical ``part<NN>`` grouping with a ``legacy_``
+  prefix on the output filename so the operator can spot the bridge
+  case.
 * TIMELAPSE (3): no .ts files exist; only JPEG snapshots, which are
   cataloged but never re-encoded into video.
 * OFF / unknown / legacy: falls through to the historical behavior
-  of concatenating every bottom .ts into a single
-  ``dive_<stamp>_on_bottom.mp4`` so older dives still finalize
-  cleanly.
+  of concatenating every bottom .ts into a single MP4 so older dives
+  still finalize cleanly.
 
-Descent and ascent always produce one MP4 per phase
-(``dive_<stamp>_descent.mp4`` / ``_ascent.mp4``) regardless of
-bottom mode.
+Output MP4s are named ``<recstart>_<phase>.mp4`` (e.g.
+``20260528t171502_on_bottom.mp4``), where ``recstart`` is the UTC
+``YYYYMMDDtHHMMSS`` the recording's footage started -- the earliest
+``.ts`` fragment open-stamp for that output (or, for continuous
+chunks, footage-start plus the cumulative duration of preceding
+chunks).  Files live inside the per-dive ``dive_<stamp>/`` folder, so
+dive grouping is preserved by directory.  Pre-upgrade ``.ts`` that
+lack an open-stamp fall back to the historical index-based names
+(``dive_<stamp>_on_bottom_videoNN.mp4`` / ``_chunkNN.mp4`` /
+``_<phase>.mp4``).
 
 Invoked at ``POST /api/v1/dive/finalize`` after the Lua dive state
 machine reaches RECOVERY.
@@ -58,7 +60,7 @@ import logging
 import os
 import re
 import shutil
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from ..config import settings
@@ -80,10 +82,17 @@ logger = logging.getLogger(__name__)
 # ``_cyc<CC>`` segment; the ``_part<NN>_<NNNNN>.ts`` suffix anchors
 # the trailing portion either way.  ``cyc`` is ``None`` for legacy
 # files and finalize routes those through the per-part fallback.
+#
+# Newest (post per-fragment open-stamp upgrade) adds a trailing
+# ``_t<YYYYMMDDtHHMMSS>`` carrying the fragment's open wall-clock (UTC):
+#   radcam_20260502_013722_on_bottom_cyc02_part10_00003_t20260502t013744.ts
+# The ``start`` group is optional so pre-upgrade .ts still match (those
+# fall back to index-based MP4 naming).
 _TS_RE = re.compile(
     r"^radcam_(?P<stamp>\d{8}_\d{6})_(?P<phase>[a-z0-9_]+?)"
     r"(?:_cyc(?P<cyc>\d{2}))?"
-    r"_part(?P<part>\d{2})_(?P<frag>\d{5})\.ts$"
+    r"_part(?P<part>\d{2})_(?P<frag>\d{5})"
+    r"(?:_t(?P<start>\d{8}t\d{6}))?\.ts$"
 )
 
 # TIMELAPSE snapshots:
@@ -92,6 +101,38 @@ _JPG_RE = re.compile(
     r"^radcam_(?P<stamp>\d{8}_\d{6})_(?P<phase>[a-z0-9_]+)"
     r"_(?P<seq>\d{5})\.jpg$"
 )
+
+
+# Output MP4 naming.  Operator-facing video files are named for *when
+# the recording actually started* rather than a synthetic index:
+#   <recstart>_<phase>.mp4   e.g. 20260528t171502_on_bottom.mp4
+# ``recstart`` is the UTC ``YYYYMMDDtHHMMSS`` of the earliest fragment in
+# the group (first frame on disk).  They live inside the per-dive
+# ``dive_<stamp>/`` folder, so the dive grouping is preserved by
+# directory and ``recstart`` is globally unique in time (no collisions
+# across cycles, chunks, or dives).  Pre-upgrade .ts that lack the
+# open-stamp fall back to the historical index-based names below.
+_START_FMT = "%Y%m%dt%H%M%S"
+
+
+def _group_start_stamp(files: list[Path]) -> str | None:
+    """Earliest fragment open-stamp (``YYYYMMDDtHHMMSS``) across a group.
+
+    The recorder tags every ``.ts`` with the wall-clock UTC time its
+    fragment opened (``_t<stamp>``); for the first fragment of a
+    recording that's the moment real frames started landing on disk.
+    The minimum across the group is therefore when that output's footage
+    began.  Fixed-width zero-padded stamps mean lexical ``min`` ==
+    chronological ``min``.  Returns ``None`` when no file carries the tag
+    (legacy .ts predating the stamp) so callers fall back to index-based
+    naming.
+    """
+    stamps = [
+        m.group("start")
+        for f in files
+        if (m := _TS_RE.match(f.name)) and m.group("start")
+    ]
+    return min(stamps) if stamps else None
 
 
 def _recordings_dir() -> Path:
@@ -403,39 +444,96 @@ async def _finalize_continuous_resegment(
     except OSError:
         pass
 
-    # ffmpeg writes chunk00.mp4, chunk01.mp4, ...  Rename chunkNN ->
-    # chunk(NN+1) so operator-facing numbering is 1-based.  Walk
-    # highest-first to avoid clobbering.
-    produced = sorted(
-        rec_dir.glob(f"dive_{dive_stamp}_on_bottom_chunk*.mp4"),
-        key=lambda p: p.name,
-    )
-    # Filter to ones that match the 0-based pattern we just produced,
-    # in case a previous run left chunk01+ on disk.
+    # Match the 0-based chunks ffmpeg just wrote (chunk00, chunk01, ...),
+    # filtering out any chunk01+ a previous run may have left on disk.
     zero_based_re = re.compile(
         r"^dive_" + re.escape(dive_stamp) + r"_on_bottom_chunk(\d{2})\.mp4$"
     )
-    matched: list[tuple[int, Path]] = []
-    for p in produced:
+    produced: list[tuple[int, Path]] = []
+    for p in rec_dir.glob(f"dive_{dive_stamp}_on_bottom_chunk*.mp4"):
         m = zero_based_re.match(p.name)
         if m:
-            matched.append((int(m.group(1)), p))
-    matched.sort(key=lambda t: t[0], reverse=True)
-    renamed: list[Path] = []
-    for idx0, p in matched:
-        new_idx = idx0 + 1
-        new_path = rec_dir / (
-            f"dive_{dive_stamp}_on_bottom_chunk{new_idx:02d}.mp4"
-        )
+            produced.append((int(m.group(1)), p))
+    produced.sort(key=lambda t: t[0])
+
+    # Re-segmented chunks don't align to .ts fragment boundaries, so
+    # derive each chunk's start by walking actual durations forward from
+    # when bottom footage began (the earliest fragment's open-stamp).
+    staging_start = _group_start_stamp(files)
+    start_dt: datetime | None = None
+    if staging_start:
         try:
-            p.rename(new_path)
-            renamed.append(new_path)
-        except OSError as e:
-            logger.warning(
-                "FINALIZE could not rename %s -> %s: %s", p, new_path, e,
+            start_dt = datetime.strptime(staging_start, _START_FMT).replace(
+                tzinfo=timezone.utc,
             )
-            renamed.append(p)
-    renamed.sort(key=lambda p: p.name)
+        except ValueError:
+            start_dt = None
+
+    chunk_entries: list[dict] = []
+    renamed: list[Path] = []
+    if start_dt is not None:
+        # Timestamped names: <chunkstart>_on_bottom.mp4, where chunkstart
+        # = footage start + cumulative duration of preceding chunks.
+        cumulative = 0.0
+        for idx, (_idx0, p) in enumerate(produced, start=1):
+            dur = await _ffprobe_duration_s(p)
+            stamp = (start_dt + timedelta(seconds=cumulative)).strftime(
+                _START_FMT,
+            )
+            new_path = rec_dir / f"{stamp}_on_bottom.mp4"
+            try:
+                p.rename(new_path)
+            except OSError as e:
+                logger.warning(
+                    "FINALIZE could not rename %s -> %s: %s", p, new_path, e,
+                )
+                new_path = p
+            renamed.append(new_path)
+            out_bytes = new_path.stat().st_size if new_path.exists() else 0
+            chunk_entries.append({
+                "phase": "on_bottom",
+                "kind": "chunk",
+                "index": idx,
+                "rec_start": stamp,
+                "output": str(new_path),
+                "output_bytes": out_bytes,
+                "output_duration_s": dur,
+                "success": True,
+                "message": "ok",
+            })
+            # Assume the configured segment length on a probe failure so
+            # the next chunk's start still advances (avoids a collision).
+            cumulative += dur if dur is not None else 300.0
+    else:
+        # Legacy fallback (pre open-stamp .ts): 1-based chunkNN names.
+        # Rename highest-first to avoid clobbering as chunkNN ->
+        # chunk(NN+1).
+        for idx0, p in sorted(produced, key=lambda t: t[0], reverse=True):
+            new_path = rec_dir / (
+                f"dive_{dive_stamp}_on_bottom_chunk{idx0 + 1:02d}.mp4"
+            )
+            try:
+                p.rename(new_path)
+                renamed.append(new_path)
+            except OSError as e:
+                logger.warning(
+                    "FINALIZE could not rename %s -> %s: %s", p, new_path, e,
+                )
+                renamed.append(p)
+        renamed.sort(key=lambda p: p.name)
+        for idx, out_path in enumerate(renamed, start=1):
+            out_bytes = out_path.stat().st_size if out_path.exists() else 0
+            dur = await _ffprobe_duration_s(out_path)
+            chunk_entries.append({
+                "phase": "on_bottom",
+                "kind": "chunk",
+                "index": idx,
+                "output": str(out_path),
+                "output_bytes": out_bytes,
+                "output_duration_s": dur,
+                "success": True,
+                "message": "ok",
+            })
 
     # All chunks landed; safe to drop the source .ts files.
     removed = 0
@@ -446,21 +544,6 @@ async def _finalize_continuous_resegment(
         except OSError:
             pass
     summary["inputs_deleted"] = removed
-
-    chunk_entries: list[dict] = []
-    for idx, out_path in enumerate(renamed, start=1):
-        out_bytes = out_path.stat().st_size if out_path.exists() else 0
-        dur = await _ffprobe_duration_s(out_path)
-        chunk_entries.append({
-            "phase": "on_bottom",
-            "kind": "chunk",
-            "index": idx,
-            "output": str(out_path),
-            "output_bytes": out_bytes,
-            "output_duration_s": dur,
-            "success": True,
-            "message": "ok",
-        })
 
     summary["outputs"] = [str(p) for p in renamed]
     summary["success"] = True
@@ -534,9 +617,13 @@ async def _finalize_interval_by_cyc(
     # counter is monotonic).
     for idx, cyc_key in enumerate(sorted(by_cyc.keys()), start=1):
         group = by_cyc[cyc_key]
-        out_path = rec_dir / (
-            f"dive_{dive_stamp}_on_bottom_video{idx:02d}.mp4"
-        )
+        # Name from when this cycle's footage actually started; fall back
+        # to the chronological 1-based index for legacy untagged .ts.
+        recstart = _group_start_stamp(group)
+        if recstart:
+            out_path = rec_dir / f"{recstart}_on_bottom.mp4"
+        else:
+            out_path = rec_dir / f"dive_{dive_stamp}_on_bottom_video{idx:02d}.mp4"
         src_bytes = sum((f.stat().st_size for f in group if f.exists()), 0)
         logger.info(
             "FINALIZE on_bottom video %02d (cyc=%s, inputs=%d, %d B) -> %s",
@@ -548,6 +635,7 @@ async def _finalize_interval_by_cyc(
             "kind": "cycle",
             "index": idx,
             "cyc": cyc_key,
+            "rec_start": recstart,
             "input_count": len(group),
             "input_bytes": src_bytes,
             "inputs_deleted": 0,
@@ -758,7 +846,13 @@ async def finalize_dive(
             )
             continue
 
-        out_path = rec_dir / f"dive_{dive_stamp}_{phase}.mp4"
+        # Name from when this phase's footage actually started; fall back
+        # to the dive-stamped name for legacy untagged .ts.
+        recstart = _group_start_stamp(files)
+        if recstart:
+            out_path = rec_dir / f"{recstart}_{phase}.mp4"
+        else:
+            out_path = rec_dir / f"dive_{dive_stamp}_{phase}.mp4"
         source_bytes = sum((f.stat().st_size for f in files if f.exists()), 0)
         logger.info(
             "FINALIZE phase=%s inputs=%d source_bytes=%d -> %s",
@@ -768,6 +862,7 @@ async def finalize_dive(
         entry: dict = {
             "phase": phase,
             "kind": "single",
+            "rec_start": recstart,
             "input_count": len(files),
             "input_bytes": source_bytes,
             "inputs_deleted": 0,

--- a/extension/backend/src/doris/services/ip_camera_recorder.py
+++ b/extension/backend/src/doris/services/ip_camera_recorder.py
@@ -36,8 +36,11 @@ SPS+PPS+IDR into a single buffer so splitmuxsink can never split
 between the parameter sets and their keyframe.
 
 ``splitmuxsink`` produces multiple
-``radcam_<stamp>_<phase>_cyc<CC>_part<NN>_%05d.ts`` segments per
-session.  Two distinct counters are embedded in the filename:
+``radcam_<stamp>_<phase>_cyc<CC>_part<NN>_%05d_t<open>.ts`` segments
+per session.  ``<open>`` is the fragment's open wall-clock
+(UTC ``YYYYMMDDtHHMMSS``); finalize names each output MP4 from the
+earliest fragment's stamp in the group.  Two distinct counters are
+also embedded in the filename:
 
 * ``cyc<CC>`` increments **once per ``start_recording`` call** within
   one dive.  Every ``.ts`` file written by a single ipcam_start /
@@ -445,10 +448,18 @@ class RecordingSession:
         if self.first_frame_at is None:
             self.first_frame_at = time.monotonic()
         phase = self.current_phase
+        # Tag the fragment with its open wall-clock (UTC, YYYYMMDDtHHMMSS).
+        # For the first fragment of a recording this is the moment real
+        # frames started landing on disk (post-connect), so finalize can
+        # name the output MP4 from the earliest fragment's stamp instead
+        # of a synthetic index.  ``.ts`` is transient (deleted at
+        # finalize); only the MP4 carries this forward.
+        opened = datetime.now(tz=timezone.utc).strftime("%Y%m%dt%H%M%S")
         path = str(
             self._out_dir
             / f"radcam_{self.base_stamp}_{phase}_cyc{self.cycle_seq:02d}"
-            f"_part{self._current_part:02d}_{int(fragment_id):05d}.ts"
+            f"_part{self._current_part:02d}_{int(fragment_id):05d}"
+            f"_t{opened}.ts"
         )
         self.last_pattern = path
         self._emit(

--- a/extension/backend/src/doris/services/ip_camera_recorder.py
+++ b/extension/backend/src/doris/services/ip_camera_recorder.py
@@ -58,6 +58,7 @@ import logging
 import os
 import re
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -279,6 +280,17 @@ class RecordingSession:
         # into a single MP4.
         self.cycle_seq = max(0, int(cycle_seq))
         self.restart_count = 0
+        # First-frame instrumentation.  ``session_started_at`` is the
+        # monotonic time the watchdog task was launched; ``first_frame_at``
+        # is the monotonic time splitmuxsink opened its first fragment
+        # (i.e. the first H.264 access unit actually hit disk).  The
+        # delta is the RTSP connect + jitter-buffer-fill latency that
+        # VIDEO_INTERVAL mode would otherwise silently charge against the
+        # operator's record window.  Set once (on the GStreamer streaming
+        # thread, GIL-safe) and read by recording_status() so the Lua
+        # dive script can gate its record clock on real frames.
+        self.session_started_at: float | None = None
+        self.first_frame_at: float | None = None
         self.last_pattern: str | None = None
         self.last_exit: dict | None = None
         self.rotation_count = 0
@@ -293,6 +305,17 @@ class RecordingSession:
     def is_alive(self) -> bool:
         return self._task is not None and not self._task.done()
 
+    @property
+    def frames_flowing(self) -> bool:
+        """True once the first .ts fragment has been opened (frames on disk)."""
+        return self.first_frame_at is not None
+
+    def first_frame_latency_s(self) -> float | None:
+        """Seconds from watchdog launch to the first frame, or None if pending."""
+        if self.first_frame_at is None or self.session_started_at is None:
+            return None
+        return round(self.first_frame_at - self.session_started_at, 3)
+
     def current_pid(self) -> int | None:
         # No subprocess any more; pipeline runs in the extension process.
         # Kept in the API shape for back-compat with /rec/status consumers.
@@ -305,6 +328,13 @@ class RecordingSession:
     # current_phase and fires split-now, the next callback (triggered
     # at the next keyframe) produces a file labelled with the new phase.
     def _on_format_location(self, _splitmux, fragment_id) -> str:
+        # The first fragment opened by this session marks the moment
+        # real video started landing on disk.  Latch it once; later
+        # fragments (segment rotations, watchdog rebuilds) leave it
+        # untouched so the recorded latency reflects the original
+        # connect, not subsequent splits.
+        if self.first_frame_at is None:
+            self.first_frame_at = time.monotonic()
         phase = self.current_phase
         path = str(
             self._out_dir
@@ -581,6 +611,7 @@ class RecordingSession:
         if self._task is not None:
             raise RuntimeError("session already started")
         _ensure_gst_init()
+        self.session_started_at = time.monotonic()
         self._task = asyncio.create_task(self._watchdog())
 
     async def stop(self, timeout_s: float = 12.0) -> None:
@@ -769,11 +800,12 @@ async def stop_recording() -> dict:
         # the next start_recording would re-use part00 and clobber the
         # files this session just produced.
         _session_part_offset = sess._current_part + 1
+        ff_latency = sess.first_frame_latency_s()
         logger.info(
-            "RECORD stop completed; restarts=%d rotations=%d last_exit=%s "
-            "next_part_offset=%d",
-            sess.restart_count, sess.rotation_count, sess.last_exit,
-            _session_part_offset,
+            "RECORD stop completed; restarts=%d rotations=%d "
+            "first_frame_latency_s=%s last_exit=%s next_part_offset=%d",
+            sess.restart_count, sess.rotation_count, ff_latency,
+            sess.last_exit, _session_part_offset,
         )
         return {
             "success": True,
@@ -781,6 +813,7 @@ async def stop_recording() -> dict:
             "base_stamp": sess.base_stamp,
             "restarts": sess.restart_count,
             "rotations": sess.rotation_count,
+            "first_frame_latency_s": ff_latency,
             "phases": list(sess._last_phases),
             "last_exit": sess.last_exit,
         }
@@ -958,8 +991,18 @@ async def recording_status() -> dict:
     last_exit = sess.last_exit if sess is not None else None
     phase = sess.current_phase if sess is not None else None
     rotations = sess.rotation_count if sess is not None else 0
+    # ``frames_flowing`` is the signal the Lua dive script gates its
+    # VIDEO_INTERVAL record clock on: only count the record window once
+    # real video is landing on disk, so a slow RTSP connect doesn't
+    # shorten the clip.  Reported even when not alive (False) so the
+    # poller gets a definite answer.  Kept near the top of the dict so
+    # it lands in the first TCP segment the Lua reader pulls.
+    frames_flowing = bool(sess.frames_flowing) if sess is not None else False
+    ff_latency = sess.first_frame_latency_s() if sess is not None else None
     return {
         "recording": alive,
+        "frames_flowing": frames_flowing,
+        "first_frame_latency_s": ff_latency,
         "base_stamp": base_stamp,
         "output_pattern": pattern,
         "phase": phase,

--- a/extension/backend/src/doris/services/ip_camera_recorder.py
+++ b/extension/backend/src/doris/services/ip_camera_recorder.py
@@ -54,6 +54,7 @@ session.  Two distinct counters are embedded in the filename:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -234,12 +235,83 @@ def _build_pipeline_description(rtsp_url: str, segment_s: int) -> str:
         f"rtspsrc location={rtsp_url} protocols=tcp is-live=true latency=2000 "
         f"retry=5 timeout=5000000 do-retransmission=false "
         f"! rtph264depay "
-        f"! h264parse config-interval=-1 "
+        f"! h264parse name=h264parse config-interval=-1 "
         f"! video/x-h264,stream-format=byte-stream,alignment=au "
         f"! splitmuxsink name=muxsink max-size-time={seg_ns} "
         f"muxer-factory=mpegtsmux send-keyframe-requests=true "
         f"async-finalize=true"
     )
+
+
+def _caps_to_dict(caps) -> dict | None:
+    """Flatten the negotiated H.264 caps into a small JSON-able dict.
+
+    Returns ``None`` if caps are absent/empty.  Best-effort: any GI
+    quirk just drops the offending field rather than raising into the
+    streaming thread.
+    """
+    try:
+        if caps is None or caps.get_size() == 0:
+            return None
+        s = caps.get_structure(0)
+        out: dict = {"name": s.get_name()}
+        ok, w = s.get_int("width")
+        if ok:
+            out["width"] = w
+        ok, h = s.get_int("height")
+        if ok:
+            out["height"] = h
+        ok, num, den = s.get_fraction("framerate")
+        if ok and den:
+            out["framerate"] = round(num / den, 3)
+        for key in ("profile", "level", "stream-format", "alignment"):
+            val = s.get_string(key)
+            if val:
+                out[key] = val
+        return out
+    except Exception:
+        return None
+
+
+class _StreamLog:
+    """Append-only JSONL log of recorder stream + cadence events for one
+    dive.
+
+    Written next to the recordings (``<dive_dir>/stream_log.jsonl``) so
+    it survives the 12 MB ``doris.log`` rotation window and is trivially
+    parseable for interval-spacing analysis: ``session_start`` /
+    ``first_frame`` / ``fragment_open`` / ``pipeline_exit`` /
+    ``session_stop`` events each carry wall-clock + monotonic stamps, so
+    the true gap between clips (pause vs. reconnect latency) can be
+    reconstructed offline.
+
+    Thread-safe: events arrive from both the asyncio event loop and the
+    GStreamer streaming threads.  Strictly best-effort -- a write failure
+    is swallowed so logging can never disrupt recording.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def emit(self, event: str, **fields) -> None:
+        rec: dict = {
+            "ts": datetime.now(tz=timezone.utc).isoformat(),
+            "mono": round(time.monotonic(), 3),
+            "event": event,
+        }
+        rec.update(fields)
+        try:
+            line = json.dumps(rec, default=str)
+        except Exception:
+            return
+        try:
+            with self._lock, open(self._path, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+        except Exception:
+            logger.debug("STREAM log write failed (%s)", self._path, exc_info=True)
+        # Mirror to doris.log so a live tail shows the same timeline.
+        logger.info("STREAM %s %s", event, fields)
 
 
 class RecordingSession:
@@ -251,7 +323,8 @@ class RecordingSession:
                  storage_label: str, base_stamp: str,
                  phase: str = PHASE_DEFAULT,
                  initial_part: int = 0,
-                 cycle_seq: int = 0) -> None:
+                 cycle_seq: int = 0,
+                 stream_log: "_StreamLog | None" = None) -> None:
         self._rtsp_url = rtsp_url
         self._segment_s = segment_s
         self._out_dir = out_dir
@@ -291,6 +364,13 @@ class RecordingSession:
         # dive script can gate its record clock on real frames.
         self.session_started_at: float | None = None
         self.first_frame_at: float | None = None
+        # Per-dive structured stream/cadence log (best-effort, may be
+        # None).  ``frame_count`` accumulates across watchdog rebuilds
+        # within this cycle; ``stream_caps`` is the negotiated
+        # resolution/framerate/profile captured on the first buffer.
+        self._stream_log = stream_log
+        self.frame_count = 0
+        self.stream_caps: dict | None = None
         self.last_pattern: str | None = None
         self.last_exit: dict | None = None
         self.rotation_count = 0
@@ -321,6 +401,35 @@ class RecordingSession:
         # Kept in the API shape for back-compat with /rec/status consumers.
         return None
 
+    def _emit(self, event: str, **fields) -> None:
+        """Emit a stream-log event tagged with this session's part/cyc."""
+        sl = self._stream_log
+        if sl is not None:
+            sl.emit(event, part=self._current_part, cyc=self.cycle_seq, **fields)
+
+    def _on_h264_buffer(self, _pad, _info):
+        """Buffer probe on h264parse src; runs on the streaming thread.
+
+        Cheap on the steady-state path (just a counter bump).  On the
+        very first buffer it latches the precise first-frame time and the
+        negotiated caps (resolution / framerate / H.264 profile+level)
+        which are otherwise never recorded, and emits a ``first_frame``
+        event carrying the connect latency.
+        """
+        self.frame_count += 1
+        if self.first_frame_at is None:
+            self.first_frame_at = time.monotonic()
+            try:
+                self.stream_caps = _caps_to_dict(_pad.get_current_caps())
+            except Exception:
+                self.stream_caps = None
+            self._emit(
+                "first_frame",
+                latency_s=self.first_frame_latency_s(),
+                caps=self.stream_caps,
+            )
+        return Gst.PadProbeReturn.OK
+
     # Invoked by GStreamer on a streaming thread whenever splitmuxsink
     # opens a new fragment.  Must be fast and avoid blocking on anything
     # that needs the asyncio loop.  Reads ``current_phase`` at the
@@ -342,6 +451,10 @@ class RecordingSession:
             f"_part{self._current_part:02d}_{int(fragment_id):05d}.ts"
         )
         self.last_pattern = path
+        self._emit(
+            "fragment_open", fragment_id=int(fragment_id), phase=phase,
+            path=path,
+        )
         return path
 
     async def rotate_to_phase(
@@ -458,6 +571,16 @@ class RecordingSession:
             raise RuntimeError("splitmuxsink 'muxsink' not found in pipeline")
         muxsink.connect("format-location", self._on_format_location)
         self._muxsink = muxsink
+        # Buffer probe on h264parse's src pad: counts frames and captures
+        # first-frame timing + negotiated caps for the stream log.  Best-
+        # effort -- a missing element or pad must never fail the build.
+        try:
+            h264 = pipeline.get_by_name("h264parse")
+            srcpad = h264.get_static_pad("src") if h264 is not None else None
+            if srcpad is not None:
+                srcpad.add_probe(Gst.PadProbeType.BUFFER, self._on_h264_buffer)
+        except Exception:
+            logger.debug("RECORD failed to attach h264 buffer probe", exc_info=True)
         return pipeline
 
     async def _run_one(self) -> tuple[str, float]:
@@ -499,6 +622,8 @@ class RecordingSession:
             self._pipeline = None
             self._muxsink = None
             return "set_state_failure", asyncio.get_event_loop().time() - t0
+
+        self._emit("pipeline_playing")
 
         exit_reason = "unknown"
         try:
@@ -583,6 +708,11 @@ class RecordingSession:
                 "runtime_s": round(runtime_s, 2),
                 "pattern": self.last_pattern,
             }
+            self._emit(
+                "pipeline_exit", reason=exit_reason,
+                runtime_s=round(runtime_s, 2), frames=self.frame_count,
+                user_stop=self._user_stop.is_set(),
+            )
             if self._user_stop.is_set():
                 logger.info(
                     "RECORD pipeline part=%d exited reason=%s runtime=%.1fs (user stop)",
@@ -597,6 +727,7 @@ class RecordingSession:
                 backoff = _RESTART_BACKOFF_S
             else:
                 backoff = min(_MAX_BACKOFF_S, backoff * 1.5)
+            self._emit("pipeline_restart", backoff_s=round(backoff, 2))
             try:
                 await asyncio.wait_for(self._user_stop.wait(), timeout=backoff)
                 break
@@ -727,6 +858,10 @@ async def start_recording(
         # into one MP4 per cycle without any timing heuristic.
         _dive_cycle_seq += 1
         cycle_seq = _dive_cycle_seq
+        # One stream log per dive, colocated with the recordings and
+        # appended across every cycle so the whole interval cadence
+        # lands in a single parseable file.
+        stream_log = _StreamLog(out_dir / "stream_log.jsonl")
         sess = RecordingSession(
             rtsp_url=rtsp_url,
             segment_s=seg,
@@ -736,10 +871,16 @@ async def start_recording(
             phase=phase_label,
             initial_part=initial_part,
             cycle_seq=cycle_seq,
+            stream_log=stream_log,
         )
         sess.start()
         _session = sess
         _last_base_stamp = stamp
+        stream_log.emit(
+            "session_start", cyc=cycle_seq, phase=phase_label,
+            part0=initial_part, seg_s=seg, storage=storage,
+            rtsp_source=source_label, base_stamp=stamp,
+        )
         logger.info(
             "RECORD session started base=%s phase=%s cyc=%02d storage=%s "
             "rtsp=%s seg=%ds",
@@ -801,11 +942,18 @@ async def stop_recording() -> dict:
         # files this session just produced.
         _session_part_offset = sess._current_part + 1
         ff_latency = sess.first_frame_latency_s()
+        if sess._stream_log is not None:
+            sess._stream_log.emit(
+                "session_stop", cyc=sess.cycle_seq,
+                restarts=sess.restart_count, rotations=sess.rotation_count,
+                first_frame_latency_s=ff_latency, frames=sess.frame_count,
+                caps=sess.stream_caps, last_exit=sess.last_exit,
+            )
         logger.info(
             "RECORD stop completed; restarts=%d rotations=%d "
-            "first_frame_latency_s=%s last_exit=%s next_part_offset=%d",
+            "first_frame_latency_s=%s frames=%d last_exit=%s next_part_offset=%d",
             sess.restart_count, sess.rotation_count, ff_latency,
-            sess.last_exit, _session_part_offset,
+            sess.frame_count, sess.last_exit, _session_part_offset,
         )
         return {
             "success": True,
@@ -999,10 +1147,14 @@ async def recording_status() -> dict:
     # it lands in the first TCP segment the Lua reader pulls.
     frames_flowing = bool(sess.frames_flowing) if sess is not None else False
     ff_latency = sess.first_frame_latency_s() if sess is not None else None
+    frame_count = sess.frame_count if sess is not None else 0
+    stream_caps = sess.stream_caps if sess is not None else None
     return {
         "recording": alive,
         "frames_flowing": frames_flowing,
         "first_frame_latency_s": ff_latency,
+        "frame_count": frame_count,
+        "stream_caps": stream_caps,
         "base_stamp": base_stamp,
         "output_pattern": pattern,
         "phase": phase,

--- a/extension/backend/src/doris/services/persistent_log.py
+++ b/extension/backend/src/doris/services/persistent_log.py
@@ -23,6 +23,45 @@ BACKUP_COUNT = 5  # keep 5 rotated files (10 MB total max)
 LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
 LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
 
+# Third-party / framework loggers that emit high-volume DEBUG/INFO
+# records.  Most damagingly, robyn logs full HTTP response *bodies* at
+# DEBUG -- so downloading a log file dumps that file's own bytes straight
+# back into the log as a multi-MB single-line entry, which blows through
+# rotation and evicts the real dive/recorder history we actually need.
+# These are pinned to WARNING (and enforced by a handler filter below) so
+# DORIS's own ``doris.*`` loggers stay fully verbose while the framework
+# chatter is kept out of the persistent log.
+NOISY_LOGGER_PREFIXES = (
+    "robyn",
+    "httpcore",
+    "httpx",
+    "websockets",
+    "actix_files",
+)
+
+
+class _NoisyLoggerFilter(logging.Filter):
+    """Drop sub-WARNING records from known high-volume framework loggers.
+
+    Attached to the persistent file handler so verbose request/response
+    DEBUG (including robyn's full response-body dumps) never reaches the
+    rotating log regardless of how those loggers' levels are configured
+    elsewhere -- robyn reconfigures its own logging after startup, so a
+    plain ``setLevel`` is not enough on its own.  ``doris.*`` records and
+    anything at WARNING or above always pass through.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        return not record.name.startswith(NOISY_LOGGER_PREFIXES)
+
+
+def _quiet_noisy_loggers() -> None:
+    """Pin the noisy framework loggers to WARNING (idempotent)."""
+    for name in NOISY_LOGGER_PREFIXES:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
 DMESG_INTERVAL_S = 300  # capture dmesg every 5 minutes
 DMESG_KEYWORDS = (
     "usb",
@@ -51,6 +90,10 @@ def setup_persistent_logging(level: int = logging.DEBUG) -> Path:
     """
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Re-assert on every call so it survives the framework reconfiguring
+    # its loggers after startup.
+    _quiet_noisy_loggers()
+
     root = logging.getLogger()
 
     log_file = LOG_DIR / "doris.log"
@@ -66,6 +109,7 @@ def setup_persistent_logging(level: int = logging.DEBUG) -> Path:
     )
     file_handler.setLevel(level)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=LOG_DATEFMT))
+    file_handler.addFilter(_NoisyLoggerFilter())
     root.addHandler(file_handler)
 
     if root.level > level:
@@ -77,6 +121,7 @@ def setup_persistent_logging(level: int = logging.DEBUG) -> Path:
         console = logging.StreamHandler()
         console.setLevel(logging.INFO)
         console.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=LOG_DATEFMT))
+        console.addFilter(_NoisyLoggerFilter())
         root.addHandler(console)
 
     logger.info("Persistent logging initialized -> %s", log_file)

--- a/extension/backend/src/doris/services/storage.py
+++ b/extension/backend/src/doris/services/storage.py
@@ -477,8 +477,12 @@ def _parse_datetime_from_filename(filename: str) -> datetime | None:
             )
         except ValueError:
             pass
-    # Loose YYYYMMDD_HHMMSS anywhere in stem
-    m2 = re.search(r"(20\d{2})(\d{2})(\d{2})[_-](\d{2})(\d{2})(\d{2})", filename)
+    # Loose YYYYMMDD<sep>HHMMSS anywhere in stem.  ``t``/``T`` covers the
+    # recorder's MP4 names (e.g. 20260528t171502_on_bottom.mp4); ``_``/``-``
+    # cover dive-stamp prefixes and other DORIS exports.
+    m2 = re.search(
+        r"(20\d{2})(\d{2})(\d{2})[_\-tT](\d{2})(\d{2})(\d{2})", filename
+    )
     if m2:
         try:
             return datetime(

--- a/extension/backend/src/doris/services/timesync.py
+++ b/extension/backend/src/doris/services/timesync.py
@@ -6,12 +6,33 @@ Artemis derives its time from GPS, so this gives microsecond-accurate UTC
 even when the Raspberry Pi has no RTC or NTP.
 
 Falls back to a browser-supplied timestamp when the Artemis is unavailable.
+
+Mission profile notes (DORIS):
+  * GPS is only available at the surface (deploy + recovery); the vehicle
+    runs blind for the whole dive.  We therefore want to grab a fix and
+    discipline the clock *quickly* during the brief surface window, then
+    let the Pi free-run for the dive.  The poll loop runs fast until the
+    first successful sync, then backs off.
+  * BlueOS has no ``fake-hwclock``; it relies on systemd-timesyncd, which
+    only persists the clock lazily (periodic + clean shutdown).  Our
+    vehicles get power-cut, so a GPS-synced time can be lost on the next
+    boot.  We therefore persist the last-good UTC to our own storage and,
+    on startup, bump the clock forward to that floor so logs never fall
+    back to 1970 mid-mission.
+  * mavlink2rest runs on the same host as DORIS, so its
+    ``status.time.last_update`` shares our (possibly wrong) system clock.
+    Relative message *age* is therefore reliable even when absolute time
+    is wrong, which lets us reject a stale cached SYSTEM_TIME that would
+    otherwise step the clock backwards underwater.
 """
 
 import asyncio
+import json
 import logging
+import os
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import httpx
 
@@ -22,8 +43,20 @@ logger = logging.getLogger(__name__)
 ARTEMIS_COMPONENT_ID = 191
 MIN_DRIFT_S = 30
 POLL_INTERVAL_S = 30
+# Poll quickly until the first successful sync so we catch the brief
+# surface GPS window before the vehicle submerges.
+FAST_POLL_INTERVAL_S = 3
+# Reject mavlink2rest messages older than this; a stale cached SYSTEM_TIME
+# must never be used to step the clock (it would jump us backwards).
+MAX_MSG_AGE_S = 15
 _SANE_YEAR_LO = 2024
 _SANE_YEAR_HI = 2030
+
+# Persist the last-good UTC here so a power-cut reboot can floor the clock
+# forward instead of dropping to the epoch.  ``configurations`` is a
+# persistent bind mount that survives container restarts and reboots.
+_DATA_ROOT = Path(os.environ.get("DORIS_DATA_ROOT", "/tmp/storage"))
+_STATE_FILE = _DATA_ROOT / "configurations" / "timesync_state.json"
 
 
 def _clock_is_sane() -> bool:
@@ -32,7 +65,12 @@ def _clock_is_sane() -> bool:
 
 
 def _set_system_clock(dt: datetime) -> bool:
-    """Set the Linux system clock via the ``date`` command."""
+    """Set the Linux system clock via the ``date`` command.
+
+    Logs the step explicitly (old -> new) so pre-sync log timestamps can be
+    reconciled after the fact.
+    """
+    old = datetime.now(tz=timezone.utc)
     date_str = dt.strftime("%Y-%m-%d %H:%M:%S")
     try:
         subprocess.run(
@@ -41,11 +79,75 @@ def _set_system_clock(dt: datetime) -> bool:
             capture_output=True,
             timeout=5,
         )
-        logger.info("System clock set to %s UTC", date_str)
+        logger.info(
+            "System clock stepped: %s -> %s UTC (delta %+.1fs)",
+            old.isoformat(),
+            dt.isoformat(),
+            (dt - old).total_seconds(),
+        )
         return True
     except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
         logger.warning("Failed to set system clock: %s", exc)
         return False
+
+
+def _message_age_seconds(data: dict) -> float | None:
+    """Age of a mavlink2rest message from its ``status.time.last_update``.
+
+    Returns ``None`` when the timestamp is missing or unparseable.  Both
+    ``last_update`` and ``now`` come from the same host clock, so the
+    returned age is valid even when the absolute clock is wrong.
+    """
+    last_update = data.get("status", {}).get("time", {}).get("last_update")
+    if not last_update or not isinstance(last_update, str):
+        return None
+    s = last_update.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(tz=timezone.utc) - dt).total_seconds()
+
+
+def _read_state() -> datetime | None:
+    """Read the persisted last-good UTC, or ``None`` if absent/invalid."""
+    try:
+        raw = _STATE_FILE.read_text()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        value = json.loads(raw).get("last_good_utc")
+    except (ValueError, AttributeError):
+        return None
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    if not (_SANE_YEAR_LO <= dt.year <= _SANE_YEAR_HI):
+        return None
+    return dt
+
+
+def _write_state(dt: datetime) -> None:
+    """Persist the last-good UTC so a reboot can floor the clock forward."""
+    try:
+        _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _STATE_FILE.write_text(
+            json.dumps(
+                {
+                    "last_good_utc": dt.astimezone(timezone.utc).isoformat(),
+                    "updated_at": datetime.now(tz=timezone.utc).isoformat(),
+                }
+            )
+        )
+    except OSError as exc:
+        logger.debug("Could not persist timesync state: %s", exc)
 
 
 class TimeSyncService:
@@ -83,8 +185,37 @@ class TimeSyncService:
             "utc": datetime.now(tz=timezone.utc).isoformat(),
         }
 
-    async def _artemis_has_gps_fix(self) -> bool:
-        """Check GPS_INPUT from the Artemis to verify it has a valid fix."""
+    def _record_good_time(self, dt: datetime, source: str) -> None:
+        """Mark synced, remember the source, and persist the floor."""
+        self._synced = True
+        self._source = source
+        _write_state(dt)
+
+    def apply_boot_floor(self) -> bool:
+        """Bump the clock forward to the last-good UTC if it is behind.
+
+        Only ever moves the clock *forward* — this is a floor, not a sync,
+        so it never marks the service as synced and the poll loop keeps
+        looking for authoritative GPS time.
+        """
+        floor = _read_state()
+        if floor is None:
+            return False
+        now = datetime.now(tz=timezone.utc)
+        if now >= floor:
+            return False
+        logger.info(
+            "Applying boot time floor: clock %s is behind last-good %s",
+            now.isoformat(),
+            floor.isoformat(),
+        )
+        if _set_system_clock(floor):
+            self._source = "restored-floor"
+            return True
+        return False
+
+    async def _artemis_has_fresh_gps_fix(self) -> bool:
+        """Check GPS_INPUT from the Artemis for a *fresh* valid fix."""
         base = blueos_services.mavlink2rest
         url = (
             f"{base}/mavlink/vehicles/1/components/"
@@ -96,23 +227,33 @@ class TimeSyncService:
                 return False
             resp.raise_for_status()
             data = resp.json()
-            msg = data.get("message", {})
-            fix_type = msg.get("fix_type", 0)
-            if isinstance(fix_type, dict):
-                fix_type = fix_type.get("bits", 0)
-            return int(fix_type) >= 2
         except Exception:
+            return False
+
+        age = _message_age_seconds(data)
+        if age is not None and age > MAX_MSG_AGE_S:
+            logger.debug("Artemis GPS_INPUT is stale (%.0fs old) — ignoring", age)
+            return False
+
+        msg = data.get("message", {})
+        fix_type = msg.get("fix_type", 0)
+        if isinstance(fix_type, dict):
+            fix_type = fix_type.get("bits", 0)
+        try:
+            return int(fix_type) >= 2
+        except (TypeError, ValueError):
             return False
 
     async def try_sync_from_artemis(self) -> bool:
         """Read SYSTEM_TIME from the Artemis (component 191) and sync if needed.
 
-        Only trusts the time when the Artemis has a GPS fix (fix_type >= 2).
-        Without a fix, the Artemis reports garbage time_unix_usec.
+        Only trusts the time when the Artemis has a fresh GPS fix
+        (fix_type >= 2) and the SYSTEM_TIME message itself is fresh.
+        Without a fix the Artemis reports garbage time_unix_usec, and a
+        stale cached message would otherwise step the clock backwards.
         """
-        has_fix = await self._artemis_has_gps_fix()
-        if not has_fix:
-            logger.debug("Artemis has no GPS fix — skipping time sync")
+        if not await self._artemis_has_fresh_gps_fix():
+            logger.debug("Artemis has no fresh GPS fix — skipping time sync")
             return False
 
         base = blueos_services.mavlink2rest
@@ -131,19 +272,29 @@ class TimeSyncService:
             logger.debug("Could not read Artemis SYSTEM_TIME: %s", exc)
             return False
 
+        age = _message_age_seconds(data)
+        if age is not None and age > MAX_MSG_AGE_S:
+            logger.debug(
+                "Artemis SYSTEM_TIME is stale (%.0fs old) — skipping sync", age
+            )
+            return False
+
         msg = data.get("message", {})
         time_unix_usec = msg.get("time_unix_usec", 0)
         if not time_unix_usec or time_unix_usec < 0:
             logger.debug("Artemis SYSTEM_TIME has no valid time_unix_usec")
             return False
 
-        gps_dt = datetime.fromtimestamp(
-            time_unix_usec / 1_000_000, tz=timezone.utc
-        )
+        gps_dt = datetime.fromtimestamp(time_unix_usec / 1_000_000, tz=timezone.utc)
+        # Compensate for the message's transport age so we set the clock to
+        # *now*, not to when the message was received.  ``age`` is measured
+        # on the consistent host clock, so this holds even if absolute time
+        # is currently wrong.
+        if age is not None and 0 <= age <= MAX_MSG_AGE_S:
+            gps_dt = gps_dt + timedelta(seconds=age)
+
         if not (_SANE_YEAR_LO <= gps_dt.year <= _SANE_YEAR_HI):
-            logger.debug(
-                "Artemis GPS time looks invalid (year %d)", gps_dt.year
-            )
+            logger.debug("Artemis GPS time looks invalid (year %d)", gps_dt.year)
             return False
 
         now = datetime.now(tz=timezone.utc)
@@ -151,8 +302,7 @@ class TimeSyncService:
         self._last_drift = drift
 
         if drift <= MIN_DRIFT_S:
-            self._synced = True
-            self._source = "artemis-gps"
+            self._record_good_time(gps_dt, "artemis-gps")
             return True
 
         logger.info(
@@ -161,8 +311,7 @@ class TimeSyncService:
             gps_dt.isoformat(),
         )
         if _set_system_clock(gps_dt):
-            self._synced = True
-            self._source = "artemis-gps"
+            self._record_good_time(gps_dt, "artemis-gps")
             return True
         return False
 
@@ -181,6 +330,7 @@ class TimeSyncService:
             self._synced = True
             if not self._source:
                 self._source = "client-browser"
+            _write_state(client_dt)
             return {
                 "synced": False,
                 "reason": "drift within tolerance",
@@ -198,8 +348,7 @@ class TimeSyncService:
 
         ok = _set_system_clock(client_dt)
         if ok:
-            self._synced = True
-            self._source = "client-browser"
+            self._record_good_time(client_dt, "client-browser")
         return {
             "synced": ok,
             "drift_seconds": round(drift, 1),
@@ -209,24 +358,36 @@ class TimeSyncService:
         }
 
     async def _poll_loop(self) -> None:
-        """Background loop: try Artemis sync every POLL_INTERVAL_S."""
+        """Background loop: poll fast until first sync, then back off."""
         while True:
+            synced_now = False
             try:
-                await self.try_sync_from_artemis()
+                synced_now = await self.try_sync_from_artemis()
             except Exception as exc:
                 logger.debug("Time sync poll error: %s", exc)
-            await asyncio.sleep(POLL_INTERVAL_S)
+            # Stay in fast-poll until we've locked the clock once, so we
+            # don't miss the brief surface GPS window at deployment.
+            interval = POLL_INTERVAL_S if self._synced else FAST_POLL_INTERVAL_S
+            await asyncio.sleep(interval)
+            _ = synced_now
 
     def start_background_sync(self) -> None:
         """Start the background polling task (call once at app startup)."""
         if self._task is not None:
             return
+        # Floor the clock forward from the last-good time before anything
+        # else logs, so early-boot timestamps are sane even with no GPS yet.
+        try:
+            self.apply_boot_floor()
+        except Exception as exc:
+            logger.debug("Boot time floor skipped: %s", exc)
         loop = asyncio.get_event_loop()
         self._task = loop.create_task(self._poll_loop())
         logger.info(
             "Time sync background task started (Artemis component %d, "
-            "interval %ds)",
+            "fast %ds until first sync then %ds)",
             ARTEMIS_COMPONENT_ID,
+            FAST_POLL_INTERVAL_S,
             POLL_INTERVAL_S,
         )
 

--- a/extension/backend/tests/test_timesync.py
+++ b/extension/backend/tests/test_timesync.py
@@ -1,0 +1,245 @@
+"""Tests for the GPS time-sync service (services/timesync.py)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from doris.services import timesync
+from doris.services.timesync import TimeSyncService
+
+
+def _iso_ago(seconds: float) -> str:
+    return (datetime.now(tz=timezone.utc) - timedelta(seconds=seconds)).isoformat()
+
+
+def _usec(dt: datetime) -> int:
+    return int(dt.timestamp() * 1_000_000)
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    """Routes mavlink2rest GETs by message-type substring in the URL."""
+
+    is_closed = False
+
+    def __init__(self, responses: dict[str, _FakeResponse]) -> None:
+        self._responses = responses
+
+    async def get(self, url: str) -> _FakeResponse:
+        for key, resp in self._responses.items():
+            if key in url:
+                return resp
+        return _FakeResponse({}, status_code=404)
+
+
+def _make_service(responses: dict[str, _FakeResponse]) -> TimeSyncService:
+    svc = TimeSyncService()
+    svc._client = _FakeClient(responses)
+    return svc
+
+
+# ── _message_age_seconds ───────────────────────────────────────────
+
+
+def test_message_age_fresh():
+    data = {"status": {"time": {"last_update": _iso_ago(2)}}}
+    age = timesync._message_age_seconds(data)
+    assert age is not None and 1 <= age <= 5
+
+
+def test_message_age_missing_returns_none():
+    assert timesync._message_age_seconds({"status": {"time": {}}}) is None
+    assert timesync._message_age_seconds({}) is None
+
+
+def test_message_age_unparseable_returns_none():
+    data = {"status": {"time": {"last_update": "not-a-date"}}}
+    assert timesync._message_age_seconds(data) is None
+
+
+# ── persistence / boot floor ───────────────────────────────────────
+
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "timesync_state.json")
+    dt = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+    timesync._write_state(dt)
+    assert timesync._read_state() == dt
+
+
+def test_read_state_rejects_insane_year(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "timesync_state.json")
+    timesync._write_state(datetime(1999, 1, 1, tzinfo=timezone.utc))
+    assert timesync._read_state() is None
+
+
+def test_read_state_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "nope.json")
+    assert timesync._read_state() is None
+
+
+def test_apply_boot_floor_steps_forward_when_behind(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "timesync_state.json")
+    future = datetime.now(tz=timezone.utc) + timedelta(days=365)
+    timesync._write_state(future)
+
+    calls: list[datetime] = []
+    monkeypatch.setattr(
+        timesync, "_set_system_clock", lambda dt: calls.append(dt) or True
+    )
+
+    svc = TimeSyncService()
+    assert svc.apply_boot_floor() is True
+    assert calls and calls[0] == future
+    assert svc._source == "restored-floor"
+    # Floor is not an authoritative sync — keep polling for real GPS.
+    assert svc.synced is False
+
+
+def test_apply_boot_floor_noop_when_clock_ahead(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "timesync_state.json")
+    past = datetime.now(tz=timezone.utc) - timedelta(days=365)
+    timesync._write_state(past)
+
+    calls: list[datetime] = []
+    monkeypatch.setattr(
+        timesync, "_set_system_clock", lambda dt: calls.append(dt) or True
+    )
+
+    svc = TimeSyncService()
+    assert svc.apply_boot_floor() is False
+    assert not calls
+
+
+def test_apply_boot_floor_noop_without_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "missing.json")
+    svc = TimeSyncService()
+    assert svc.apply_boot_floor() is False
+
+
+# ── try_sync_from_artemis: freshness gates ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_when_no_fix(monkeypatch):
+    svc = _make_service(
+        {
+            "GPS_INPUT": _FakeResponse(
+                {"message": {"fix_type": 1}, "status": {"time": {"last_update": _iso_ago(1)}}}
+            ),
+        }
+    )
+    monkeypatch.setattr(timesync, "_set_system_clock", lambda dt: True)
+    assert await svc.try_sync_from_artemis() is False
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_when_fix_is_stale(monkeypatch):
+    svc = _make_service(
+        {
+            "GPS_INPUT": _FakeResponse(
+                {
+                    "message": {"fix_type": 3},
+                    "status": {"time": {"last_update": _iso_ago(120)}},
+                }
+            ),
+        }
+    )
+    monkeypatch.setattr(timesync, "_set_system_clock", lambda dt: True)
+    assert await svc.try_sync_from_artemis() is False
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_when_system_time_is_stale(monkeypatch):
+    # Fresh fix, but the SYSTEM_TIME message itself is stale: must not be
+    # used to step the clock (this is the backward-jump guard).
+    stale_time = datetime.now(tz=timezone.utc) - timedelta(hours=2)
+    svc = _make_service(
+        {
+            "GPS_INPUT": _FakeResponse(
+                {"message": {"fix_type": 3}, "status": {"time": {"last_update": _iso_ago(1)}}}
+            ),
+            "SYSTEM_TIME": _FakeResponse(
+                {
+                    "message": {"time_unix_usec": _usec(stale_time)},
+                    "status": {"time": {"last_update": _iso_ago(120)}},
+                }
+            ),
+        }
+    )
+    calls: list[datetime] = []
+    monkeypatch.setattr(
+        timesync, "_set_system_clock", lambda dt: calls.append(dt) or True
+    )
+    assert await svc.try_sync_from_artemis() is False
+    assert not calls
+
+
+@pytest.mark.asyncio
+async def test_sync_steps_clock_on_fresh_drift(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "timesync_state.json")
+    # GPS says it is ~10 minutes ahead of the current clock -> drift > 30s.
+    gps_time = datetime.now(tz=timezone.utc) + timedelta(minutes=10)
+    svc = _make_service(
+        {
+            "GPS_INPUT": _FakeResponse(
+                {"message": {"fix_type": 3}, "status": {"time": {"last_update": _iso_ago(1)}}}
+            ),
+            "SYSTEM_TIME": _FakeResponse(
+                {
+                    "message": {"time_unix_usec": _usec(gps_time)},
+                    "status": {"time": {"last_update": _iso_ago(1)}},
+                }
+            ),
+        }
+    )
+    calls: list[datetime] = []
+    monkeypatch.setattr(
+        timesync, "_set_system_clock", lambda dt: calls.append(dt) or True
+    )
+    assert await svc.try_sync_from_artemis() is True
+    assert calls and abs((calls[0] - gps_time).total_seconds()) < 5
+    assert svc.synced is True
+    assert svc._source == "artemis-gps"
+    # The good time was persisted as a floor.
+    assert timesync._read_state() is not None
+
+
+@pytest.mark.asyncio
+async def test_sync_within_tolerance_marks_synced_without_stepping(tmp_path, monkeypatch):
+    monkeypatch.setattr(timesync, "_STATE_FILE", tmp_path / "timesync_state.json")
+    gps_time = datetime.now(tz=timezone.utc) + timedelta(seconds=2)
+    svc = _make_service(
+        {
+            "GPS_INPUT": _FakeResponse(
+                {"message": {"fix_type": 3}, "status": {"time": {"last_update": _iso_ago(1)}}}
+            ),
+            "SYSTEM_TIME": _FakeResponse(
+                {
+                    "message": {"time_unix_usec": _usec(gps_time)},
+                    "status": {"time": {"last_update": _iso_ago(1)}},
+                }
+            ),
+        }
+    )
+    calls: list[datetime] = []
+    monkeypatch.setattr(
+        timesync, "_set_system_clock", lambda dt: calls.append(dt) or True
+    )
+    assert await svc.try_sync_from_artemis() is True
+    assert not calls  # within MIN_DRIFT_S, no step needed
+    assert svc.synced is True

--- a/scripts/check_fake_hwclock.py
+++ b/scripts/check_fake_hwclock.py
@@ -1,0 +1,57 @@
+"""One-off diagnostic: check fake-hwclock / RTC status on the DORIS vehicle host.
+
+Queries the BlueOS Commander API (host commands) and reports whether
+fake-hwclock is installed/active, whether a hardware RTC exists, and what
+the persisted clock data looks like.
+"""
+
+import json
+import urllib.parse
+import urllib.request
+
+COMMANDER = "http://blueos-wifi.local:9100"
+TIMEOUT = 8
+
+
+def host(cmd: str) -> dict:
+    url = (
+        f"{COMMANDER}/v1.0/command/host?command="
+        f"{urllib.parse.quote(cmd)}&i_know_what_i_am_doing=true"
+    )
+    req = urllib.request.Request(url, method="POST")
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.loads(resp.read().decode())
+
+
+CHECKS = {
+    "which fake-hwclock": "which fake-hwclock || echo MISSING",
+    "fake-hwclock save status": "fake-hwclock 2>&1 || echo NO_BIN",
+    "fake-hwclock.data": "cat /etc/fake-hwclock.data 2>&1 || echo NO_DATA",
+    "systemd unit": "systemctl is-enabled fake-hwclock 2>&1; systemctl is-active fake-hwclock 2>&1",
+    "cron hooks": "ls -la /etc/cron.hourly/ 2>&1 | grep -i hwclock || echo NO_CRON",
+    "rtc devices": "ls -la /dev/rtc* 2>&1 || echo NO_RTC",
+    "rtc in dmesg": "dmesg 2>/dev/null | grep -i rtc | tail -n 20 || echo NO_DMESG_RTC",
+    "timedatectl": "timedatectl 2>&1 || echo NO_TIMEDATECTL",
+    "current date": "date -u",
+}
+
+
+def main() -> None:
+    for label, cmd in CHECKS.items():
+        print(f"\n===== {label} =====")
+        try:
+            res = host(cmd)
+            rc = res.get("return_code")
+            out = (res.get("stdout") or "").strip()
+            err = (res.get("stderr") or "").strip()
+            print(f"[return_code={rc}]")
+            if out:
+                print(out)
+            if err:
+                print("STDERR:", err)
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Recording reliability + diagnostics improvements for interval/continuous dives, plus GPS clock-sync hardening. Branched cleanly from `bh-0.4.4`.

- **First-frame gating** (`fix(recorder)`): the interval record clock no longer starts on `ipcam_start`; it waits until real frames are landing on disk (polled via `/rec/status` `frames_flowing`, with a 30 s safety timeout). This decouples recorded duration from variable RTSP handshake latency (previously 4–30 s), which was the root cause of inconsistent interval-video lengths.
- **Structured per-dive stream logging** (`feat(recorder)`): new `stream_log.jsonl` per dive captures `session_start` / `first_frame` / `fragment_open` / `pipeline_exit` / `pipeline_restart` / `session_stop` with wall-clock + monotonic stamps and negotiated caps (resolution, framerate, H.264 profile/level). `/rec/status` now also exposes `frames_flowing`, `first_frame_latency_s`, `frame_count`, and `stream_caps`.
- **Logs travel with the recordings** (`feat(finalize)`): finalize copies `doris.log*` and `dmesg.log*` into `<dive_dir>/logs/` so the full diagnostic bundle rides along on the operator's USB stick. A `logs` summary is added to `manifest.json`.
- **Timestamped output MP4s** (`feat(finalize)`): outputs are named `<recstart>_<phase>.mp4` (e.g. `20260528t171502_on_bottom.mp4`), where `recstart` is the UTC `YYYYMMDDtHHMMSS` of first frame on disk. Interval cycles use their own first-frame stamp; continuous chunks use footage-start + cumulative duration; descent/ascent use the phase's first-frame stamp. Files stay grouped by the per-dive `dive_<stamp>/` folder; pre-upgrade `.ts` lacking the stamp fall back to the historical `videoNN`/`chunkNN`/`<phase>` names. Storage's filename-timestamp fallback now also accepts the `t`/`T` separator.
- **GPS clock-sync hardening** (`feat(timesync)`): harden GPS clock sync for surface-only fix windows (adds `test_timesync.py` and `check_fake_hwclock.py`).

## Commits

- `805c173` fix(recorder): gate interval record clock on first frame
- `db8ce37` feat(recorder): structured per-dive stream/cadence logging
- `4f6c7b6` feat(finalize): copy doris/dmesg logs into the dive folder
- `f5a4f90` feat(finalize): name output MP4s by recording start time
- `d5eb359` feat(timesync): harden GPS clock sync for surface-only fix windows

## Test plan

- [ ] Interval dive: confirm each cycle's MP4 duration matches the configured record window (independent of connect latency) and is named `<recstart>_on_bottom.mp4`.
- [ ] Continuous dive: confirm 5-min chunks are named by cumulative `recstart` and play back losslessly.
- [ ] Descent/ascent: confirm single MP4s named `<recstart>_<phase>.mp4`.
- [ ] Verify `stream_log.jsonl` is written per dive and `/rec/status` exposes the new fields.
- [ ] Verify `<dive_dir>/logs/` contains `doris.log*` + `dmesg.log*` after finalize, and `manifest.json` has the `logs` summary.
- [ ] Confirm media manager + dive history still list/group recordings correctly (association is by mtime, not filename).
- [ ] Run `extension/backend/tests/test_timesync.py`; verify clock sync behaves correctly with a surface-only GPS fix window.

Built/tagged as `bh-0.4.5` for on-vehicle CI image.
