### PR TITLE
fix: DORIS issue triage batch (#28, #29, #30, #32; verify #10)

### DIFF
--- a/extension/backend/scripts/doris.lua
+++ b/extension/backend/scripts/doris.lua
@@ -1190,7 +1190,14 @@ function update()
         --                  (driven by tl_strobe_active below)
         local bottom_lgt_eff = cfg.btm_lgt
         if ipcam_cfg.btm_cmod == 2 then
-            bottom_lgt_eff = cfg.btm_lgt and ipcam_recording
+            -- INTERVAL: the camera starts each cycle, the light comes on
+            -- cfg.btm_dly_ms (light delay) after recording starts, and
+            -- both turn off together when the record window ends.  The
+            -- "record for" duration is measured from when the camera
+            -- started, so the light is lit for (btm_rec_ms - btm_dly_ms).
+            bottom_lgt_eff = cfg.btm_lgt
+                and ipcam_state.cycle_is_record
+                and (now_ms - ipcam_state.cycle_start_ms) >= cfg.btm_dly_ms
         elseif ipcam_cfg.btm_cmod == 3 then
             local pre_active = ipcam_state.next_snap_ms > 0
                 and (ipcam_state.next_snap_ms - now_ms) <= ipcam_cfg.tl_pre_ms
@@ -1199,7 +1206,12 @@ function update()
             bottom_lgt_eff = cfg.btm_lgt and (pre_active or post_active)
         end
 
-        if not bottom_delay_done then
+        if ipcam_cfg.btm_cmod == 2 then
+            -- INTERVAL owns its light timing per-cycle (above).  The
+            -- one-time bottom settling delay is replaced by the camera
+            -- settle (cam_delay_done), which gates the first cycle.
+            update_lights(bottom_lgt_eff, now_ms)
+        elseif not bottom_delay_done then
             update_lights(false, now_ms)
             if bottom_elapsed >= cfg.btm_dly_ms then
                 bottom_delay_done = true
@@ -1225,7 +1237,10 @@ function update()
                 ipcam_btm_started = ipcam_recording
             end
         elseif ipcam_cfg.btm_cmod == 2 then
-            -- VIDEO_INTERVAL: duty-cycle record for btm_rec_ms, pause btm_pau_ms.
+            -- VIDEO_INTERVAL: record for btm_rec_ms (measured from camera
+            -- start), pause btm_pau_ms.  The light comes on btm_dly_ms
+            -- into the record window (handled in the light block above)
+            -- and goes off with the camera at the end of the window.
             if cam_delay_done and ipcam_cfg.btm_rec_ms > 0
                and ipcam_cfg.btm_pau_ms > 0 then
                 if ipcam_state.cycle_start_ms == 0 then
@@ -1234,8 +1249,9 @@ function update()
                     ipcam_begin_phase(true, "on_bottom")
                     ipcam_btm_started = ipcam_recording
                     gcs:send_text(MAV_SEVERITY.INFO,
-                        string.format("DIVE: IPcam interval start (rec %ds)",
-                            math.floor(ipcam_cfg.btm_rec_ms / 1000)))
+                        string.format("DIVE: IPcam interval start (rec %ds, light +%ds)",
+                            math.floor(ipcam_cfg.btm_rec_ms / 1000),
+                            math.floor(cfg.btm_dly_ms / 1000)))
                 else
                     local cycle_elapsed = now_ms - ipcam_state.cycle_start_ms
                     if ipcam_state.cycle_is_record
@@ -1254,8 +1270,9 @@ function update()
                             ipcam_start("on_bottom")
                         end
                         gcs:send_text(MAV_SEVERITY.INFO,
-                            string.format("DIVE: IPcam interval record (%ds)",
-                                math.floor(ipcam_cfg.btm_rec_ms / 1000)))
+                            string.format("DIVE: IPcam interval record (%ds, light +%ds)",
+                                math.floor(ipcam_cfg.btm_rec_ms / 1000),
+                                math.floor(cfg.btm_dly_ms / 1000)))
                     end
                 end
             end

--- a/extension/backend/src/doris/services/storage.py
+++ b/extension/backend/src/doris/services/storage.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import quote
 
+from ..config import settings
 from ..models.configuration import (
     ConfigurationSummary,
     DeploymentConfiguration,
@@ -35,6 +36,15 @@ ALL_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS | DATA_EXTENSIONS
 
 DATA_ROOT = Path(os.environ.get("DORIS_DATA_ROOT", "/tmp/storage"))
 RECORDER_ROOT = Path(os.environ.get("DORIS_RECORDER_ROOT", "/tmp/storage/userdata/recorder"))
+# Internal fallback for IP-camera recordings when no USB stick is mounted.
+# The recorder writes here (see services/ip_camera_recorder._output_dir);
+# without scanning it, test/dive recordings made without a USB drive never
+# appeared on the data page (issue #32).
+IPCAM_ROOT = DATA_ROOT / settings.ipcam_recordings_subdir.strip("/")
+# Path parts of the ipcam subdir relative to DATA_ROOT, e.g.
+# ("userdata", "ipcam_recordings"). Used to label internal recordings by
+# their per-dive folder instead of the generic "userdata" top-level dir.
+IPCAM_SUBDIR_PARTS = tuple(Path(settings.ipcam_recordings_subdir.strip("/")).parts)
 
 # BlueOS bind-mount folders under DATA_ROOT — not user dive names.
 SYSTEM_TOP_LEVEL = frozenset(
@@ -594,6 +604,25 @@ def _file_to_media(
     dive_name: str | None = None
     media_type = content_kind
 
+    # Internal IP-camera recordings live under
+    # ``userdata/ipcam_recordings/dive_<stamp>/`` — group them by that
+    # per-dive folder rather than the generic "userdata" top-level dir.
+    n = len(IPCAM_SUBDIR_PARTS)
+    if IPCAM_SUBDIR_PARTS and len(parts) > n and parts[:n] == IPCAM_SUBDIR_PARTS:
+        dive_folder = parts[n]
+        wn = _match_dive_window(dive_windows, eff_utc)
+        dive_name = wn.display_name if wn else dive_folder
+        return MediaFile(
+            id=str(rel),
+            filename=path.name,
+            media_type=media_type,
+            size_bytes=stat.st_size,
+            created_at=eff,
+            mission_id=dive_folder,
+            dive_name=dive_name,
+            download_url=f"/api/v1/media/download/{rel}",
+        )
+
     if top == RECORDER_DIR:
         wn = _match_dive_window(dive_windows, eff_utc)
         dive_name = wn.display_name if wn else None
@@ -618,6 +647,37 @@ def _file_to_media(
     )
 
 
+def _summarize_media_dir(
+    entry: Path,
+) -> tuple[int, int, int, int, datetime | None]:
+    """Count images/videos/data files, total bytes, and the latest mtime."""
+    images = videos = data_files = 0
+    total_size = 0
+    latest_date: datetime | None = None
+    for path in entry.rglob("*"):
+        try:
+            if not path.is_file():
+                continue
+            ext = path.suffix.lstrip(".").lower()
+            if ext not in ALL_EXTENSIONS:
+                continue
+            stat = path.stat()
+            total_size += stat.st_size
+            eff = _effective_created_at(path, stat.st_mtime)
+            if latest_date is None or eff > latest_date:
+                latest_date = eff
+            mt = _detect_media_type(path.name)
+            if mt == MediaType.IMAGE:
+                images += 1
+            elif mt == MediaType.VIDEO:
+                videos += 1
+            else:
+                data_files += 1
+        except (FileNotFoundError, PermissionError):
+            continue
+    return images, videos, data_files, total_size, latest_date
+
+
 class StorageService:
     """Service for managing stored media files on the local filesystem.
 
@@ -627,9 +687,16 @@ class StorageService:
     for configurations and other extension data.
     """
 
-    def __init__(self, root: Path | None = None, media_root: Path | None = None):
+    def __init__(
+        self,
+        root: Path | None = None,
+        media_root: Path | None = None,
+        ipcam_root: Path | None = None,
+    ):
         self.root = root or DATA_ROOT
         self.media_root = media_root or RECORDER_ROOT
+        # Internal IP-camera recordings tree (used when no USB is mounted).
+        self.ipcam_root = ipcam_root or IPCAM_ROOT
         if not self.root.exists():
             self.root.mkdir(parents=True, exist_ok=True)
         if not self.media_root.exists() and not self.media_root.is_symlink():
@@ -693,7 +760,13 @@ class StorageService:
             if mission_id:
                 search_root = self.media_root / mission_id
                 if not search_root.exists():
-                    return []
+                    # Fall back to the internal IP-camera tree so a dive
+                    # recorded without a USB stick is still browsable.
+                    alt = self.ipcam_root / mission_id
+                    if alt.exists():
+                        search_root = alt
+                    else:
+                        return []
                 for path in search_root.rglob("*"):
                     try:
                         if not path.is_file():
@@ -706,8 +779,13 @@ class StorageService:
                     except (FileNotFoundError, PermissionError):
                         continue
             else:
-                if self.media_root.exists():
-                    for path in self.media_root.rglob("*"):
+                # ``media_root`` and ``ipcam_root`` are sibling trees under
+                # DATA_ROOT; the latter only holds files when recording
+                # without a USB stick, so scanning both never double-counts.
+                for scan_root in (self.media_root, self.ipcam_root):
+                    if not scan_root.exists():
+                        continue
+                    for path in scan_root.rglob("*"):
                         try:
                             if not path.is_file():
                                 continue
@@ -760,31 +838,9 @@ class StorageService:
                     if entry.name.lower() in SYSTEM_TOP_LEVEL:
                         continue
 
-                    images = videos = data_files = 0
-                    total_size = 0
-                    latest_date: datetime | None = None
-
-                    for path in entry.rglob("*"):
-                        try:
-                            if not path.is_file():
-                                continue
-                            ext = path.suffix.lstrip(".").lower()
-                            if ext not in ALL_EXTENSIONS:
-                                continue
-                            stat = path.stat()
-                            total_size += stat.st_size
-                            eff = _effective_created_at(path, stat.st_mtime)
-                            if latest_date is None or eff > latest_date:
-                                latest_date = eff
-                            mt = _detect_media_type(path.name)
-                            if mt == MediaType.IMAGE:
-                                images += 1
-                            elif mt == MediaType.VIDEO:
-                                videos += 1
-                            else:
-                                data_files += 1
-                        except (FileNotFoundError, PermissionError):
-                            continue
+                    images, videos, data_files, total_size, latest_date = (
+                        _summarize_media_dir(entry)
+                    )
 
                     if images + videos + data_files == 0:
                         continue
@@ -798,6 +854,28 @@ class StorageService:
                         MediaMission(
                             mission_id=entry.name,
                             mission_name=display_name,
+                            date=latest_date or datetime.now(tz=timezone.utc),
+                            image_count=images,
+                            video_count=videos,
+                            data_file_count=data_files,
+                            total_size_bytes=total_size,
+                        )
+                    )
+
+            # Internal IP-camera dives (recorded without a USB stick).
+            if self.ipcam_root.exists() and self.ipcam_root != self.media_root:
+                for entry in sorted(self.ipcam_root.iterdir(), reverse=True):
+                    if not entry.is_dir():
+                        continue
+                    images, videos, data_files, total_size, latest_date = (
+                        _summarize_media_dir(entry)
+                    )
+                    if images + videos + data_files == 0:
+                        continue
+                    missions.append(
+                        MediaMission(
+                            mission_id=entry.name,
+                            mission_name=entry.name,
                             date=latest_date or datetime.now(tz=timezone.utc),
                             image_count=images,
                             video_count=videos,

--- a/extension/backend/src/doris/services/tracker.py
+++ b/extension/backend/src/doris/services/tracker.py
@@ -22,6 +22,7 @@ missed even if the AGT emits dozens of messages between polls.
 import asyncio
 import json
 import logging
+import time
 from collections import deque
 from datetime import datetime, timezone
 
@@ -57,6 +58,15 @@ STATUSTEXT_BUFFER_SIZE = 100
 WS_RECONNECT_DELAY_S = 2.0
 WS_FIRST_CONNECT_TIMEOUT_S = 5.0  # max wait before sending first MAV_CMD_USER_4
 TRIGGER_POST_TIMEOUT_S = 15.0  # mavlink2rest POST commonly takes 4-5s
+
+# Keep reporting the tracker (and therefore the Iridium button) for this
+# long after the last good HEARTBEAT.  mavlink2rest's per-message
+# frequency estimate is noisy and regularly dips below the detection
+# threshold for a poll or two even while the AGT is heartbeating at 1 Hz,
+# which made the tracker tile randomly vanish from the sensors page
+# (issue #29).  A grace window rides out those dips without keeping a
+# truly disconnected tracker visible forever.
+TRACKER_STICKY_GRACE_S = 60.0
 
 
 def _m2r_base() -> str:
@@ -125,6 +135,9 @@ class ArtemisTrackerService:
         # AGT's "IRIDIUM: Test starting" reply (and possibly PASSED/FAILED
         # if the test resolves quickly) gets dropped on the floor.
         self._ws_connected: asyncio.Event = asyncio.Event()
+        # Monotonic timestamp of the most recent good HEARTBEAT, used to
+        # keep the tracker tile sticky across mavlink2rest frequency dips.
+        self._last_heartbeat_monotonic: float | None = None
 
     @property
     def client(self) -> httpx.AsyncClient:
@@ -133,10 +146,22 @@ class ArtemisTrackerService:
         return self._client
 
     async def get_modules(self) -> list[ModuleInfo]:
-        """Return a ModuleInfo for the tracker if a recent heartbeat exists."""
+        """Return a ModuleInfo for the tracker if it's present or was seen recently.
+
+        Detection is sticky: a single missed/low-frequency HEARTBEAT poll
+        no longer drops the tile.  We only stop reporting the tracker once
+        no heartbeat has been seen for ``TRACKER_STICKY_GRACE_S`` (issue #29).
+        """
         hb = await self._get_heartbeat()
-        if hb is None:
-            return []
+        now = time.monotonic()
+        if hb is not None:
+            self._last_heartbeat_monotonic = now
+        else:
+            last = self._last_heartbeat_monotonic
+            if last is None or (now - last) > TRACKER_STICKY_GRACE_S:
+                return []
+            # Within the grace window — ride out a transient frequency dip
+            # and keep the tile (with whatever GPS data is still available).
 
         gps = await self.get_gps_data()
 

--- a/extension/backend/tests/test_storage_ipcam.py
+++ b/extension/backend/tests/test_storage_ipcam.py
@@ -1,0 +1,108 @@
+"""Tests for internal IP-camera recording discovery (issue #32).
+
+When no USB stick is mounted, the recorder writes to
+``DATA_ROOT/userdata/ipcam_recordings/dive_<stamp>/``.  Those files used
+to be invisible on the data page because the media scan only covered the
+recorder tree and mounted USB volumes.  ``StorageService`` now also scans
+the internal ipcam tree and labels files by their per-dive folder.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from doris.models.media import MediaType
+from doris.services.storage import (
+    StorageService,
+    media_abs_path_from_download_id,
+)
+
+
+@pytest.fixture
+def svc(tmp_path: Path) -> StorageService:
+    root = tmp_path
+    media_root = root / "userdata" / "recorder"
+    ipcam_root = root / "userdata" / "ipcam_recordings"
+    media_root.mkdir(parents=True, exist_ok=True)
+    ipcam_root.mkdir(parents=True, exist_ok=True)
+    return StorageService(root=root, media_root=media_root, ipcam_root=ipcam_root)
+
+
+def _make_ipcam_recording(svc: StorageService, dive: str) -> Path:
+    d = svc.ipcam_root / dive
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / f"{dive}_part00_cyc00_00000.ts"
+    f.write_bytes(b"\x00" * 2048)
+    return f
+
+
+def _make_recorder_file(svc: StorageService, mission: str) -> Path:
+    d = svc.media_root / mission
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "clip.mp4"
+    f.write_bytes(b"\x00" * 1024)
+    return f
+
+
+async def test_flat_scan_includes_internal_ipcam(svc):
+    _make_ipcam_recording(svc, "dive_20260601_120000")
+
+    files = await svc.get_media_files()
+
+    assert len(files) == 1
+    mf = files[0]
+    assert mf.media_type == MediaType.VIDEO
+    # Grouped by the per-dive folder, not the generic "userdata" dir.
+    assert mf.mission_id == "dive_20260601_120000"
+    assert mf.dive_name == "dive_20260601_120000"
+
+
+async def test_flat_scan_no_double_count(svc):
+    _make_ipcam_recording(svc, "dive_a")
+    _make_recorder_file(svc, "mission_x")
+
+    files = await svc.get_media_files()
+    ids = sorted(f.id for f in files)
+
+    assert len(ids) == 2
+    assert len(set(ids)) == 2
+
+
+async def test_missions_include_internal_ipcam(svc):
+    _make_ipcam_recording(svc, "dive_20260601_120000")
+
+    missions = await svc.get_missions_with_media()
+    by_id = {m.mission_id: m for m in missions}
+
+    assert "dive_20260601_120000" in by_id
+    assert by_id["dive_20260601_120000"].video_count == 1
+
+
+async def test_mission_filter_resolves_ipcam_folder(svc):
+    _make_ipcam_recording(svc, "dive_20260601_120000")
+
+    files = await svc.get_media_files(mission_id="dive_20260601_120000")
+
+    assert len(files) == 1
+    assert files[0].filename.endswith(".ts")
+
+
+async def test_download_id_resolves_for_internal_ipcam(svc):
+    f = _make_ipcam_recording(svc, "dive_20260601_120000")
+
+    files = await svc.get_media_files()
+    resolved = media_abs_path_from_download_id(files[0].id, svc.root)
+
+    assert resolved == f.resolve()
+
+
+async def test_empty_ipcam_tree_is_noop(svc):
+    _make_recorder_file(svc, "mission_x")
+
+    files = await svc.get_media_files()
+    missions = await svc.get_missions_with_media()
+
+    assert len(files) == 1
+    assert all(m.mission_id == "mission_x" for m in missions)

--- a/extension/backend/tests/test_tracker.py
+++ b/extension/backend/tests/test_tracker.py
@@ -1,0 +1,101 @@
+"""Tests for Artemis tracker detection stickiness (services/tracker.py).
+
+Regression coverage for issue #29: the tracker tile (and the Iridium
+button on it) used to vanish whenever a single HEARTBEAT poll reported a
+low/zero frequency from mavlink2rest.  ``get_modules`` now keeps the
+tracker visible for ``TRACKER_STICKY_GRACE_S`` after the last good
+heartbeat so transient frequency dips don't drop the tile.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from doris.services import tracker as tracker_mod
+from doris.services.tracker import ArtemisTrackerService
+
+
+@pytest.fixture
+def svc(monkeypatch) -> ArtemisTrackerService:
+    s = ArtemisTrackerService()
+    # GPS read is irrelevant to detection; keep it cheap and deterministic.
+    monkeypatch.setattr(s, "get_gps_data", _async_return(None))
+    return s
+
+
+def _async_return(value):
+    async def _coro(*_args, **_kwargs):
+        return value
+    return _coro
+
+
+def _set_heartbeat(monkeypatch, svc: ArtemisTrackerService, present: bool) -> None:
+    monkeypatch.setattr(
+        svc, "_get_heartbeat", _async_return({"type": "HEARTBEAT"} if present else None)
+    )
+
+
+def _set_clock(monkeypatch, value: float) -> None:
+    monkeypatch.setattr(tracker_mod.time, "monotonic", lambda: value)
+
+
+async def test_present_heartbeat_shows_tracker(svc, monkeypatch):
+    _set_clock(monkeypatch, 100.0)
+    _set_heartbeat(monkeypatch, svc, present=True)
+
+    modules = await svc.get_modules()
+
+    assert len(modules) == 1
+    assert modules[0].type == "tracker"
+
+
+async def test_never_seen_returns_empty(svc, monkeypatch):
+    _set_clock(monkeypatch, 100.0)
+    _set_heartbeat(monkeypatch, svc, present=False)
+
+    assert await svc.get_modules() == []
+
+
+async def test_transient_dip_within_grace_keeps_tile(svc, monkeypatch):
+    # Seen at t=100 …
+    _set_clock(monkeypatch, 100.0)
+    _set_heartbeat(monkeypatch, svc, present=True)
+    assert len(await svc.get_modules()) == 1
+
+    # … missed heartbeat 10s later (well within the grace window).
+    _set_clock(monkeypatch, 110.0)
+    _set_heartbeat(monkeypatch, svc, present=False)
+    assert len(await svc.get_modules()) == 1
+
+
+async def test_grace_expiry_drops_tile(svc, monkeypatch):
+    _set_clock(monkeypatch, 100.0)
+    _set_heartbeat(monkeypatch, svc, present=True)
+    assert len(await svc.get_modules()) == 1
+
+    # Past the grace window with no heartbeat -> tracker gone.
+    _set_clock(monkeypatch, 100.0 + tracker_mod.TRACKER_STICKY_GRACE_S + 1.0)
+    _set_heartbeat(monkeypatch, svc, present=False)
+    assert await svc.get_modules() == []
+
+
+async def test_recovered_heartbeat_resets_grace(svc, monkeypatch):
+    _set_clock(monkeypatch, 100.0)
+    _set_heartbeat(monkeypatch, svc, present=True)
+    await svc.get_modules()
+
+    # Dip, then recover before grace expires; the recovery should refresh
+    # the timestamp so the tile survives another full grace window.
+    _set_clock(monkeypatch, 130.0)
+    _set_heartbeat(monkeypatch, svc, present=False)
+    assert len(await svc.get_modules()) == 1
+
+    _set_clock(monkeypatch, 140.0)
+    _set_heartbeat(monkeypatch, svc, present=True)
+    assert len(await svc.get_modules()) == 1
+
+    # 50s after the *recovery*: still within grace (would have expired if
+    # measured from the original t=100 sighting).
+    _set_clock(monkeypatch, 190.0)
+    _set_heartbeat(monkeypatch, svc, present=False)
+    assert len(await svc.get_modules()) == 1

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -225,13 +225,15 @@ const descentCaptureFrequencyTooLow = computed(() => {
 })
 
 const releaseWeightWarning = computed(() => {
+  // This value is the bottom time before weight release (counted from when
+  // DORIS reaches the seafloor), not total dive duration. A short bottom
+  // time is a valid choice, so we only flag implausibly long values.
   const totalMinutes = releaseWeightElapsedUnit.value === 'hours'
     ? Number(releaseWeightElapsedNumber.value) * 60
     : releaseWeightElapsedUnit.value === 'minutes'
     ? Number(releaseWeightElapsedNumber.value)
     : Number(releaseWeightElapsedNumber.value) / 60
-  if (totalMinutes < 20) return { show: true, severity: 'warning' as const, title: 'Release Time May Be Short', message: 'Release time is under 20 minutes. This may not allow enough dive duration, but will be used as configured.' }
-  if (totalMinutes > 1200) return { show: true, severity: 'error' as const, title: 'Release Time Too Long', message: 'Release time exceeds 20 hours. Consider if this extended duration is necessary for mission objectives.' }
+  if (totalMinutes > 1200) return { show: true, severity: 'error' as const, title: 'Bottom Time Too Long', message: 'Bottom time before release exceeds 20 hours. Consider if this extended duration is necessary for mission objectives.' }
   return { show: false, severity: 'warning' as const, title: '', message: '' }
 })
 
@@ -1416,7 +1418,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
             <div class="space-y-3">
               <label class="flex items-center gap-2 cursor-pointer">
                 <input type="radio" value="elapsed" :checked="releaseWeightBy === 'elapsed'" @change="emit('update:releaseWeightBy', 'elapsed')" class="w-4 h-4" />
-                <span style="color: #96EEF2">By Elapsed Time from Dive Start</span>
+                <span style="color: #96EEF2">By Elapsed Time on Bottom</span>
               </label>
               <div v-if="releaseWeightBy === 'elapsed'" class="pl-6 space-y-3">
                 <div class="flex gap-2">
@@ -1425,6 +1427,9 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
                     <option value="seconds">seconds</option><option value="minutes">minutes</option><option value="hours">hours</option>
                   </select>
                 </div>
+                <p class="text-xs italic" style="color: rgba(150, 238, 242, 0.5)">
+                  Time spent on the bottom before the weight is released. Counted from when DORIS reaches the seafloor, not from launch.
+                </p>
                 <div v-if="releaseWeightWarning.show" class="mt-3 rounded-lg p-4" :style="releaseWeightWarning.severity === 'warning' ? 'background-color: rgba(255, 184, 0, 0.1); border: 1px solid rgba(255, 184, 0, 0.5)' : 'background-color: #0E2446; border: 2px solid #DD2C1D'">
                   <div class="flex items-start gap-3">
                     <AlertTriangle class="w-5 h-5 flex-shrink-0 mt-0.5" :style="releaseWeightWarning.severity === 'warning' ? 'color: #FFB800' : 'color: #DD2C1D'" />


### PR DESCRIPTION
## Summary

Batch of DORIS extension fixes from an issue triage pass. Each commit is scoped to one issue.

- **#28 — Release timing wording** (`fix(mission-ui)`): the release-weight "elapsed" option is measured from bottom arrival (`DORIS_BTM_TIM` / `bottom_elapsed`), not from dive start. Relabeled "By Elapsed Time on Bottom", added a clarifying hint, and removed the misleading "release time under 20 minutes" warning that conflated bottom time with total dive duration.
- **#29 — Iridium tile randomly missing** (`fix(sensors)`): the Artemis tracker tile (which hosts the Iridium test button) dropped out whenever a single HEARTBEAT poll reported `frequency < 0.05`, which mavlink2rest does intermittently even at a steady 1 Hz. Detection is now sticky for a 60s grace window after the last good heartbeat. Adds regression tests.
- **#32 — Internal recordings not on data page** (`fix(media)`): when no USB stick is mounted the recorder writes to `DATA_ROOT/userdata/ipcam_recordings/dive_<stamp>/`, but the media scan only covered the recorder tree and USB volumes, so those recordings were invisible. `StorageService` now also scans the internal ipcam tree (flat listing, per-mission filtering, mission discovery) and labels files by their per-dive folder. Sibling-tree scanning never double-counts USB recordings. Adds regression tests.
- **#30 — Interval-recording light delay** (`fix(dive)`): in interval bottom recording the light was hard-tied to the recorder, so after the first cycle camera and light came on together and the configured light delay was ignored. The light now turns on `light_delay` (`DORIS_BTM_DLY`) seconds after each recording starts and turns off with the camera when the record window (`DORIS_BTM_RECS`, measured from camera start) ends. The one-time camera settle (`DORIS_CAM_DLY`) still gates the first cycle. No new Lua upvalues/locals — per-cycle state reuses `ipcam_state`.

Also verified **#10** (slow downloads) is already addressed by the streaming/HEAD/DownloadToast changes already in `master`, and closed it.

## Test plan

- [x] Backend unit tests pass (`pytest` — 89 passed, including new `test_tracker.py` and `test_storage_ipcam.py`).
- [x] Frontend change is a label/warning/copy edit; reviewed (no `node_modules` in this env to run `vue-tsc`).
- [ ] Bench/SITL check of the interval recording light timing on real hardware before the next deployment (the Lua change controls deployment hardware and there's no Lua toolchain in CI here to `luac -p`).
- [ ] Confirm internal (no-USB) test recordings now appear on the Data page on a device.
- [ ] Confirm the Iridium tile stays visible across mavlink2rest frequency dips on a device.
