### PR TITLE
fix(dive-csv): match MP4 timestamp format in CSV filename

### DIFF
--- a/extension/backend/src/doris/services/mcap_telemetry.py
+++ b/extension/backend/src/doris/services/mcap_telemetry.py
@@ -629,11 +629,13 @@ def _filename_slug(value: str) -> str:
 
 
 def dive_csv_filename(dive_record: dict[str, Any], dive_id: str) -> str:
-    """Download/USB name: ``<YYYYMMDD_HHMMSS>_<dive_name>_dive_data.csv``.
+    """Download/USB name: ``<YYYYMMDDtHHMMSS>_<dive_name>_dive_data.csv``.
 
     Leads with the dive's start timestamp (UTC) so exports sort
-    chronologically, followed by the slugified dive name.  The timestamp
-    falls back to the dive id stem when the start time is missing/unparseable,
+    chronologically, followed by the slugified dive name.  The timestamp uses
+    the same ``YYYYMMDDtHHMMSS`` form as the finalized MP4 names
+    (``dive_finalize._START_FMT``) so video and CSV exports stay consistent.
+    Falls back to the dive id stem when the start time is missing/unparseable,
     and the dive-name segment is omitted when there is no name.
     """
     started = dive_record.get("started_at")
@@ -646,7 +648,7 @@ def dive_csv_filename(dive_record: dict[str, Any], dive_id: str) -> str:
         if dt is not None:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
-            stamp = dt.astimezone(timezone.utc).strftime("%Y%m%d_%H%M%S")
+            stamp = dt.astimezone(timezone.utc).strftime("%Y%m%dt%H%M%S")
     parts = [stamp or dive_id]
     name = _filename_slug(str(dive_record.get("dive_name") or ""))
     if name:

--- a/extension/backend/tests/test_dive_csv_export.py
+++ b/extension/backend/tests/test_dive_csv_export.py
@@ -110,8 +110,8 @@ def test_export_writes_csv_to_usb(tmp_path: Path, monkeypatch) -> None:
     result = asyncio.run(dce.export_dive_csv_to_usb(dive_file))
 
     assert result["status"] == "ok"
-    # Named by dive start time then dive name (matches video file stamp format).
-    out = usb / "20260528_165058_reef_survey_dive_data.csv"
+    # Named by dive start time (YYYYMMDDtHHMMSS) then dive name.
+    out = usb / "20260528t165058_reef_survey_dive_data.csv"
     assert out.is_file()
     assert result["file"] == str(out)
     assert result["rows"] == 2
@@ -164,7 +164,7 @@ def test_export_without_mcap_still_writes_header(tmp_path: Path, monkeypatch) ->
 
     assert result["status"] == "ok"
     assert result["rows"] == 0
-    out = usb / "20260528_165058_reef_survey_dive_data.csv"
+    out = usb / "20260528t165058_reef_survey_dive_data.csv"
     assert out.is_file()
     assert "# DIVE DATA" in out.read_text(encoding="utf-8")
 

--- a/extension/backend/tests/test_mcap_telemetry.py
+++ b/extension/backend/tests/test_mcap_telemetry.py
@@ -375,18 +375,18 @@ def test_value_precision_rounding() -> None:
 def test_dive_csv_filename() -> None:
     from doris.services.mcap_telemetry import dive_csv_filename
 
-    # Start time (UTC, YYYYMMDD_HHMMSS to match the video files) then dive name.
+    # Start time (UTC, YYYYMMDDtHHMMSS to match finalized MP4 names) then name.
     assert (
         dive_csv_filename(
             {"started_at": "2026-05-28T16:50:58+00:00", "dive_name": "Reef Survey #2"},
             "dive_0007",
         )
-        == "20260528_165058_reef_survey_2_dive_data.csv"
+        == "20260528t165058_reef_survey_2_dive_data.csv"
     )
     # Non-UTC offset is converted to UTC.
     assert (
         dive_csv_filename({"started_at": "2026-05-28T09:50:58-07:00", "dive_name": ""}, "dive_0007")
-        == "20260528_165058_dive_data.csv"
+        == "20260528t165058_dive_data.csv"
     )
     # Missing/!parseable start time falls back to the dive id.
     assert dive_csv_filename({"dive_name": "Test"}, "dive_0007") == "dive_0007_test_dive_data.csv"

--- a/extension/frontend/src/components/AllMissions.vue
+++ b/extension/frontend/src/components/AllMissions.vue
@@ -135,7 +135,7 @@ async function handleExportCsv(mission: DisplayMission) {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    // Backend names the file <YYYYMMDD_HHMMSS>_<dive_name>_dive_data.csv via
+    // Backend names the file <YYYYMMDDtHHMMSS>_<dive_name>_dive_data.csv via
     // Content-Disposition; honor it, falling back to the dive id.
     a.download = filenameFromContentDisposition(
       res.headers.get('Content-Disposition'),


### PR DESCRIPTION
## Summary
- The finalized, operator-facing MP4s are named with a `YYYYMMDDtHHMMSS` UTC stamp (`dive_finalize._START_FMT`, e.g. `20260528t171502_on_bottom.mp4`).
- The dive-data CSV export now uses the same `YYYYMMDDtHHMMSS` form (e.g. `20260528t165058_<dive_name>_dive_data.csv`) so the video and CSV exports for a dive carry a consistent timestamp.
- This is a small follow-up to #34 after #27 landed the MP4 naming.

## Notes
- Internal/raw recorder files (`radcam_YYYYMMDD_HHMMSS_*.ts/.jpg`) and the `dive_<stamp>/` folder still use the underscore form; those are not operator-facing and were intentionally left unchanged.

## Test plan
- [x] `pytest tests/test_mcap_telemetry.py tests/test_dive_csv_export.py` (filename assertions updated to lowercase `t`)
- [x] Full backend suite green (104 passed)
