### PR TITLE
feat(dive-csv): comprehensive dive-data CSV export from mcap, with onboard USB generation

### DIFF
--- a/extension/backend/src/doris/routes/dive.py
+++ b/extension/backend/src/doris/routes/dive.py
@@ -541,6 +541,10 @@ def register_dive_routes(app: Robyn) -> None:
                 headers={"Content-Type": "application/json"},
             )
 
+        from ..services.mcap_telemetry import dive_csv_filename
+
+        download_name = dive_csv_filename(dive_data, dive_id)
+
         # Prefer a CSV already generated to USB at dive end -- serving it
         # is instant, whereas a fresh parse of a large .mcap can take tens
         # of seconds on the vehicle's Raspberry Pi.
@@ -556,7 +560,7 @@ def register_dive_routes(app: Robyn) -> None:
                     description=raw,
                     headers={
                         "Content-Type": "text/csv; charset=utf-8",
-                        "Content-Disposition": f'attachment; filename="{dive_id}_dive_data.csv"',
+                        "Content-Disposition": f'attachment; filename="{download_name}"',
                         "Content-Length": str(len(raw)),
                     },
                 )
@@ -588,7 +592,7 @@ def register_dive_routes(app: Robyn) -> None:
             description=raw,
             headers={
                 "Content-Type": "text/csv; charset=utf-8",
-                "Content-Disposition": f'attachment; filename="{dive_id}_dive_data.csv"',
+                "Content-Disposition": f'attachment; filename="{download_name}"',
                 "Content-Length": str(len(raw)),
             },
         )

--- a/extension/backend/src/doris/routes/dive.py
+++ b/extension/backend/src/doris/routes/dive.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from robyn import Response, Robyn
 
-from ..services import binlog
+from ..services import binlog, dive_csv_export
 from ..services import ip_camera_recorder as iprec
 from ..services.camera import CameraService
 from ..services.dive import DiveService
@@ -81,6 +81,7 @@ def _sync_mission_state_from_vehicle(status_dict: dict) -> None:
             updated = None
         if updated is not None:
             _schedule_binlog_archive(updated)
+            _schedule_csv_export(updated)
     if changed:
         try:
             MISSION_STATE_PATH.write_text(json.dumps(ms, indent=2, default=str))
@@ -173,6 +174,32 @@ def _schedule_binlog_archive(dive_file: Path) -> None:
             logger.info("BIN archive (%s): %s", dive_file.name, result)
         except Exception:
             logger.exception("BIN archive failed for %s", dive_file)
+
+    loop.create_task(_runner())
+
+
+def _schedule_csv_export(dive_file: Path) -> None:
+    """Fire-and-forget background dive-data CSV export to USB.
+
+    Parses the dive's ``.mcap`` once at dive end and writes the CSV to
+    USB so the "Export dive data" button can serve it instantly instead
+    of re-parsing on the request path.  Like the BIN archive this runs on
+    the request path's event loop and must never bubble failures up: a
+    missing USB drive or unreadable log just leaves the on-demand export
+    as the fallback.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("No running loop; skipping CSV export for %s", dive_file)
+        return
+
+    async def _runner() -> None:
+        try:
+            result = await dive_csv_export.export_dive_csv_to_usb(dive_file)
+            logger.info("CSV export (%s): %s", dive_file.name, result)
+        except Exception:
+            logger.exception("CSV export failed for %s", dive_file)
 
     loop.create_task(_runner())
 
@@ -376,6 +403,7 @@ def register_dive_routes(app: Robyn) -> None:
 
         if updated_dive_file is not None:
             _schedule_binlog_archive(updated_dive_file)
+            _schedule_csv_export(updated_dive_file)
 
         try:
             _set_mission_terminal_status("cancelled")
@@ -487,7 +515,8 @@ def register_dive_routes(app: Robyn) -> None:
 
     @app.get("/api/v1/dive/history/:dive_id/export/scientific.csv")
     async def dive_history_scientific_csv(request):
-        """CSV with dive metadata and time-series samples from the dive's primary .mcap."""
+        """CSV with a dive-data header plus per-cycle system + science telemetry
+        reassembled from the dive's primary .mcap."""
         dive_id = request.path_params.get("dive_id", "").strip()
         if not re.fullmatch(r"dive_\d{4}", dive_id):
             return Response(
@@ -512,9 +541,29 @@ def register_dive_routes(app: Robyn) -> None:
                 headers={"Content-Type": "application/json"},
             )
 
+        # Prefer a CSV already generated to USB at dive end -- serving it
+        # is instant, whereas a fresh parse of a large .mcap can take tens
+        # of seconds on the vehicle's Raspberry Pi.
+        cached = dive_csv_export.find_cached_csv(dive_data)
+        if cached is not None:
+            try:
+                raw = cached.read_bytes()
+            except OSError as e:
+                logger.warning("Cached CSV unreadable (%s); regenerating: %s", cached, e)
+            else:
+                return Response(
+                    status_code=200,
+                    description=raw,
+                    headers={
+                        "Content-Type": "text/csv; charset=utf-8",
+                        "Content-Disposition": f'attachment; filename="{dive_id}_dive_data.csv"',
+                        "Content-Length": str(len(raw)),
+                    },
+                )
+
         from ..services.mcap_telemetry import (
             McapSummary,
-            build_scientific_csv,
+            build_dive_csv,
             map_dive_stem_to_largest_mcap,
             summarize_mcap,
         )
@@ -532,14 +581,14 @@ def register_dive_routes(app: Robyn) -> None:
             except Exception as e:
                 logger.warning("MCAP summarize failed for %s: %s", mcap_path, e)
 
-        csv_text = build_scientific_csv(dive_data, summary, rel)
+        csv_text = build_dive_csv(dive_data, summary, rel)
         raw = csv_text.encode("utf-8")
         return Response(
             status_code=200,
             description=raw,
             headers={
                 "Content-Type": "text/csv; charset=utf-8",
-                "Content-Disposition": f'attachment; filename="{dive_id}_scientific.csv"',
+                "Content-Disposition": f'attachment; filename="{dive_id}_dive_data.csv"',
                 "Content-Length": str(len(raw)),
             },
         )
@@ -591,6 +640,43 @@ def register_dive_routes(app: Robyn) -> None:
             result = await binlog.archive_dive_bin_logs(path)
         except Exception as e:
             logger.exception("Manual BIN archive failed for %s", dive_id)
+            return Response(
+                status_code=500,
+                description=json.dumps({"error": str(e)}),
+                headers={"Content-Type": "application/json"},
+            )
+        return Response(
+            status_code=200,
+            description=json.dumps(result, default=str),
+            headers={"Content-Type": "application/json"},
+        )
+
+    @app.post("/api/v1/dive/history/:dive_id/export_csv_to_usb")
+    async def dive_history_export_csv_to_usb(request):
+        """Re-run the dive-data CSV export to USB for a past dive.
+
+        Useful when the USB drive was missing at dive end, or when the
+        operator wants to refresh the cached CSV.  Returns the same status
+        dict the background exporter writes into the dive record.
+        """
+        dive_id = request.path_params.get("dive_id", "").strip()
+        if not re.fullmatch(r"dive_\d{4}", dive_id):
+            return Response(
+                status_code=400,
+                description=json.dumps({"error": "Invalid dive id"}),
+                headers={"Content-Type": "application/json"},
+            )
+        path = DIVES_DIR / f"{dive_id}.json"
+        if not path.is_file():
+            return Response(
+                status_code=404,
+                description=json.dumps({"error": "Dive record not found"}),
+                headers={"Content-Type": "application/json"},
+            )
+        try:
+            result = await dive_csv_export.export_dive_csv_to_usb(path)
+        except Exception as e:
+            logger.exception("Manual CSV export failed for %s", dive_id)
             return Response(
                 status_code=500,
                 description=json.dumps({"error": str(e)}),

--- a/extension/backend/src/doris/services/dive_csv_export.py
+++ b/extension/backend/src/doris/services/dive_csv_export.py
@@ -29,7 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from . import usb_storage
-from .binlog import slug_for_dive, wait_until_quiescent
+from .binlog import wait_until_quiescent
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,7 @@ async def export_dive_csv_to_usb(dive_file: Path) -> dict:
     from .mcap_telemetry import (
         McapSummary,
         build_dive_csv,
+        dive_csv_filename,
         map_dive_stem_to_largest_mcap,
         summarize_mcap,
     )
@@ -159,8 +160,7 @@ async def export_dive_csv_to_usb(dive_file: Path) -> dict:
         _write_record(dive_file, record)
         return {"status": "skipped_no_usb"}
 
-    slug = slug_for_dive(record, dive_file)
-    dest = Path(usb_dir) / f"{slug}_dive_data.csv"
+    dest = Path(usb_dir) / dive_csv_filename(record, dive_file.stem)
     try:
         await asyncio.to_thread(_write_text_atomic, dest, csv_text)
     except Exception as e:

--- a/extension/backend/src/doris/services/dive_csv_export.py
+++ b/extension/backend/src/doris/services/dive_csv_export.py
@@ -1,0 +1,196 @@
+"""Post-dive dive-data CSV export to USB.
+
+After a dive ends (completed or cancelled), parse the dive's primary
+``.mcap`` and write the comprehensive dive-data CSV to the external USB
+drive.  This mirrors :mod:`binlog` (which archives ArduPilot ``.BIN``
+logs to USB on the same hook) and exists for two reasons:
+
+1. **Latency.** Parsing a multi-million-message ``.mcap`` takes tens of
+   seconds on the vehicle's Raspberry Pi.  Doing it once in the
+   background at dive end means the operator's "Export dive data" button
+   can serve the pre-generated file instantly instead of re-parsing on
+   the request path.
+2. **Durability.** The CSV lands on the USB stick alongside the BIN logs
+   and video, so it survives even when no laptop is connected and shows
+   up automatically in the Data tab (USB files are indexed as media).
+
+The ``.mcap`` remains the source of truth: the export is best-effort and
+idempotent, and the on-demand route always falls back to a fresh parse
+when no cached CSV is available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import usb_storage
+from .binlog import slug_for_dive, wait_until_quiescent
+
+logger = logging.getLogger(__name__)
+
+USB_SUBDIR = "dive_data"
+
+
+def _data_root() -> Path:
+    return Path(os.environ.get("DORIS_DATA_ROOT", "/tmp/storage"))
+
+
+def _set_export_status(
+    record: dict,
+    *,
+    status: str,
+    file: str | None = None,
+    error: str | None = None,
+) -> None:
+    record["csv_export_status"] = status
+    record["csv_exported_at"] = datetime.now(tz=timezone.utc).isoformat()
+    if file is not None:
+        record["csv_export_file"] = file
+    elif status != "ok":
+        # Drop a stale path when the latest attempt did not produce a file
+        # so the route doesn't try to serve a file that is gone.
+        record.pop("csv_export_file", None)
+    if error is not None:
+        record["csv_export_error"] = error
+    else:
+        record.pop("csv_export_error", None)
+
+
+def _write_record(dive_file: Path, record: dict) -> None:
+    import json
+
+    try:
+        dive_file.write_text(json.dumps(record, indent=2, default=str))
+    except OSError as e:
+        logger.warning("CSV export: failed to write dive record %s: %s", dive_file, e)
+
+
+def _write_text_atomic(dest: Path, text: str) -> None:
+    """Write ``text`` (UTF-8) to ``dest`` atomically; create parent dirs."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        tmp.write_bytes(text.encode("utf-8"))
+        os.replace(tmp, dest)
+    finally:
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+
+
+async def export_dive_csv_to_usb(dive_file: Path) -> dict:
+    """Parse this dive's ``.mcap`` and write its dive-data CSV to USB.
+
+    Idempotent: re-running replaces ``csv_export_*`` on the dive record
+    with the latest result.  Returns a JSON-friendly status dict.  Never
+    raises -- all failures are captured in the returned ``status``.
+    """
+    import json
+
+    # Lazy imports to avoid import cycles (storage imports services too).
+    from .mcap_telemetry import (
+        McapSummary,
+        build_dive_csv,
+        map_dive_stem_to_largest_mcap,
+        summarize_mcap,
+    )
+    from .storage import (
+        _load_dive_windows,
+        media_download_id_from_abs_path,
+    )
+
+    try:
+        record = json.loads(dive_file.read_text())
+    except OSError as e:
+        logger.warning("CSV export: cannot read %s: %s", dive_file, e)
+        return {"status": "error", "error": f"read_dive: {e}"}
+    except json.JSONDecodeError as e:
+        logger.warning("CSV export: invalid JSON in %s: %s", dive_file, e)
+        return {"status": "error", "error": f"parse_dive: {e}"}
+
+    data_root = _data_root()
+    dive_id = dive_file.stem  # e.g. "dive_0066"
+
+    # Locate this dive's primary .mcap via the same window mapping the
+    # history list and on-demand export use.
+    try:
+        windows = _load_dive_windows(data_root)
+        mcap_map = map_dive_stem_to_largest_mcap(data_root, windows)
+    except Exception as e:
+        logger.warning("CSV export: mcap mapping failed for %s: %s", dive_id, e)
+        mcap_map = {}
+    mcap_path = mcap_map.get(dive_id)
+
+    rel: str | None = None
+    summary = McapSummary()
+    if mcap_path is not None:
+        rel = media_download_id_from_abs_path(mcap_path, data_root)
+        # The recorder may still be flushing the file at dive end; wait for
+        # it to go idle before reading so we don't parse a half-written log.
+        with contextlib.suppress(Exception):
+            await wait_until_quiescent(mcap_path)
+        try:
+            summary = await asyncio.to_thread(summarize_mcap, mcap_path)
+        except Exception as e:
+            logger.warning("CSV export: summarize failed for %s: %s", mcap_path, e)
+            _set_export_status(record, status="error", error=f"summarize: {e}")
+            _write_record(dive_file, record)
+            return {"status": "error", "error": f"summarize: {e}"}
+    else:
+        logger.info("CSV export: no .mcap matched %s", dive_id)
+
+    try:
+        csv_text = build_dive_csv(record, summary, rel)
+    except Exception as e:
+        logger.warning("CSV export: build_dive_csv failed for %s: %s", dive_id, e)
+        _set_export_status(record, status="error", error=f"build: {e}")
+        _write_record(dive_file, record)
+        return {"status": "error", "error": f"build: {e}"}
+
+    usb_dir = usb_storage.get_recording_dir_if_available(USB_SUBDIR)
+    if usb_dir is None:
+        logger.warning("CSV export: USB unavailable; skipping write for %s", dive_id)
+        _set_export_status(record, status="skipped_no_usb")
+        _write_record(dive_file, record)
+        return {"status": "skipped_no_usb"}
+
+    slug = slug_for_dive(record, dive_file)
+    dest = Path(usb_dir) / f"{slug}_dive_data.csv"
+    try:
+        await asyncio.to_thread(_write_text_atomic, dest, csv_text)
+    except Exception as e:
+        logger.exception("CSV export: write failed for %s", dive_id)
+        _set_export_status(record, status="error", error=f"write: {e}")
+        _write_record(dive_file, record)
+        return {"status": "error", "error": f"write: {e}"}
+
+    rows = len(summary.frames)
+    logger.info(
+        "CSV export: wrote %s (%d rows, %d bytes)",
+        dest,
+        rows,
+        len(csv_text.encode("utf-8")),
+    )
+    _set_export_status(record, status="ok", file=str(dest))
+    record["csv_export_rows"] = rows
+    _write_record(dive_file, record)
+    return {"status": "ok", "file": str(dest), "rows": rows}
+
+
+def find_cached_csv(record: dict) -> Path | None:
+    """Return the pre-generated USB CSV for this dive if it still exists."""
+    raw = record.get("csv_export_file")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    p = Path(raw)
+    try:
+        if p.is_file() and p.stat().st_size > 0:
+            return p
+    except OSError:
+        return None
+    return None

--- a/extension/backend/src/doris/services/mcap_telemetry.py
+++ b/extension/backend/src/doris/services/mcap_telemetry.py
@@ -1,9 +1,15 @@
-"""Best-effort telemetry extraction from recorder .mcap files.
+"""Telemetry extraction from recorder .mcap files for the dive CSV export.
 
-DORIS Lua publishes mavlink NAMED_VALUE_FLOAT-style names such as MAX_DPTH, DEPTH,
-and MIN_TEMP. Messages may be wrapped in ROS/JSON/other encodings; we scan each
-record payload for those name patterns and little-endian floats that precede the
-10-byte MAVLink name field (uint32 time + float value + char[10] name).
+The BlueOS recorder stores each MAVLink message as a JSON record on its own
+topic, e.g. ``mavlink/1/1/NAMED_VALUE_FLOAT`` or ``mavlink/1/1/SCALED_PRESSURE``
+with a ``{"header": {...}, "message": {...}}`` payload.  We decode the subset
+of autopilot (system 1, component 1) messages that carry relevant system and
+science data and merge those asynchronous streams into fixed UTC time buckets
+so the export has one row per timestamp and one column per signal.
+
+DORIS-specific telemetry arrives as NAMED_VALUE_FLOAT bursts published by
+``backend/scripts/doris.lua`` (STATE, DEPTH, MAX_DPTH, MIN_TEMP, ...); standard
+ArduSub messages provide position, attitude, pressure and power.
 """
 
 from __future__ import annotations
@@ -12,7 +18,7 @@ import csv
 import io
 import json
 import math
-import struct
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -63,247 +69,589 @@ def map_dive_stem_to_largest_mcap(root: Path, windows: list[Any]) -> dict[str, P
     return {stem: p for stem, (_, p) in best.items()}
 
 
-def _pad_name_10(name: str) -> bytes:
-    b = name.encode("ascii", errors="ignore")[:10]
-    return b + b"\x00" * (10 - len(b))
+# ── column model ─────────────────────────────────────────────────────────────
+
+# DORIS NAMED_VALUE_FLOAT name -> CSV column (see update_telemetry in doris.lua).
+# The descent/ascent rate floats are intentionally omitted: vertical motion is
+# represented by the single signed vertical_velocity_mps column (VFR_HUD.climb).
+NAMED_FLOAT_COLUMNS: dict[str, str] = {
+    "STATE": "mission_state",
+    "MSN_TIME": "mission_time_s",
+    "BTM_TIME": "bottom_time_s",
+    "DEPTH": "depth_m",
+    "RELAY": "relay_active",
+    "BATT_V": "battery_voltage_v",
+}
+
+# NAMED_VALUE_FLOATs that are deliberately excluded from the export:
+#   * ArduSub manual-control pilot inputs (not relevant to a passive lander)
+#   * DORIS floats superseded by other columns -- MAX_DPTH (max depth is in the
+#     header only), DSC_RATE/ASC_RATE/ASC_VEL (replaced by vertical_velocity_mps)
+#     and BATT_PCT (dropped).
+# Everything else is captured dynamically (see _sensor_column).
+NAMED_FLOAT_DENYLIST: frozenset[str] = frozenset(
+    {
+        # ArduSub pilot inputs
+        "CamTilt",
+        "CamPan",
+        "TetherTrn",
+        "Lights1",
+        "Lights2",
+        "PilotGain",
+        "InputHold",
+        "RollPitch",
+        "RFTarget",
+        # DORIS floats intentionally not exported as time-series columns
+        "MAX_DPTH",
+        "DSC_RATE",
+        "ASC_RATE",
+        "ASC_VEL",
+        "BATT_PCT",
+        # MIN_TEMP is the internal baro min; environmental temperature comes
+        # from the external probe instead (see min_external_temperature_c).
+        "MIN_TEMP",
+    }
+)
+
+# Friendly column names for recognized sensor NAMED_VALUE_FLOATs (keyed by the
+# uppercased mavlink name).  Any other non-denylisted named float is still
+# captured dynamically under its own sanitized name, so new sensors added to
+# the MAVLink stream (e.g. a CO2/oxygen probe) appear in the CSV automatically
+# without a code change -- see _sensor_column().
+SENSOR_FLOAT_ALIASES: dict[str, str] = {
+    "COND": "conductivity",
+    "CONDUCT": "conductivity",
+    "SALINITY": "salinity",
+    "CO2": "co2",
+    "O2": "oxygen",
+    "OXY": "oxygen",
+    "OXYGEN": "oxygen",
+    "DOXY": "oxygen",
+}
 
 
-def _values_before_name(blob: bytes, name: str) -> list[float]:
-    """Extract float values immediately before a 10-byte MAVLink-style name field."""
-    needle = _pad_name_10(name)
-    if len(needle) != 10:
-        return []
-    vals: list[float] = []
-    start = 0
-    while True:
-        i = blob.find(needle, start)
-        if i < 0:
-            break
-        if i >= 4:
-            (v,) = struct.unpack_from("<f", blob, i - 4)
-            if math.isfinite(v):
-                vals.append(v)
-        start = i + 1
-    return vals
+def _sensor_column(name: str) -> str | None:
+    """Map an unknown NAMED_VALUE_FLOAT name to a CSV column.
+
+    Recognized sensors get a friendly alias; anything else is sanitized to a
+    lowercase snake-ish identifier so future named floats are captured as-is.
+    """
+    alias = SENSOR_FLOAT_ALIASES.get(name.upper())
+    if alias:
+        return alias
+    safe = re.sub(r"[^0-9a-z]+", "_", name.lower()).strip("_")
+    return safe or None
+
+# Inclusive sanity bounds; out-of-range samples are dropped so a corrupt or
+# sentinel value (e.g. 65535) never reaches the CSV.  Columns without an entry
+# (string columns) are passed through untouched.
+COLUMN_BOUNDS: dict[str, tuple[float, float]] = {
+    "mission_state": (-1.0, 4.0),
+    "mission_time_s": (0.0, 1.0e7),
+    "bottom_time_s": (0.0, 1.0e7),
+    "depth_m": (-10.0, 15_000.0),
+    "vertical_velocity_mps": (-50.0, 50.0),
+    "internal_pressure_hpa": (0.0, 20_000.0),
+    "internal_temperature_c": (-100.0, 150.0),
+    "external_pressure_hpa": (0.0, 20_000.0),
+    "external_temperature_c": (-100.0, 150.0),
+    "latitude": (-90.0, 90.0),
+    "longitude": (-180.0, 180.0),
+    "heading_trueN_degrees": (0.0, 360.0),
+    "ground_speed_mps": (-50.0, 50.0),
+    "gps_satellites": (0.0, 255.0),
+    "roll_deg": (-360.0, 360.0),
+    "pitch_deg": (-360.0, 360.0),
+    "yaw_deg": (-360.0, 360.0),
+    "relay_active": (0.0, 1.0),
+    "light_level_percent": (0.0, 100.0),
+    "battery_voltage_v": (0.0, 100.0),
+    "battery_current_a": (-1_000.0, 1_000.0),
+}
+
+# Ordered numeric/string signal columns stored per time bucket.
+SIGNAL_COLUMNS: list[str] = [
+    "mission_state",
+    "mission_time_s",
+    "bottom_time_s",
+    "depth_m",
+    "vertical_velocity_mps",
+    "internal_pressure_hpa",
+    "internal_temperature_c",
+    "external_pressure_hpa",
+    "external_temperature_c",
+    "latitude",
+    "longitude",
+    "heading_trueN_degrees",
+    "ground_speed_mps",
+    "gps_fix_type",
+    "gps_satellites",
+    "roll_deg",
+    "pitch_deg",
+    "yaw_deg",
+    "relay_active",
+    "light_level_percent",
+    "battery_voltage_v",
+    "battery_current_a",
+]
+
+# Columns produced by the fixed extractors; anything else a message yields is a
+# dynamically-discovered sensor column (appended after these in the CSV).
+_KNOWN_COLUMNS: frozenset[str] = frozenset(SIGNAL_COLUMNS)
+
+# CSV header labels with units fully spelled out.  Internal logic keeps the
+# short keys above; this map is applied only when writing the time-series
+# header row.  Columns not listed (e.g. dynamically-discovered sensors) fall
+# back to their raw name.
+COLUMN_DISPLAY_NAMES: dict[str, str] = {
+    "mission_time_s": "mission_time_seconds",
+    "bottom_time_s": "bottom_time_seconds",
+    "depth_m": "depth_meters",
+    "vertical_velocity_mps": "vertical_velocity_meters_per_second",
+    "internal_pressure_hpa": "internal_pressure_hectopascals",
+    "internal_temperature_c": "internal_temperature_celsius",
+    "external_pressure_hpa": "external_pressure_hectopascals",
+    "external_temperature_c": "external_temperature_celsius",
+    "latitude": "latitude_degrees",
+    "longitude": "longitude_degrees",
+    "ground_speed_mps": "ground_speed_meters_per_second",
+    "roll_deg": "roll_degrees",
+    "pitch_deg": "pitch_degrees",
+    "yaw_deg": "yaw_degrees",
+    "battery_voltage_v": "battery_voltage_volts",
+    "battery_current_a": "battery_current_amperes",
+}
+
+# DORIS_STATE numeric -> human label (mirrors STATE_* constants in doris.lua).
+STATE_LABELS: dict[int, str] = {
+    -1: "CONFIG",
+    0: "MISSION_START",
+    1: "DESCENT",
+    2: "ON_BOTTOM",
+    3: "ASCENT",
+    4: "RECOVERY",
+}
+
+_RAD_TO_DEG = 180.0 / math.pi
+# Bucket asynchronous streams into 1-second rows keyed by recorder UTC time.
+BUCKET_NS = 1_000_000_000
 
 
-def _scan_named_floats(blob: bytes) -> dict[str, list[float]]:
-    out: dict[str, list[float]] = {}
-    for name in ("MAX_DPTH", "DEPTH", "MIN_TEMP", "TEMP"):
-        vs = _values_before_name(blob, name)
-        if vs:
-            out[name] = vs
+def _f(value: Any) -> float | None:
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if math.isfinite(out) else None
+
+
+# Lights are commanded over the ArduSub default lights PWM range (1100-1900 us,
+# off..full); express the level as 0-100% of that span (values are clamped).
+_LIGHT_PWM_MIN = 1100.0
+_LIGHT_PWM_MAX = 1900.0
+
+
+def _pwm_to_percent(us: float) -> float:
+    pct = (us - _LIGHT_PWM_MIN) / (_LIGHT_PWM_MAX - _LIGHT_PWM_MIN) * 100.0
+    return round(max(0.0, min(100.0, pct)), 1)
+
+
+def _extract_message(msg_type: str, m: dict[str, Any]) -> dict[str, float | str]:
+    """Map one decoded MAVLink message to {column: value} signal pairs."""
+    out: dict[str, float | str] = {}
+    if msg_type == "NAMED_VALUE_FLOAT":
+        name = str(m.get("name", "")).replace("\x00", "").strip()
+        v = _f(m.get("value"))
+        if name and v is not None:
+            if name in NAMED_FLOAT_COLUMNS:
+                out[NAMED_FLOAT_COLUMNS[name]] = v
+            elif name not in NAMED_FLOAT_DENYLIST:
+                col = _sensor_column(name)
+                if col is not None:
+                    out[col] = v
+    elif msg_type == "SCALED_PRESSURE":
+        # Pressure 1: internal barometer inside the sealed housing.
+        pa = _f(m.get("press_abs"))
+        if pa is not None:
+            out["internal_pressure_hpa"] = pa
+        t = _f(m.get("temperature"))
+        if t is not None:
+            out["internal_temperature_c"] = t / 100.0
+    elif msg_type == "SCALED_PRESSURE2":
+        # Pressure 2: external pressure sensor.  Its on-board temperature
+        # duplicates the dedicated external probe below, so only pressure is
+        # kept here.
+        pa = _f(m.get("press_abs"))
+        if pa is not None:
+            out["external_pressure_hpa"] = pa
+    elif msg_type == "SCALED_PRESSURE3":
+        # Pressure 3: dedicated external temperature probe (press_abs unused).
+        t = _f(m.get("temperature"))
+        if t is not None:
+            out["external_temperature_c"] = t / 100.0
+    elif msg_type == "GLOBAL_POSITION_INT":
+        lat = _f(m.get("lat"))
+        lon = _f(m.get("lon"))
+        if lat is not None:
+            out["latitude"] = lat / 1.0e7
+        if lon is not None:
+            out["longitude"] = lon / 1.0e7
+        hdg = _f(m.get("hdg"))
+        if hdg is not None and hdg != 65535:
+            # EKF yaw (GLOBAL_POSITION_INT.hdg).  ArduPilot applies the
+            # magnetic declination (COMPASS_DEC, auto-set via COMPASS_AUTODEC)
+            # so this is referenced to TRUE north, not magnetic.
+            out["heading_trueN_degrees"] = hdg / 100.0
+    elif msg_type == "GPS_RAW_INT":
+        sats = _f(m.get("satellites_visible"))
+        if sats is not None and sats != 255:
+            out["gps_satellites"] = sats
+        # GPS course-over-ground (cog) is intentionally not exported: it is
+        # only meaningful for horizontal surface travel and reads 0 for a
+        # vertical profiler.  Heading comes from the compass-aided
+        # GLOBAL_POSITION_INT.hdg -> mag_heading_deg instead.
+        fix = m.get("fix_type")
+        if isinstance(fix, dict):
+            fix = fix.get("type")
+        if isinstance(fix, str):
+            out["gps_fix_type"] = fix.replace("GPS_FIX_TYPE_", "")
+    elif msg_type == "VFR_HUD":
+        climb = _f(m.get("climb"))
+        if climb is not None:
+            # Single signed vertical-velocity signal: positive = up (ascending),
+            # negative = down (descending).
+            out["vertical_velocity_mps"] = climb
+        gs = _f(m.get("groundspeed"))
+        if gs is not None:
+            out["ground_speed_mps"] = gs
+    elif msg_type == "ATTITUDE":
+        for key, col in (("roll", "roll_deg"), ("pitch", "pitch_deg"), ("yaw", "yaw_deg")):
+            rad = _f(m.get(key))
+            if rad is not None:
+                out[col] = rad * _RAD_TO_DEG
+    elif msg_type == "BATTERY_STATUS":
+        volts = m.get("voltages")
+        if isinstance(volts, list) and volts:
+            mv = _f(volts[0])
+            if mv is not None and mv != 65535:
+                out["battery_voltage_v"] = mv / 1000.0
+        cur = _f(m.get("current_battery"))
+        if cur is not None and cur >= 0:
+            out["battery_current_a"] = cur / 100.0
+    elif msg_type == "RC_CHANNELS":
+        # ArduSub Lights 1 is on RC input channel 9.  Map the PWM (us) to a
+        # 0-100% light level.  0 / 65535 mean "channel not available".
+        raw = _f(m.get("chan9_raw"))
+        if raw is not None and raw > 0 and raw != 65535:
+            out["light_level_percent"] = _pwm_to_percent(raw)
     return out
 
 
-def _try_json_coords(blob: bytes) -> tuple[float | None, float | None]:
-    """If payload is JSON, try to read latitude/longitude-like keys."""
-    try:
-        t = blob.decode("utf-8", errors="strict")
-    except UnicodeDecodeError:
-        return None, None
-    t = t.strip()
-    if not t or t[0] not in "{[":
-        return None, None
-    try:
-        obj = json.loads(t)
-    except json.JSONDecodeError:
-        return None, None
-
-    def walk(o: Any) -> tuple[float | None, float | None]:
-        if isinstance(o, dict):
-            lat = o.get("latitude", o.get("lat"))
-            lon = o.get("longitude", o.get("lon", o.get("lng")))
-            try:
-                if lat is not None and lon is not None:
-                    return float(lat), float(lon)
-            except (TypeError, ValueError):
-                pass
-            for v in o.values():
-                la, lo = walk(v)
-                if la is not None and lo is not None:
-                    return la, lo
-        elif isinstance(o, list):
-            for it in o:
-                la, lo = walk(it)
-                if la is not None and lo is not None:
-                    return la, lo
-        return None, None
-
-    return walk(obj)
+# Message types we decode (component 1, the autopilot).  NAMED_VALUE_FLOAT is
+# matched specially since DORIS publishes its science/system signals there.
+_DECODED_TYPES = frozenset(
+    {
+        "NAMED_VALUE_FLOAT",
+        "SCALED_PRESSURE",
+        "SCALED_PRESSURE2",
+        "SCALED_PRESSURE3",
+        "GLOBAL_POSITION_INT",
+        "GPS_RAW_INT",
+        "VFR_HUD",
+        "ATTITUDE",
+        "BATTERY_STATUS",
+        "RC_CHANNELS",
+    }
+)
 
 
 @dataclass
-class TelemetrySample:
+class TelemetryFrame:
+    """One reassembled time bucket: a UTC timestamp + the latest signals in it."""
+
     log_time_ns: int
-    depth_m: float | None = None
-    temperature_c: float | None = None
-    lat: float | None = None
-    lon: float | None = None
+    values: dict[str, float | str] = field(default_factory=dict)
 
 
 @dataclass
 class McapSummary:
-    """Aggregates used for dive history and CSV export."""
+    """Aggregates + per-bucket frames used for dive history and CSV export."""
 
     max_depth_m: float | None = None
-    log_max_depth_m: float | None = None
-    min_temperature_c: float | None = None
-    samples: list[TelemetrySample] = field(default_factory=list)
+    min_external_temperature_c: float | None = None
+    min_battery_voltage_v: float | None = None
+    max_satellites: int | None = None
+    frames: list[TelemetryFrame] = field(default_factory=list)
     last_lat: float | None = None
     last_lon: float | None = None
     messages_seen: int = 0
+    # Magnetic declination the autopilot applied to derive true heading
+    # (COMPASS_DEC, converted to degrees) and whether it was auto-set
+    # (COMPASS_AUTODEC).  Read from the PARAM_VALUE stream.
+    compass_declination_deg: float | None = None
+    compass_autodec: int | None = None
+    # Dynamically-discovered sensor columns (e.g. conductivity, co2, oxygen)
+    # that aren't part of the fixed column set, sorted for stable output.
+    extra_columns: list[str] = field(default_factory=list)
 
 
-_MAX_MESSAGES = 400_000
+# Cap parsed (decoded) messages so a pathologically long recording can't stall
+# the request path; 2M decoded messages already covers a multi-hour dive.
+_MAX_DECODED = 2_000_000
 
 
 def summarize_mcap(path: Path) -> McapSummary:
-    """Parse one .mcap file; tolerates missing or non-mavlink data."""
+    """Parse one .mcap file into time-bucketed telemetry frames.
+
+    Tolerant of missing or unexpected data: anything that fails to decode is
+    skipped and an empty summary is returned on a hard read error.
+    """
     summary = McapSummary()
-    max_depth = 0.0
-    max_d_max = 0.0
-    has_depth = False
-    has_max_d = False
-    min_temp: float | None = None
-    lat: float | None = None
-    lon: float | None = None
+    # bucket_ns -> {column: (value, log_time_ns)} keeping the latest sample.
+    buckets: dict[int, dict[str, tuple[float | str, int]]] = {}
+    dynamic_cols: set[str] = set()
+    decoded = 0
 
     try:
         with path.open("rb") as f:
             reader = make_reader(f)
-            for _schema, _channel, message in reader.iter_messages():
+            for _schema, channel, message in reader.iter_messages():
                 summary.messages_seen += 1
-                if summary.messages_seen > _MAX_MESSAGES:
-                    break
-                blob = message.data
-                if not blob:
+                topic = channel.topic
+                # Autopilot messages only (system 1, component 1).
+                if not topic.startswith("mavlink/1/1/"):
                     continue
+                msg_type = topic.rsplit("/", 1)[-1]
+                if msg_type == "PARAM_VALUE":
+                    try:
+                        pm = json.loads(message.data)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        continue
+                    pmsg = pm.get("message") if isinstance(pm, dict) else None
+                    if isinstance(pmsg, dict):
+                        _extract_param(summary, pmsg)
+                    continue
+                if msg_type not in _DECODED_TYPES:
+                    continue
+                decoded += 1
+                if decoded > _MAX_DECODED:
+                    break
+                try:
+                    payload = json.loads(message.data)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                m = payload.get("message") if isinstance(payload, dict) else None
+                if not isinstance(m, dict):
+                    continue
+                signals = _extract_message(msg_type, m)
+                if not signals:
+                    continue
+
                 lt = int(message.log_time)
-                nf = _scan_named_floats(blob)
-                row = TelemetrySample(log_time_ns=lt)
-                if "DEPTH" in nf:
-                    v = nf["DEPTH"][-1]
-                    if math.isfinite(v) and 0 <= v < 15_000:
-                        row.depth_m = v
-                        max_depth = max(max_depth, v)
-                        has_depth = True
-                if "MAX_DPTH" in nf:
-                    v = nf["MAX_DPTH"][-1]
-                    if math.isfinite(v) and 0 <= v < 15_000:
-                        row.depth_m = row.depth_m or v
-                        max_d_max = max(max_d_max, v)
-                        has_max_d = True
-                if "MIN_TEMP" in nf:
-                    v = nf["MIN_TEMP"][-1]
-                    if math.isfinite(v) and -100 < v < 60:
-                        row.temperature_c = v
-                        min_temp = v if min_temp is None else min(min_temp, v)
-                elif "TEMP" in nf:
-                    v = nf["TEMP"][-1]
-                    if math.isfinite(v) and -100 < v < 60:
-                        row.temperature_c = v
-                        min_temp = v if min_temp is None else min(min_temp, v)
-
-                jlat, jlon = _try_json_coords(blob)
-                if jlat is not None and jlon is not None:
-                    row.lat, row.lon = jlat, jlon
-                    lat, lon = jlat, jlon
-
-                if (
-                    row.depth_m is not None
-                    or row.temperature_c is not None
-                    or (row.lat is not None and row.lon is not None)
-                ):
-                    summary.samples.append(row)
-
+                bkey = lt // BUCKET_NS
+                slot = buckets.setdefault(bkey, {})
+                for col, val in signals.items():
+                    bounds = COLUMN_BOUNDS.get(col)
+                    if bounds is not None and (
+                        not isinstance(val, (int, float)) or not (bounds[0] <= val <= bounds[1])
+                    ):
+                        continue
+                    prev = slot.get(col)
+                    if prev is None or lt >= prev[1]:
+                        slot[col] = (val, lt)
+                    if col not in _KNOWN_COLUMNS:
+                        dynamic_cols.add(col)
+                    _update_aggregates(summary, col, val)
     except Exception:
         return McapSummary()
 
-    if has_max_d:
-        summary.log_max_depth_m = max_d_max
-    if has_depth:
-        summary.max_depth_m = max_depth
-    if has_max_d and has_depth:
-        summary.max_depth_m = max(max_depth, max_d_max)
-    elif has_max_d and not has_depth:
-        summary.max_depth_m = max_d_max
-    summary.min_temperature_c = min_temp
-    summary.last_lat = lat
-    summary.last_lon = lon
+    summary.extra_columns = sorted(dynamic_cols)
+    for bkey in sorted(buckets):
+        slot = buckets[bkey]
+        frame = TelemetryFrame(log_time_ns=bkey * BUCKET_NS)
+        for col, (val, _ts) in slot.items():
+            frame.values[col] = val
+        summary.frames.append(frame)
     return summary
 
 
+def _update_aggregates(summary: McapSummary, col: str, val: float | str) -> None:
+    if not isinstance(val, (int, float)):
+        return
+    if col == "depth_m":
+        summary.max_depth_m = val if summary.max_depth_m is None else max(summary.max_depth_m, val)
+    elif col == "external_temperature_c":
+        summary.min_external_temperature_c = (
+            val
+            if summary.min_external_temperature_c is None
+            else min(summary.min_external_temperature_c, val)
+        )
+    elif col == "battery_voltage_v" and val > 1.0:
+        summary.min_battery_voltage_v = (
+            val if summary.min_battery_voltage_v is None else min(summary.min_battery_voltage_v, val)
+        )
+    elif col == "gps_satellites":
+        iv = int(val)
+        summary.max_satellites = iv if summary.max_satellites is None else max(summary.max_satellites, iv)
+    elif col == "latitude":
+        summary.last_lat = val
+    elif col == "longitude":
+        summary.last_lon = val
+
+
+def _extract_param(summary: McapSummary, m: dict[str, Any]) -> None:
+    """Capture compass declination params from a PARAM_VALUE message.
+
+    ArduPilot derives ``heading_trueN_degrees`` (GLOBAL_POSITION_INT.hdg, the
+    EKF yaw) referenced to true north by applying ``COMPASS_DEC``.  We surface
+    the declination it used (and whether it was auto-set) in the CSV header.
+    """
+    pid = str(m.get("param_id", "")).replace("\x00", "").strip()
+    if pid == "COMPASS_DEC":
+        rad = _f(m.get("param_value"))
+        if rad is not None:
+            summary.compass_declination_deg = round(math.degrees(rad), 3)
+    elif pid == "COMPASS_AUTODEC":
+        v = _f(m.get("param_value"))
+        if v is not None:
+            summary.compass_autodec = int(v)
+
+
+# ── CSV export ─────────────────────────────────────────────────────────────
+
+
 def _ns_to_utc_iso(ns: int) -> str:
-    sec = ns / 1e9
-    dt = datetime.fromtimestamp(sec, tz=timezone.utc)
-    return dt.isoformat()
+    # No timezone offset: every timestamp in this file is UTC (the column is
+    # named timestamp_utc), so a trailing "+00:00" is just noise.
+    return datetime.fromtimestamp(ns / 1e9, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
 
 
-def build_scientific_csv(
+def _strip_utc_offset(value: Any) -> str:
+    """Drop a trailing UTC offset / 'Z' from an ISO timestamp for display.
+
+    Header timestamps are already labeled ``*_utc``; the offset is redundant.
+    """
+    s = str(value or "")
+    if s.endswith("+00:00"):
+        return s[:-6]
+    if s.endswith("Z"):
+        return s[:-1]
+    return s
+
+
+def _to_float(value: Any) -> float | None:
+    return _f(value)
+
+
+def _cell(value: float | str | None) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, str):
+        return value
+    return f"{value:g}"
+
+
+# gps_fix_type values (GPS_FIX_TYPE_* prefix already stripped) that mean the
+# receiver has no horizontal position lock, so any latitude/longitude in that
+# bucket is stale and must not be reported as a real coordinate.
+_NO_FIX_LABELS: frozenset[str] = frozenset({"NO_GPS", "NO_FIX"})
+
+
+def _has_no_gps_fix(frame_values: dict[str, float | str]) -> bool:
+    fix = frame_values.get("gps_fix_type")
+    return isinstance(fix, str) and fix in _NO_FIX_LABELS
+
+
+def _duration_label(started: str | None, ended: str | None) -> str:
+    """H:MM:SS between two ISO-8601 timestamps, or '' if unavailable."""
+    if not started or not ended:
+        return ""
+    try:
+        a = datetime.fromisoformat(str(started))
+        b = datetime.fromisoformat(str(ended))
+    except ValueError:
+        return ""
+    secs = int((b - a).total_seconds())
+    if secs < 0:
+        return ""
+    h, rem = divmod(secs, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}"
+
+
+def build_dive_csv(
     dive_record: dict[str, Any],
     summary: McapSummary,
     mcap_rel: str | None,
 ) -> str:
-    """Build CSV text: metadata rows then time series."""
-    start_lat = dive_record.get("latitude")
-    start_lon = dive_record.get("longitude")
-    try:
-        s_lat = float(start_lat) if start_lat is not None else None
-    except (TypeError, ValueError):
-        s_lat = None
-    try:
-        s_lon = float(start_lon) if start_lon is not None else None
-    except (TypeError, ValueError):
-        s_lon = None
+    """Build the dive CSV: a dive-data header section then per-second telemetry.
 
-    # Ending GPS: last position seen in the log (not duplicated from start if unknown).
+    Section 1 (DIVE DATA): key/value metadata from the dive record plus
+    aggregates computed from the linked .mcap.  Section 2 (TIME SERIES): one row
+    per 1-second UTC bucket covering system data (state, relay, battery,
+    attitude, rates) and science data (depth, temperature, pressure, GPS).
+    """
+    s_lat = _to_float(dive_record.get("latitude"))
+    s_lon = _to_float(dive_record.get("longitude"))
     end_lat = summary.last_lat
     end_lon = summary.last_lon
-
     started = dive_record.get("started_at")
     ended = dive_record.get("ended_at")
     dive_name = str(dive_record.get("dive_name") or "").strip()
 
     buf = io.StringIO()
-    w = csv.writer(buf)
-    w.writerow(["doris_scientific_export", "v1"])
+    # Pin the row terminator to a single "\n"; csv's default "\r\n" turns into
+    # "\r\r\n" once written/served in text mode, which shows up as a blank row
+    # between every line in Excel.
+    w = csv.writer(buf, lineterminator="\n")
+
+    # ── Section 1: dive data ──
+    w.writerow(["# DIVE DATA"])
+    w.writerow(["doris_dive_export", "v2"])
     w.writerow(["dive_name", dive_name])
+    w.writerow(["user_name", str(dive_record.get("username") or "")])
+    w.writerow(["configuration", str(dive_record.get("configuration") or "")])
+    w.writerow(["status", str(dive_record.get("status") or "")])
+    w.writerow(["profile_id", str(dive_record.get("profile_id") or "")])
+    w.writerow(["started_at_utc", _strip_utc_offset(started)])
+    w.writerow(["ended_at_utc", _strip_utc_offset(ended)])
+    w.writerow(["duration", _duration_label(started, ended)])
+    w.writerow(["start_latitude", _cell(s_lat)])
+    w.writerow(["start_longitude", _cell(s_lon)])
+    w.writerow(["end_latitude", _cell(end_lat)])
+    w.writerow(["end_longitude", _cell(end_lon)])
+    w.writerow(["max_depth_from_log_meters", _cell(summary.max_depth_m)])
+    w.writerow(["min_external_temperature_celsius", _cell(summary.min_external_temperature_c)])
+    w.writerow(["min_battery_voltage_volts", _cell(summary.min_battery_voltage_v)])
+    w.writerow(["max_gps_satellites", _cell(summary.max_satellites)])
+    w.writerow(["compass_declination_degrees", _cell(summary.compass_declination_deg)])
+    w.writerow(["compass_autodec", _cell(summary.compass_autodec)])
     w.writerow(["mcap_file", mcap_rel or ""])
-    w.writerow(["started_at_utc", str(started or "")])
-    w.writerow(["ended_at_utc", str(ended or "")])
-    w.writerow(["max_depth_from_log_m", summary.max_depth_m if summary.max_depth_m is not None else ""])
-    w.writerow(["min_temperature_from_log_c", summary.min_temperature_c if summary.min_temperature_c is not None else ""])
-    w.writerow(["start_latitude", s_lat if s_lat is not None else ""])
-    w.writerow(["start_longitude", s_lon if s_lon is not None else ""])
-    w.writerow(["end_latitude", end_lat if end_lat is not None else ""])
-    w.writerow(["end_longitude", end_lon if end_lon is not None else ""])
+    w.writerow(["telemetry_rows", str(len(summary.frames))])
     w.writerow([])
-    w.writerow(
-        [
-            "timestamp_utc",
-            "depth_m",
-            "temperature_c",
-            "latitude",
-            "longitude",
-            "dive_start_latitude",
-            "dive_start_longitude",
-            "dive_end_latitude",
-            "dive_end_longitude",
-        ]
-    )
-    for s in sorted(summary.samples, key=lambda x: x.log_time_ns):
-        w.writerow(
-            [
-                _ns_to_utc_iso(s.log_time_ns),
-                s.depth_m if s.depth_m is not None else "",
-                s.temperature_c if s.temperature_c is not None else "",
-                s.lat if s.lat is not None else "",
-                s.lon if s.lon is not None else "",
-                s_lat if s_lat is not None else "",
-                s_lon if s_lon is not None else "",
-                (end_lat if end_lat is not None else ""),
-                (end_lon if end_lon is not None else ""),
-            ]
-        )
+
+    # ── Section 2: per-second telemetry ──
+    # Fixed columns first, then any dynamically-discovered sensor columns
+    # (conductivity, co2, oxygen, ...) appended in stable sorted order.
+    data_columns = [c for c in SIGNAL_COLUMNS if c != "mission_state"]
+    data_columns += list(summary.extra_columns)
+    display_columns = [COLUMN_DISPLAY_NAMES.get(c, c) for c in data_columns]
+    w.writerow(["# TIME SERIES"])
+    w.writerow(["timestamp_utc", "mission_state_label", *display_columns])
+
+    for fr in summary.frames:
+        state_val = fr.values.get("mission_state")
+        label = ""
+        if isinstance(state_val, (int, float)):
+            label = STATE_LABELS.get(int(round(state_val)), "")
+        row: list[str] = [_ns_to_utc_iso(fr.log_time_ns), label]
+        # When the GPS has no fix, position is stale -> report "na" rather
+        # than a misleading last-known coordinate.
+        no_fix = _has_no_gps_fix(fr.values)
+        for col in data_columns:
+            if no_fix and col in ("latitude", "longitude"):
+                row.append("na")
+            else:
+                row.append(_cell(fr.values.get(col)))
+        w.writerow(row)
     return buf.getvalue()

--- a/extension/backend/src/doris/services/mcap_telemetry.py
+++ b/extension/backend/src/doris/services/mcap_telemetry.py
@@ -222,6 +222,34 @@ COLUMN_DISPLAY_NAMES: dict[str, str] = {
     "battery_current_a": "battery_current_amperes",
 }
 
+# Decimal places per column for CSV output (trailing zeros are stripped).
+# Chosen to match each sensor's useful resolution rather than dumping the raw
+# float's 6 significant figures.  Position keeps 6 dp (~0.1 m); columns not
+# listed (e.g. dynamically-discovered sensors) use _DEFAULT_DECIMALS.
+_DEFAULT_DECIMALS = 3
+COLUMN_DECIMALS: dict[str, int] = {
+    "mission_time_s": 0,
+    "bottom_time_s": 0,
+    "depth_m": 2,
+    "vertical_velocity_mps": 2,
+    "internal_pressure_hpa": 1,
+    "internal_temperature_c": 2,
+    "external_pressure_hpa": 1,
+    "external_temperature_c": 2,
+    "latitude": 6,
+    "longitude": 6,
+    "heading_trueN_degrees": 1,
+    "ground_speed_mps": 2,
+    "gps_satellites": 0,
+    "roll_deg": 1,
+    "pitch_deg": 1,
+    "yaw_deg": 1,
+    "relay_active": 0,
+    "light_level_percent": 1,
+    "battery_voltage_v": 2,
+    "battery_current_a": 2,
+}
+
 # DORIS_STATE numeric -> human label (mirrors STATE_* constants in doris.lua).
 STATE_LABELS: dict[int, str] = {
     -1: "CONFIG",
@@ -543,12 +571,22 @@ def _to_float(value: Any) -> float | None:
     return _f(value)
 
 
-def _cell(value: float | str | None) -> str:
+def _cell(value: float | str | None, decimals: int | None = None) -> str:
     if value is None or value == "":
         return ""
     if isinstance(value, str):
         return value
-    return f"{value:g}"
+    if decimals is None:
+        return f"{value:g}"
+    r = round(value, decimals)
+    if r == 0:  # collapse -0.0 -> 0
+        r = 0.0
+    # Fixed-point (so we don't hit %g's 6-significant-figure cap, which would
+    # truncate latitude/longitude), then drop trailing zeros for a clean cell.
+    s = f"{r:.{decimals}f}"
+    if "." in s:
+        s = s.rstrip("0").rstrip(".")
+    return s
 
 
 # gps_fix_type values (GPS_FIX_TYPE_* prefix already stripped) that mean the
@@ -616,15 +654,15 @@ def build_dive_csv(
     w.writerow(["started_at_utc", _strip_utc_offset(started)])
     w.writerow(["ended_at_utc", _strip_utc_offset(ended)])
     w.writerow(["duration", _duration_label(started, ended)])
-    w.writerow(["start_latitude", _cell(s_lat)])
-    w.writerow(["start_longitude", _cell(s_lon)])
-    w.writerow(["end_latitude", _cell(end_lat)])
-    w.writerow(["end_longitude", _cell(end_lon)])
-    w.writerow(["max_depth_from_log_meters", _cell(summary.max_depth_m)])
-    w.writerow(["min_external_temperature_celsius", _cell(summary.min_external_temperature_c)])
-    w.writerow(["min_battery_voltage_volts", _cell(summary.min_battery_voltage_v)])
-    w.writerow(["max_gps_satellites", _cell(summary.max_satellites)])
-    w.writerow(["compass_declination_degrees", _cell(summary.compass_declination_deg)])
+    w.writerow(["start_latitude", _cell(s_lat, 6)])
+    w.writerow(["start_longitude", _cell(s_lon, 6)])
+    w.writerow(["end_latitude", _cell(end_lat, 6)])
+    w.writerow(["end_longitude", _cell(end_lon, 6)])
+    w.writerow(["max_depth_from_log_meters", _cell(summary.max_depth_m, 2)])
+    w.writerow(["min_external_temperature_celsius", _cell(summary.min_external_temperature_c, 2)])
+    w.writerow(["min_battery_voltage_volts", _cell(summary.min_battery_voltage_v, 2)])
+    w.writerow(["max_gps_satellites", _cell(summary.max_satellites, 0)])
+    w.writerow(["compass_declination_degrees", _cell(summary.compass_declination_deg, 3)])
     w.writerow(["compass_autodec", _cell(summary.compass_autodec)])
     w.writerow(["mcap_file", mcap_rel or ""])
     w.writerow(["telemetry_rows", str(len(summary.frames))])
@@ -652,6 +690,6 @@ def build_dive_csv(
             if no_fix and col in ("latitude", "longitude"):
                 row.append("na")
             else:
-                row.append(_cell(fr.values.get(col)))
+                row.append(_cell(fr.values.get(col), COLUMN_DECIMALS.get(col, _DEFAULT_DECIMALS)))
         w.writerow(row)
     return buf.getvalue()

--- a/extension/backend/src/doris/services/mcap_telemetry.py
+++ b/extension/backend/src/doris/services/mcap_telemetry.py
@@ -617,6 +617,43 @@ def _duration_label(started: str | None, ended: str | None) -> str:
     return f"{h}:{m:02d}:{s:02d}"
 
 
+_FNAME_BAD = re.compile(r"[^\w\s-]")
+_FNAME_SPACE = re.compile(r"[\s-]+")
+
+
+def _filename_slug(value: str) -> str:
+    """Filename-safe lowercase slug of a dive name (empty if nothing usable)."""
+    s = _FNAME_BAD.sub("", value.strip().lower())
+    s = _FNAME_SPACE.sub("_", s)
+    return s.strip("_")
+
+
+def dive_csv_filename(dive_record: dict[str, Any], dive_id: str) -> str:
+    """Download/USB name: ``<YYYYMMDD_HHMMSS>_<dive_name>_dive_data.csv``.
+
+    Leads with the dive's start timestamp (UTC) so exports sort
+    chronologically, followed by the slugified dive name.  The timestamp
+    falls back to the dive id stem when the start time is missing/unparseable,
+    and the dive-name segment is omitted when there is no name.
+    """
+    started = dive_record.get("started_at")
+    stamp = ""
+    if started:
+        try:
+            dt = datetime.fromisoformat(str(started).replace("Z", "+00:00"))
+        except ValueError:
+            dt = None
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            stamp = dt.astimezone(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    parts = [stamp or dive_id]
+    name = _filename_slug(str(dive_record.get("dive_name") or ""))
+    if name:
+        parts.append(name)
+    return "_".join(parts) + "_dive_data.csv"
+
+
 def build_dive_csv(
     dive_record: dict[str, Any],
     summary: McapSummary,

--- a/extension/backend/tests/test_dive_csv_export.py
+++ b/extension/backend/tests/test_dive_csv_export.py
@@ -110,7 +110,8 @@ def test_export_writes_csv_to_usb(tmp_path: Path, monkeypatch) -> None:
     result = asyncio.run(dce.export_dive_csv_to_usb(dive_file))
 
     assert result["status"] == "ok"
-    out = usb / "reef_survey_dive_data.csv"
+    # Named by dive start time then dive name (matches video file stamp format).
+    out = usb / "20260528_165058_reef_survey_dive_data.csv"
     assert out.is_file()
     assert result["file"] == str(out)
     assert result["rows"] == 2
@@ -163,7 +164,7 @@ def test_export_without_mcap_still_writes_header(tmp_path: Path, monkeypatch) ->
 
     assert result["status"] == "ok"
     assert result["rows"] == 0
-    out = usb / "reef_survey_dive_data.csv"
+    out = usb / "20260528_165058_reef_survey_dive_data.csv"
     assert out.is_file()
     assert "# DIVE DATA" in out.read_text(encoding="utf-8")
 

--- a/extension/backend/tests/test_dive_csv_export.py
+++ b/extension/backend/tests/test_dive_csv_export.py
@@ -1,0 +1,181 @@
+"""Tests for the post-dive CSV-to-USB export (services/dive_csv_export.py).
+
+These exercise the background export path without touching the real
+recorder/USB layout: the dive's .mcap mapping, the USB directory, and the
+mcap quiescence wait are all stubbed so the test asserts the orchestration
+(parse -> build -> atomic write -> record status) and the cached-file
+lookup the download route relies on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from mcap.writer import Writer
+
+from doris.services import dive_csv_export as dce
+
+BASE = datetime(2026, 5, 28, 16, 50, 58, tzinfo=timezone.utc)
+BASE_NS = int(BASE.timestamp() * 1_000_000_000)
+
+
+def _write_min_mcap(path: Path) -> None:
+    """Two 1-second buckets of DORIS depth/state telemetry."""
+    msgs = [
+        ("NAMED_VALUE_FLOAT", {"type": "NAMED_VALUE_FLOAT", "name": "STATE", "value": 1.0}),
+        ("NAMED_VALUE_FLOAT", {"type": "NAMED_VALUE_FLOAT", "name": "DEPTH", "value": 12.5}),
+        ("SCALED_PRESSURE3", {"type": "SCALED_PRESSURE3", "press_abs": 0, "temperature": 540}),
+    ]
+    with path.open("wb") as f:
+        writer = Writer(f)
+        writer.start()
+        channels: dict[str, int] = {}
+
+        def channel_for(msg_type: str) -> int:
+            topic = f"mavlink/1/1/{msg_type}"
+            if topic not in channels:
+                sid = writer.register_schema(
+                    name=f"mavlink.1.1.{msg_type}", encoding="jsonschema", data=b"{}"
+                )
+                channels[topic] = writer.register_channel(
+                    topic=topic, message_encoding="json", schema_id=sid
+                )
+            return channels[topic]
+
+        for i in range(2):
+            base = BASE_NS + i * 1_000_000_000
+            for j, (msg_type, message) in enumerate(msgs):
+                payload = {"header": {"system_id": 1, "component_id": 1}, "message": message}
+                writer.add_message(
+                    channel_id=channel_for(msg_type),
+                    log_time=base + j,
+                    data=json.dumps(payload).encode("utf-8"),
+                    publish_time=base + j,
+                )
+        writer.finish()
+
+
+def _make_dive(tmp_path: Path, name: str = "Reef Survey") -> Path:
+    dives = tmp_path / "dives"
+    dives.mkdir(parents=True, exist_ok=True)
+    rec = {
+        "dive_name": name,
+        "username": "brian",
+        "status": "completed",
+        "started_at": BASE.isoformat(),
+        "ended_at": "2026-05-28T17:30:00+00:00",
+        "latitude": 33.7261,
+        "longitude": -118.2754,
+    }
+    p = dives / "dive_0001.json"
+    p.write_text(json.dumps(rec, indent=2))
+    return p
+
+
+async def _noop_quiescent(*_a, **_k) -> bool:
+    return True
+
+
+def _patch_common(monkeypatch, tmp_path: Path, mcap_path: Path | None) -> None:
+    monkeypatch.setattr(dce, "_data_root", lambda: tmp_path)
+    monkeypatch.setattr(dce, "wait_until_quiescent", _noop_quiescent)
+    monkeypatch.setattr(
+        "doris.services.storage._load_dive_windows", lambda root: []
+    )
+    mapping = {"dive_0001": mcap_path} if mcap_path is not None else {}
+    monkeypatch.setattr(
+        "doris.services.mcap_telemetry.map_dive_stem_to_largest_mcap",
+        lambda root, windows: mapping,
+    )
+
+
+def test_export_writes_csv_to_usb(tmp_path: Path, monkeypatch) -> None:
+    rec_dir = tmp_path / "recorder"
+    rec_dir.mkdir()
+    mcap = rec_dir / "dive.mcap"
+    _write_min_mcap(mcap)
+    dive_file = _make_dive(tmp_path)
+
+    usb = tmp_path / "usb" / "dive_data"
+    usb.mkdir(parents=True)
+    _patch_common(monkeypatch, tmp_path, mcap)
+    monkeypatch.setattr(
+        dce.usb_storage, "get_recording_dir_if_available", lambda sub: str(usb)
+    )
+
+    result = asyncio.run(dce.export_dive_csv_to_usb(dive_file))
+
+    assert result["status"] == "ok"
+    out = usb / "reef_survey_dive_data.csv"
+    assert out.is_file()
+    assert result["file"] == str(out)
+    assert result["rows"] == 2
+
+    text = out.read_text(encoding="utf-8")
+    assert "# DIVE DATA" in text
+    assert "# TIME SERIES" in text
+    assert "timestamp_utc" in text
+    # No spurious carriage returns (the blank-row bug we previously fixed).
+    assert "\r" not in text
+
+    # Record was updated and the cache lookup finds the file.
+    record = json.loads(dive_file.read_text())
+    assert record["csv_export_status"] == "ok"
+    assert record["csv_export_file"] == str(out)
+    assert dce.find_cached_csv(record) == out
+
+
+def test_export_skips_when_no_usb(tmp_path: Path, monkeypatch) -> None:
+    rec_dir = tmp_path / "recorder"
+    rec_dir.mkdir()
+    mcap = rec_dir / "dive.mcap"
+    _write_min_mcap(mcap)
+    dive_file = _make_dive(tmp_path)
+
+    _patch_common(monkeypatch, tmp_path, mcap)
+    monkeypatch.setattr(
+        dce.usb_storage, "get_recording_dir_if_available", lambda sub: None
+    )
+
+    result = asyncio.run(dce.export_dive_csv_to_usb(dive_file))
+
+    assert result["status"] == "skipped_no_usb"
+    record = json.loads(dive_file.read_text())
+    assert record["csv_export_status"] == "skipped_no_usb"
+    assert "csv_export_file" not in record
+    assert dce.find_cached_csv(record) is None
+
+
+def test_export_without_mcap_still_writes_header(tmp_path: Path, monkeypatch) -> None:
+    dive_file = _make_dive(tmp_path)
+    usb = tmp_path / "usb" / "dive_data"
+    usb.mkdir(parents=True)
+    _patch_common(monkeypatch, tmp_path, None)
+    monkeypatch.setattr(
+        dce.usb_storage, "get_recording_dir_if_available", lambda sub: str(usb)
+    )
+
+    result = asyncio.run(dce.export_dive_csv_to_usb(dive_file))
+
+    assert result["status"] == "ok"
+    assert result["rows"] == 0
+    out = usb / "reef_survey_dive_data.csv"
+    assert out.is_file()
+    assert "# DIVE DATA" in out.read_text(encoding="utf-8")
+
+
+def test_find_cached_csv_handles_missing_file(tmp_path: Path) -> None:
+    assert dce.find_cached_csv({}) is None
+    assert dce.find_cached_csv({"csv_export_file": ""}) is None
+    assert dce.find_cached_csv({"csv_export_file": str(tmp_path / "nope.csv")}) is None
+    real = tmp_path / "ok.csv"
+    real.write_text("data")
+    assert dce.find_cached_csv({"csv_export_file": str(real)}) == real
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/extension/backend/tests/test_mcap_telemetry.py
+++ b/extension/backend/tests/test_mcap_telemetry.py
@@ -332,6 +332,46 @@ def test_light_level_percent_mapping(tmp_path: Path) -> None:
     assert [data[0][li], data[1][li], data[2][li], data[3][li], data[4][li]] == ["0", "50", "100", "100", ""]
 
 
+def test_value_precision_rounding() -> None:
+    """Each column is rounded to its useful resolution; position keeps 6 dp."""
+    from doris.services.mcap_telemetry import McapSummary, TelemetryFrame
+
+    s = McapSummary()
+    s.frames.append(
+        TelemetryFrame(
+            log_time_ns=BASE_NS,
+            values={
+                "depth_m": 12.34567,
+                "vertical_velocity_mps": -0.540541,
+                "internal_pressure_hpa": 989.4719,
+                "internal_temperature_c": 26.7434,
+                "roll_deg": 86.6259,
+                "heading_trueN_degrees": 300.541,
+                "latitude": 33.7261148,
+                "longitude": -118.2754123,
+                "battery_voltage_v": 16.4843,
+                "gps_satellites": 14.0,
+            },
+        )
+    )
+    text = build_dive_csv({"dive_name": "Precision"}, s, None)
+    rows = list(csv.reader(io.StringIO(text)))
+    hi = next(i for i, r in enumerate(rows) if r and r[0] == "timestamp_utc")
+    row = dict(zip(rows[hi], rows[hi + 1], strict=False))
+
+    assert row["depth_meters"] == "12.35"
+    assert row["vertical_velocity_meters_per_second"] == "-0.54"
+    assert row["internal_pressure_hectopascals"] == "989.5"
+    assert row["internal_temperature_celsius"] == "26.74"
+    assert row["roll_degrees"] == "86.6"
+    assert row["heading_trueN_degrees"] == "300.5"
+    assert row["battery_voltage_volts"] == "16.48"
+    assert row["gps_satellites"] == "14"
+    # Position retains sub-meter precision (6 decimal places).
+    assert row["latitude_degrees"] == "33.726115"
+    assert row["longitude_degrees"] == "-118.275412"
+
+
 def test_empty_summary_still_emits_header() -> None:
     from doris.services.mcap_telemetry import McapSummary
 

--- a/extension/backend/tests/test_mcap_telemetry.py
+++ b/extension/backend/tests/test_mcap_telemetry.py
@@ -1,0 +1,343 @@
+"""Tests for the dive CSV export (services/mcap_telemetry.py).
+
+Builds a tiny JSON-encoded .mcap mirroring the BlueOS recorder layout (one
+topic per MAVLink message type, ``{"header": ..., "message": ...}`` payloads)
+and checks that telemetry is decoded, bucketed into per-second rows, and
+rendered into the dive CSV.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mcap.writer import Writer
+
+from doris.services.mcap_telemetry import build_dive_csv, summarize_mcap
+
+BASE = datetime(2026, 5, 20, 17, 49, 7, tzinfo=timezone.utc)
+BASE_NS = int(BASE.timestamp() * 1_000_000_000)
+
+
+def _named_float(name: str, value: float) -> tuple[str, dict]:
+    return "NAMED_VALUE_FLOAT", {
+        "type": "NAMED_VALUE_FLOAT",
+        "time_boot_ms": 1000,
+        "value": value,
+        "name": name,
+    }
+
+
+def _cycle(state: int, depth: float, temp: float, volt: float, climb: float) -> list[tuple[str, dict]]:
+    """A DORIS telemetry burst plus a few standard autopilot messages."""
+    return [
+        _named_float("STATE", float(state)),
+        _named_float("DEPTH", depth),
+        # Internal baro MIN_TEMP is denylisted (troubleshooting only); the
+        # external probe (SCALED_PRESSURE3 below) drives environmental temp.
+        _named_float("MIN_TEMP", 99.0),
+        _named_float("BATT_V", volt),
+        _named_float("RELAY", 0.0),
+        # Science sensors: recognized aliases + a future/unknown name + a
+        # denylisted ArduSub pilot input that must be ignored.
+        _named_float("COND", 4.21),
+        _named_float("CO2", 410.0),
+        _named_float("TURB", 7.5),
+        _named_float("CamTilt", 1.0),
+        ("SCALED_PRESSURE", {"type": "SCALED_PRESSURE", "press_abs": 1011.0, "temperature": 4822}),
+        ("SCALED_PRESSURE2", {"type": "SCALED_PRESSURE2", "press_abs": 1164.0, "temperature": 2475}),
+        ("SCALED_PRESSURE3", {"type": "SCALED_PRESSURE3", "press_abs": 0, "temperature": int(temp * 100)}),
+        ("VFR_HUD", {"type": "VFR_HUD", "climb": climb, "groundspeed": 0.1}),
+        (
+            "GLOBAL_POSITION_INT",
+            {"type": "GLOBAL_POSITION_INT", "lat": 337261140, "lon": -1182754125, "alt": 3350, "hdg": 33034},
+        ),
+        (
+            "GPS_RAW_INT",
+            {"type": "GPS_RAW_INT", "satellites_visible": 13, "cog": 12000, "fix_type": {"type": "GPS_FIX_TYPE_3D_FIX"}},
+        ),
+        ("ATTITUDE", {"type": "ATTITUDE", "roll": 0.0, "pitch": 0.0, "yaw": 1.5707963}),
+        # Sentinel pack voltage must be rejected; DORIS BATT_V wins instead.
+        ("BATTERY_STATUS", {"type": "BATTERY_STATUS", "voltages": [65535], "current_battery": 72, "battery_remaining": 91}),
+    ]
+
+
+def _write_mcap(path: Path, cycles: list[list[tuple[str, dict]]]) -> None:
+    channels: dict[str, int] = {}
+    with path.open("wb") as f:
+        writer = Writer(f)
+        writer.start()
+
+        def channel_for(msg_type: str) -> int:
+            topic = f"mavlink/1/1/{msg_type}"
+            if topic not in channels:
+                sid = writer.register_schema(
+                    name=f"mavlink.1.1.{msg_type}", encoding="jsonschema", data=b"{}"
+                )
+                channels[topic] = writer.register_channel(
+                    topic=topic, message_encoding="json", schema_id=sid
+                )
+            return channels[topic]
+
+        for i, cycle in enumerate(cycles):
+            base = BASE_NS + i * 1_000_000_000  # one bucket (1 s) apart
+            for j, (msg_type, message) in enumerate(cycle):
+                ts = base + j  # within-burst offset (same 1 s bucket)
+                payload = {"header": {"system_id": 1, "component_id": 1}, "message": message}
+                writer.add_message(
+                    channel_id=channel_for(msg_type),
+                    log_time=ts,
+                    data=json.dumps(payload).encode("utf-8"),
+                    publish_time=ts,
+                )
+        writer.finish()
+
+
+def test_summarize_buckets_and_aggregates(tmp_path: Path) -> None:
+    mcap = tmp_path / "dive.mcap"
+    _write_mcap(
+        mcap,
+        [
+            _cycle(state=1, depth=10.0, temp=18.0, volt=15.9, climb=-0.4),
+            _cycle(state=2, depth=25.0, temp=16.5, volt=15.4, climb=0.0),
+        ],
+    )
+    s = summarize_mcap(mcap)
+
+    assert len(s.frames) == 2
+    assert s.max_depth_m == 25.0
+    assert s.min_external_temperature_c == 16.5  # from external probe (P3), not internal MIN_TEMP
+    assert s.min_battery_voltage_v == 15.4  # from DORIS BATT_V, not 65535 sentinel
+    assert s.max_satellites == 13
+    assert s.last_lat is not None and abs(s.last_lat - 33.726114) < 1e-4
+    assert s.last_lon is not None and abs(s.last_lon - (-118.2754125)) < 1e-4
+
+    f0 = s.frames[0]
+    assert f0.values["mission_state"] == 1.0
+    assert f0.values["depth_m"] == 10.0
+    assert f0.values["vertical_velocity_mps"] == -0.4
+    assert f0.values["gps_fix_type"] == "3D_FIX"
+    assert f0.values["internal_pressure_hpa"] == 1011.0
+    assert f0.values["internal_temperature_c"] == 48.22
+    assert f0.values["external_pressure_hpa"] == 1164.0
+    # External temperature comes from the dedicated probe (P3), not the P2
+    # pressure sensor's duplicate reading.
+    assert f0.values["external_temperature_c"] == 18.0
+    # GLOBAL_POSITION_INT.hdg is the EKF yaw, declination-corrected to true
+    # north by ArduPilot -> reported as heading_trueN_degrees.
+    assert f0.values["heading_trueN_degrees"] == 330.34
+    # GPS course-over-ground is not exported (meaningless for a vertical
+    # profiler); compass heading covers it.
+    assert "gps_heading_deg" not in f0.values
+    assert abs(f0.values["yaw_deg"] - 90.0) < 0.01
+    assert f0.values["battery_voltage_v"] == 15.9
+    assert f0.values["battery_current_a"] == 0.72
+    # MAX_DPTH is no longer parsed (max depth lives only in the CSV header).
+    assert "max_depth_m" not in f0.values
+
+    # Dynamic science sensors: friendly aliases + raw unknown name.
+    assert f0.values["conductivity"] == 4.21
+    assert f0.values["co2"] == 410.0
+    assert f0.values["turb"] == 7.5
+    assert s.extra_columns == ["co2", "conductivity", "turb"]
+    # Denylisted ArduSub pilot float must not leak into the export.
+    assert "camtilt" not in f0.values
+
+
+def test_build_dive_csv_structure(tmp_path: Path) -> None:
+    mcap = tmp_path / "dive.mcap"
+    _write_mcap(
+        mcap,
+        [
+            _cycle(state=1, depth=10.0, temp=18.0, volt=15.9, climb=-0.4),
+            _cycle(state=2, depth=25.0, temp=16.5, volt=15.4, climb=0.0),
+        ],
+    )
+    s = summarize_mcap(mcap)
+    record = {
+        "dive_name": "Unit Test Dive",
+        "username": "tester",
+        "configuration": "cfg",
+        "status": "completed",
+        "started_at": BASE.isoformat(),
+        "ended_at": (BASE.replace(minute=59)).isoformat(),
+        "latitude": 33.7,
+        "longitude": -118.2,
+    }
+    text = build_dive_csv(record, s, "recorder/dive.mcap")
+
+    assert "# DIVE DATA" in text
+    assert "doris_dive_export,v2" in text
+    assert "dive_name,Unit Test Dive" in text
+    assert "user_name,tester" in text
+    assert "operator," not in text
+    assert "estimated_depth" not in text
+    assert "max_depth_from_log_meters,25" in text
+    assert "# TIME SERIES" in text
+
+    rows = list(csv.reader(io.StringIO(text)))
+    header_idx = next(i for i, r in enumerate(rows) if r and r[0] == "timestamp_utc")
+    header = rows[header_idx]
+    # Numeric mission_state column removed; readable label retained.
+    assert header[:2] == ["timestamp_utc", "mission_state_label"]
+    assert "mission_state" not in header
+    # Units fully spelled out in the column headers.
+    assert "depth_meters" in header and "battery_voltage_volts" in header and "gps_fix_type" in header
+    assert "vertical_velocity_meters_per_second" in header
+    for col in (
+        "internal_temperature_celsius",
+        "external_temperature_celsius",
+        "internal_pressure_hectopascals",
+        "external_pressure_hectopascals",
+        "latitude_degrees",
+        "longitude_degrees",
+    ):
+        assert col in header
+    # Old abbreviated names must not linger.
+    for gone in ("depth_m", "battery_voltage_v", "internal_temperature_c", "latitude", "longitude"):
+        assert gone not in header
+    # Consolidated: no duplicate external temperature / brand-named columns.
+    for gone in ("water_temperature_c", "bar100_temperature_c", "celsius_temperature_c", "baro_temperature_c"):
+        assert gone not in header
+    # Dynamic sensor columns appended after the fixed columns.
+    for sensor_col in ("conductivity", "co2", "turb"):
+        assert sensor_col in header
+    assert "camtilt" not in header and "CamTilt" not in header
+    # Dropped columns must not appear in the time-series header.
+    for dropped in (
+        "max_depth_m",
+        "min_temperature_c",
+        "descent_rate_mps",
+        "ascent_rate_mps",
+        "ascent_velocity_mps",
+        "climb_rate_mps",
+        "gps_heading_deg",
+    ):
+        assert dropped not in header
+    # True-north heading remains the single heading column.
+    assert "heading_trueN_degrees" in header
+    assert "mag_heading_deg" not in header
+
+    data_rows = [r for r in rows[header_idx + 1 :] if r]
+    assert len(data_rows) == 2
+    first = dict(zip(header, data_rows[0], strict=False))
+    assert first["mission_state_label"] == "DESCENT"
+    assert first["depth_meters"] == "10"
+    assert first["vertical_velocity_meters_per_second"] == "-0.4"
+    assert first["gps_fix_type"] == "3D_FIX"
+    # Timestamps carry no UTC offset (column is already named *_utc).
+    assert data_rows[0][0] == "2026-05-20T17:49:07"
+    assert "+00:00" not in text
+    assert "started_at_utc,2026-05-20T17:49:07" in text
+
+
+def test_no_gps_fix_writes_na_for_lat_lon(tmp_path: Path) -> None:
+    """A bucket with NO_FIX must report latitude/longitude as 'na', while a
+    3D-fix bucket keeps the real coordinates."""
+    mcap = tmp_path / "dive.mcap"
+    fixed = [
+        _named_float("DEPTH", 1.0),
+        (
+            "GLOBAL_POSITION_INT",
+            {"type": "GLOBAL_POSITION_INT", "lat": 337261140, "lon": -1182754125, "hdg": 1000},
+        ),
+        (
+            "GPS_RAW_INT",
+            {"type": "GPS_RAW_INT", "satellites_visible": 12, "fix_type": {"type": "GPS_FIX_TYPE_3D_FIX"}},
+        ),
+    ]
+    no_fix = [
+        _named_float("DEPTH", 80.0),
+        # Stale position still streamed underwater, but the fix is gone.
+        (
+            "GLOBAL_POSITION_INT",
+            {"type": "GLOBAL_POSITION_INT", "lat": 337261140, "lon": -1182754125, "hdg": 1000},
+        ),
+        (
+            "GPS_RAW_INT",
+            {"type": "GPS_RAW_INT", "satellites_visible": 0, "fix_type": {"type": "GPS_FIX_TYPE_NO_FIX"}},
+        ),
+    ]
+    _write_mcap(mcap, [fixed, no_fix])
+    s = summarize_mcap(mcap)
+    text = build_dive_csv({"dive_name": "Fix Test"}, s, None)
+
+    rows = list(csv.reader(io.StringIO(text)))
+    header_idx = next(i for i, r in enumerate(rows) if r and r[0] == "timestamp_utc")
+    header = rows[header_idx]
+    data = [dict(zip(header, r, strict=False)) for r in rows[header_idx + 1 :] if r]
+    assert len(data) == 2
+    # First bucket: 3D fix -> real coordinates.
+    assert data[0]["gps_fix_type"] == "3D_FIX"
+    assert abs(float(data[0]["latitude_degrees"]) - 33.726114) < 1e-4
+    # Second bucket: no fix -> na for both lat and lon.
+    assert data[1]["gps_fix_type"] == "NO_FIX"
+    assert data[1]["latitude_degrees"] == "na"
+    assert data[1]["longitude_degrees"] == "na"
+
+
+def test_compass_declination_parsed_into_header(tmp_path: Path) -> None:
+    """COMPASS_DEC / COMPASS_AUTODEC from the PARAM_VALUE stream surface in
+    the dive-data header (declination converted from radians to degrees)."""
+    mcap = tmp_path / "dive.mcap"
+    cycle = [
+        _named_float("DEPTH", 5.0),
+        ("PARAM_VALUE", {"type": "PARAM_VALUE", "param_id": "COMPASS_DEC", "param_value": 0.19978905}),
+        ("PARAM_VALUE", {"type": "PARAM_VALUE", "param_id": "COMPASS_AUTODEC", "param_value": 1.0}),
+        ("PARAM_VALUE", {"type": "PARAM_VALUE", "param_id": "SOME_OTHER", "param_value": 42.0}),
+    ]
+    _write_mcap(mcap, [cycle])
+    s = summarize_mcap(mcap)
+
+    assert s.compass_declination_deg is not None
+    assert abs(s.compass_declination_deg - 11.447) < 0.01
+    assert s.compass_autodec == 1
+
+    text = build_dive_csv({"dive_name": "Declination"}, s, None)
+    assert "compass_declination_degrees,11.447" in text
+    assert "compass_autodec,1" in text
+
+
+def test_light_level_percent_mapping(tmp_path: Path) -> None:
+    """RC channel 9 PWM (us) maps to a 0-100% light level over 1100-1900 us
+    (clamped); an unavailable channel (0) yields no value."""
+    mcap = tmp_path / "dive.mcap"
+    cycles = [
+        [_named_float("DEPTH", 1.0), ("RC_CHANNELS", {"type": "RC_CHANNELS", "chan9_raw": 1100})],
+        [_named_float("DEPTH", 2.0), ("RC_CHANNELS", {"type": "RC_CHANNELS", "chan9_raw": 1500})],
+        [_named_float("DEPTH", 3.0), ("RC_CHANNELS", {"type": "RC_CHANNELS", "chan9_raw": 1900})],
+        [_named_float("DEPTH", 4.0), ("RC_CHANNELS", {"type": "RC_CHANNELS", "chan9_raw": 2100})],
+        [_named_float("DEPTH", 5.0), ("RC_CHANNELS", {"type": "RC_CHANNELS", "chan9_raw": 0})],
+    ]
+    _write_mcap(mcap, cycles)
+    s = summarize_mcap(mcap)
+
+    assert s.frames[0].values["light_level_percent"] == 0.0
+    assert s.frames[1].values["light_level_percent"] == 50.0
+    assert s.frames[2].values["light_level_percent"] == 100.0
+    # Above the operational max clamps to 100.
+    assert s.frames[3].values["light_level_percent"] == 100.0
+    assert "light_level_percent" not in s.frames[4].values
+
+    text = build_dive_csv({"dive_name": "Lights"}, s, None)
+    rows = list(csv.reader(io.StringIO(text)))
+    hi = next(i for i, r in enumerate(rows) if r and r[0] == "timestamp_utc")
+    header = rows[hi]
+    assert "light_level_percent" in header
+    li = header.index("light_level_percent")
+    data = [r for r in rows[hi + 1 :] if r]
+    assert [data[0][li], data[1][li], data[2][li], data[3][li], data[4][li]] == ["0", "50", "100", "100", ""]
+
+
+def test_empty_summary_still_emits_header() -> None:
+    from doris.services.mcap_telemetry import McapSummary
+
+    text = build_dive_csv({"dive_name": "No Log"}, McapSummary(), None)
+    assert "# DIVE DATA" in text
+    assert "telemetry_rows,0" in text
+    rows = list(csv.reader(io.StringIO(text)))
+    header_idx = next(i for i, r in enumerate(rows) if r and r[0] == "timestamp_utc")
+    assert not [r for r in rows[header_idx + 1 :] if r]

--- a/extension/backend/tests/test_mcap_telemetry.py
+++ b/extension/backend/tests/test_mcap_telemetry.py
@@ -372,6 +372,27 @@ def test_value_precision_rounding() -> None:
     assert row["longitude_degrees"] == "-118.275412"
 
 
+def test_dive_csv_filename() -> None:
+    from doris.services.mcap_telemetry import dive_csv_filename
+
+    # Start time (UTC, YYYYMMDD_HHMMSS to match the video files) then dive name.
+    assert (
+        dive_csv_filename(
+            {"started_at": "2026-05-28T16:50:58+00:00", "dive_name": "Reef Survey #2"},
+            "dive_0007",
+        )
+        == "20260528_165058_reef_survey_2_dive_data.csv"
+    )
+    # Non-UTC offset is converted to UTC.
+    assert (
+        dive_csv_filename({"started_at": "2026-05-28T09:50:58-07:00", "dive_name": ""}, "dive_0007")
+        == "20260528_165058_dive_data.csv"
+    )
+    # Missing/!parseable start time falls back to the dive id.
+    assert dive_csv_filename({"dive_name": "Test"}, "dive_0007") == "dive_0007_test_dive_data.csv"
+    assert dive_csv_filename({"started_at": "nope"}, "dive_0007") == "dive_0007_dive_data.csv"
+
+
 def test_empty_summary_still_emits_header() -> None:
     from doris.services.mcap_telemetry import McapSummary
 

--- a/extension/frontend/src/components/AllMissions.vue
+++ b/extension/frontend/src/components/AllMissions.vue
@@ -114,6 +114,12 @@ const isDeleting = ref(false)
 const exportingIds = ref<Set<string>>(new Set())
 const exportErrors = ref<Record<string, string>>({})
 
+function filenameFromContentDisposition(header: string | null, fallback: string): string {
+  if (!header) return fallback
+  const match = /filename\*?=(?:UTF-8'')?"?([^"';]+)"?/i.exec(header)
+  return match ? decodeURIComponent(match[1].trim()) : fallback
+}
+
 async function handleExportCsv(mission: DisplayMission) {
   if (exportingIds.value.has(mission.id)) return
   exportingIds.value = new Set(exportingIds.value).add(mission.id)
@@ -129,7 +135,12 @@ async function handleExportCsv(mission: DisplayMission) {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `${mission.id}_dive_data.csv`
+    // Backend names the file <YYYYMMDD_HHMMSS>_<dive_name>_dive_data.csv via
+    // Content-Disposition; honor it, falling back to the dive id.
+    a.download = filenameFromContentDisposition(
+      res.headers.get('Content-Disposition'),
+      `${mission.id}_dive_data.csv`,
+    )
     document.body.appendChild(a)
     a.click()
     a.remove()

--- a/extension/frontend/src/components/AllMissions.vue
+++ b/extension/frontend/src/components/AllMissions.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import {
   Database, Calendar, Clock, MapPin, Camera, Image, FileText, Play,
-  Download, Trash2, AlertTriangle, Archive, Search, X
+  Download, Trash2, AlertTriangle, Archive, Search, X, Loader2
 } from 'lucide-vue-next'
 import { useDiveHistory } from '../composables/useApi'
 import { parseBackendDateTime } from '../parseBackendTime'
@@ -107,6 +107,44 @@ const selectedMission = ref<string | null>(null)
 const nameFilter = ref('')
 const dateSort = ref<'recent' | 'oldest'>('recent')
 const isDeleting = ref(false)
+
+// Per-dive CSV export state. The export parses the dive's .mcap, which can
+// take tens of seconds on the vehicle when no pre-generated copy exists, so
+// we fetch it explicitly and show a spinner instead of using a bare link.
+const exportingIds = ref<Set<string>>(new Set())
+const exportErrors = ref<Record<string, string>>({})
+
+async function handleExportCsv(mission: DisplayMission) {
+  if (exportingIds.value.has(mission.id)) return
+  exportingIds.value = new Set(exportingIds.value).add(mission.id)
+  if (exportErrors.value[mission.id]) {
+    const next = { ...exportErrors.value }
+    delete next[mission.id]
+    exportErrors.value = next
+  }
+  try {
+    const res = await fetch(scientificCsvHref(mission.id))
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${mission.id}_dive_data.csv`
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  } catch (e) {
+    exportErrors.value = {
+      ...exportErrors.value,
+      [mission.id]: 'Export failed. Please try again.',
+    }
+  } finally {
+    const next = new Set(exportingIds.value)
+    next.delete(mission.id)
+    exportingIds.value = next
+  }
+}
 
 const filteredMissions = computed(() => {
   return previousMissions.value
@@ -326,15 +364,25 @@ const handleDeleteMission = async () => {
                 <Archive class="w-4 h-4 flex-shrink-0" />
                 No MCAP linked
               </span>
-              <a
-                :href="scientificCsvHref(mission.id)"
-                class="px-4 py-2 rounded-lg flex items-center justify-center gap-2 text-sm whitespace-nowrap transition-all hover:opacity-90 no-underline"
+              <button
+                type="button"
+                @click="handleExportCsv(mission)"
+                :disabled="exportingIds.has(mission.id)"
+                class="px-4 py-2 rounded-lg flex items-center justify-center gap-2 text-sm whitespace-nowrap transition-all hover:opacity-90 disabled:opacity-70 disabled:cursor-wait"
                 style="background-color: rgba(0, 212, 170, 0.2); border: 1px solid rgba(0, 212, 170, 0.5); color: #00D4AA"
-                :title="mission.mcapRelativePath ? 'Depth, temperature, GPS columns from recorder log where available' : 'Dive metadata and any samples we could read from the linked log'"
+                :title="exportingIds.has(mission.id) ? 'Reading the recorder log — long dives can take a minute' : (mission.mcapRelativePath ? 'Dive-data header plus per-timestamp system + science telemetry (depth, temperature, state, battery, relay, GPS) from the recorder log' : 'Dive metadata and any telemetry we could read from the linked log')"
               >
-                <Download class="w-4 h-4 flex-shrink-0" />
-                Export scientific CSV
-              </a>
+                <Loader2 v-if="exportingIds.has(mission.id)" class="w-4 h-4 flex-shrink-0 animate-spin" />
+                <Download v-else class="w-4 h-4 flex-shrink-0" />
+                {{ exportingIds.has(mission.id) ? 'Generating CSV…' : 'Export dive data (CSV)' }}
+              </button>
+              <span
+                v-if="exportErrors[mission.id]"
+                class="text-xs text-center"
+                style="color: #FF4757"
+              >
+                {{ exportErrors[mission.id] }}
+              </span>
               <button
                 type="button"
                 disabled


### PR DESCRIPTION
## Summary

Adds a comprehensive **dive-data CSV export** reconstructed from the recorder `.mcap`, available from the Previous Dives page, plus **onboard generation to the USB drive** at dive end.

- **CSV contents**: a header section (dive metadata + log-derived aggregates: max depth, min external temperature, min battery voltage, max GPS satellites, compass declination) followed by one row per 1-second UTC bucket of merged system + science telemetry (depth, vertical velocity, internal/external pressure & temperature, position, true-north heading, attitude, GPS, relay, light level, battery).
- **Onboard USB generation**: at dive end a background task (mirroring the BIN-log archiver) parses the dive's `.mcap` and writes `<dive>_dive_data.csv` to USB, so the file is durable and surfaces in the Data tab. The export route prefers this cached copy (instant download) and falls back to an on-demand parse. A manual re-export endpoint is included for when USB was absent.
- **Frontend**: the export button now does a `fetch` with an inline spinner + error state instead of a bare link, so the operator gets feedback during the (potentially minute-long) parse on the vehicle.

## Column / format details

- Heading is sourced from the EKF yaw (`GLOBAL_POSITION_INT.hdg`), which ArduPilot corrects to **true north** via `COMPASS_DEC`; exported as `heading_trueN_degrees`, with the declination used surfaced in the header. The all-zero GPS course-over-ground column was dropped.
- `latitude`/`longitude` render as `na` when the GPS has no fix (stale position suppressed).
- UTC timestamps have the redundant `+00:00` offset stripped (columns are already `*_utc`).
- `operator` renamed to `user_name`; units fully spelled out in all column headers; numeric `mission_state` dropped (human-readable `mission_state_label` kept); `estimated_depth` removed.
- `light_level_percent` added from RC channel 9, mapped 1100–1900 us -> 0–100% (clamped).

## Test plan

- [x] Backend unit tests (`test_mcap_telemetry.py`, `test_dive_csv_export.py`) — 10 tests covering bucketing/aggregates, CSV structure, no-fix `na`, timestamp format, declination parsing, light-level mapping, and USB export orchestration (write / skip-no-usb / no-mcap / cache lookup). All pass.
- [x] Full backend suite passes (85 tests).
- [x] Validated end-to-end against two real recorder `.mcap` files (~2.7M messages, deep dive to 791 m).
- [x] Verify on-vehicle: USB CSV generated at dive end and instant download from Previous Dives.
- [x] Verify frontend spinner/error state in the browser.
