### PR TITLE
fix: DORIS UI quick-wins (#36, #41, #40, #39)

### DIFF
--- a/extension/backend/src/doris/models/configuration.py
+++ b/extension/backend/src/doris/models/configuration.py
@@ -76,7 +76,7 @@ class CameraSettings(BaseModel):
 class LightSettings(BaseModel):
     enabled: bool = False
     mode: LightMode = LightMode.CONTINUOUS
-    brightness: int = 75
+    brightness: int = 60
     match_camera_interval: bool = False
 
     on_time: TimeValue = Field(default_factory=lambda: TimeValue(number="10", unit="seconds"))

--- a/extension/frontend/src/components/AllMissions.vue
+++ b/extension/frontend/src/components/AllMissions.vue
@@ -4,9 +4,10 @@ import {
   Database, Calendar, Clock, MapPin, Camera, Image, FileText, Play,
   Download, Trash2, AlertTriangle, Archive, Search, X, Loader2
 } from 'lucide-vue-next'
-import { useDiveHistory } from '../composables/useApi'
+import { useDiveHistory, useMedia } from '../composables/useApi'
+import { enqueueBulkDownload } from '../composables/useDownloads'
 import { parseBackendDateTime } from '../parseBackendTime'
-import type { DiveHistorySummary } from '../composables/useApi'
+import type { DiveHistorySummary, MediaFile } from '../composables/useApi'
 import type { Screen, DiveData } from '../types'
 
 const emit = defineEmits<{
@@ -14,6 +15,7 @@ const emit = defineEmits<{
 }>()
 
 const { dives: apiDives, loading, error, fetchDives, deleteDiveRecord } = useDiveHistory()
+const { files: mediaFiles, fetchFiles } = useMedia()
 
 function mcapDownloadHref(relativePath: string): string {
   return `/api/v1/media/download?path=${encodeURIComponent(relativePath)}`
@@ -154,6 +156,87 @@ async function handleExportCsv(mission: DisplayMission) {
     const next = new Set(exportingIds.value)
     next.delete(mission.id)
     exportingIds.value = next
+  }
+}
+
+// Per-dive bulk download state. "Download Media" grabs images + videos;
+// "Download All Files" adds data files. Both join media to the dive by
+// dive_name (the same key the media browser uses) and stream through the
+// shared download queue so the global <DownloadToast /> shows progress.
+const downloadingMediaIds = ref<Set<string>>(new Set())
+const downloadingAllIds = ref<Set<string>>(new Set())
+const downloadErrors = ref<Record<string, string>>({})
+
+function setDownloadError(missionId: string, message: string) {
+  downloadErrors.value = { ...downloadErrors.value, [missionId]: message }
+}
+
+function clearDownloadError(missionId: string) {
+  if (downloadErrors.value[missionId]) {
+    const next = { ...downloadErrors.value }
+    delete next[missionId]
+    downloadErrors.value = next
+  }
+}
+
+function withId(set: Set<string>, id: string, present: boolean): Set<string> {
+  const next = new Set(set)
+  if (present) next.add(id)
+  else next.delete(id)
+  return next
+}
+
+async function diveMediaFiles(mission: DisplayMission): Promise<MediaFile[]> {
+  // Fetch generously: the endpoint has no dive_name filter, so we pull the
+  // flat file list and join client-side. A high limit avoids truncating a
+  // dive's files in a "download all" action when many dives are on disk.
+  await fetchFiles({ limit: 5000 })
+  const want = mission.name.trim().toLowerCase()
+  if (!want) return []
+  return mediaFiles.value.filter(f => (f.dive_name ?? '').trim().toLowerCase() === want)
+}
+
+function toDownloadItems(rows: MediaFile[]) {
+  return rows.map(f => ({ filePath: f.id, fileName: f.filename, sizeBytes: f.size_bytes }))
+}
+
+async function handleDownloadMedia(mission: DisplayMission) {
+  if (downloadingMediaIds.value.has(mission.id)) return
+  downloadingMediaIds.value = withId(downloadingMediaIds.value, mission.id, true)
+  clearDownloadError(mission.id)
+  try {
+    const rows = (await diveMediaFiles(mission)).filter(
+      f => f.media_type === 'image' || f.media_type === 'video',
+    )
+    const items = toDownloadItems(rows)
+    if (items.length === 0) {
+      setDownloadError(mission.id, 'No media files found for this dive.')
+      return
+    }
+    await enqueueBulkDownload(items)
+  } catch {
+    setDownloadError(mission.id, 'Download failed. Please try again.')
+  } finally {
+    downloadingMediaIds.value = withId(downloadingMediaIds.value, mission.id, false)
+  }
+}
+
+async function handleDownloadAllFiles(mission: DisplayMission) {
+  if (downloadingAllIds.value.has(mission.id)) return
+  downloadingAllIds.value = withId(downloadingAllIds.value, mission.id, true)
+  clearDownloadError(mission.id)
+  try {
+    const rows = await diveMediaFiles(mission)
+    const items = toDownloadItems(rows)
+    if (items.length === 0) {
+      setDownloadError(mission.id, 'No files found for this dive.')
+      return
+    }
+    await enqueueBulkDownload(items)
+  } catch {
+    setDownloadError(mission.id, 'Download failed. Please try again.')
+  } finally {
+    downloadingAllIds.value = withId(downloadingAllIds.value, mission.id, false)
   }
 }
 
@@ -423,24 +506,35 @@ const handleDeleteMission = async () => {
               </button>
               <button
                 type="button"
-                disabled
-                title="Use the Data page to download files"
-                class="px-4 py-2 rounded-lg flex items-center gap-2 text-sm whitespace-nowrap opacity-45 cursor-not-allowed"
+                @click="handleDownloadMedia(mission)"
+                :disabled="downloadingMediaIds.has(mission.id)"
+                title="Download all images and videos from this dive"
+                class="px-4 py-2 rounded-lg flex items-center gap-2 text-sm whitespace-nowrap transition-all hover:opacity-90 disabled:opacity-70 disabled:cursor-wait"
                 style="background-color: rgba(65, 185, 195, 0.3); border: 1px solid #41B9C3; color: #96EEF2"
               >
-                <Download class="w-4 h-4" />
-                Download Media
+                <Loader2 v-if="downloadingMediaIds.has(mission.id)" class="w-4 h-4 animate-spin" />
+                <Download v-else class="w-4 h-4" />
+                {{ downloadingMediaIds.has(mission.id) ? 'Starting…' : 'Download Media' }}
               </button>
               <button
                 type="button"
-                disabled
-                title="Not available yet"
-                class="px-4 py-2 rounded-lg flex items-center gap-2 text-sm whitespace-nowrap opacity-45 cursor-not-allowed"
+                @click="handleDownloadAllFiles(mission)"
+                :disabled="downloadingAllIds.has(mission.id)"
+                title="Download all images, videos and data files from this dive"
+                class="px-4 py-2 rounded-lg flex items-center gap-2 text-sm whitespace-nowrap transition-all hover:opacity-90 disabled:opacity-70 disabled:cursor-wait"
                 style="background-color: rgba(65, 185, 195, 0.2); border: 1px solid #41B9C3; color: #41B9C3"
               >
-                <Archive class="w-4 h-4" />
-                Download All Files
+                <Loader2 v-if="downloadingAllIds.has(mission.id)" class="w-4 h-4 animate-spin" />
+                <Archive v-else class="w-4 h-4" />
+                {{ downloadingAllIds.has(mission.id) ? 'Starting…' : 'Download All Files' }}
               </button>
+              <span
+                v-if="downloadErrors[mission.id]"
+                class="text-xs text-center"
+                style="color: #FF4757"
+              >
+                {{ downloadErrors[mission.id] }}
+              </span>
               <button
                 class="px-4 py-2 rounded-lg transition-all hover:opacity-90 flex items-center gap-2 text-sm whitespace-nowrap"
                 style="background-color: rgba(221, 44, 29, 0.2); border: 1px solid #DD2C1D; color: #DD2C1D"

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -71,7 +71,7 @@ const descentLightOnNumber = ref('10')
 const descentLightOnUnit = ref('seconds')
 const descentLightOffNumber = ref('5')
 const descentLightOffUnit = ref('seconds')
-const descentLightBrightness = ref(75)
+const descentLightBrightness = ref(60)
 const descentMatchCameraInterval = ref(false)
 
 // On Bottom settings
@@ -109,7 +109,7 @@ const bottomLightOnNumber = ref('10')
 const bottomLightOnUnit = ref('seconds')
 const bottomLightOffNumber = ref('5')
 const bottomLightOffUnit = ref('seconds')
-const bottomLightBrightness = ref(75)
+const bottomLightBrightness = ref(60)
 const bottomMatchCameraInterval = ref(false)
 
 // Ascent settings
@@ -146,7 +146,7 @@ const ascentLightOnNumber = ref('10')
 const ascentLightOnUnit = ref('seconds')
 const ascentLightOffNumber = ref('5')
 const ascentLightOffUnit = ref('seconds')
-const ascentLightBrightness = ref(75)
+const ascentLightBrightness = ref(60)
 const ascentMatchCameraInterval = ref(false)
 
 // Recovery settings
@@ -296,7 +296,7 @@ function resetToDefaults() {
   descentLightOnUnit.value = 'seconds'
   descentLightOffNumber.value = '5'
   descentLightOffUnit.value = 'seconds'
-  descentLightBrightness.value = 75
+  descentLightBrightness.value = 60
   descentMatchCameraInterval.value = false
   bottomCameraOn.value = true
   bottomCameraDelayNumber.value = '30'
@@ -332,7 +332,7 @@ function resetToDefaults() {
   bottomLightOnUnit.value = 'seconds'
   bottomLightOffNumber.value = '5'
   bottomLightOffUnit.value = 'seconds'
-  bottomLightBrightness.value = 75
+  bottomLightBrightness.value = 60
   bottomMatchCameraInterval.value = false
   ascentSameAsDescent.value = false
   emit('update:releaseWeightBy', 'elapsed')
@@ -368,7 +368,7 @@ function resetToDefaults() {
   ascentLightOnUnit.value = 'seconds'
   ascentLightOffNumber.value = '5'
   ascentLightOffUnit.value = 'seconds'
-  ascentLightBrightness.value = 75
+  ascentLightBrightness.value = 60
   ascentMatchCameraInterval.value = false
   activateMastLight.value = false
   updateFrequency.value = '5min'
@@ -716,7 +716,7 @@ function handleBrightnessChange(value: number, phase: 'descent' | 'bottom' | 'as
   const currentBrightness = phase === 'descent' ? descentLightBrightness.value
     : phase === 'bottom' ? bottomLightBrightness.value
     : ascentLightBrightness.value
-  if (value < 75 && currentBrightness >= 75) {
+  if (value < 60 && currentBrightness >= 60) {
     pendingBrightness.value = { value, phase }
     showBrightnessWarning.value = true
   } else {
@@ -1870,7 +1870,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
             <AlertTriangle class="w-5 h-5 flex-shrink-0 mt-0.5" style="color: #DD2C1D" />
             <div class="flex-1">
               <h3 class="text-white font-semibold mb-1">Low Brightness Warning</h3>
-              <p class="text-white text-sm opacity-90">Setting the light brightness below 75% may result in poor image quality and reduced visibility.</p>
+              <p class="text-white text-sm opacity-90">Setting the light brightness below 60% may result in poor image quality and reduced visibility.</p>
             </div>
             <div class="flex gap-2 ml-2">
               <button @click="cancelBrightnessChange" class="px-3 py-1.5 text-sm text-white rounded transition-all hover:opacity-80" style="background-color: rgba(65, 185, 195, 0.2); border: 1px solid rgba(65, 185, 195, 0.4)">Cancel</button>

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted, onUnmounted, computed } from 'vue'
-import { Settings, Save, Copy, AlertTriangle, ChevronDown, ChevronUp, Camera as CameraIcon, Lightbulb, Database as DatabaseIcon, Battery, ArrowDown, Anchor, ArrowUp, Radio, X } from 'lucide-vue-next'
+import { Settings, Save, Copy, AlertTriangle, ChevronDown, ChevronUp, Camera as CameraIcon, Lightbulb, Database as DatabaseIcon, Battery, ArrowDown, Anchor, ArrowUp, Radio, X, Trash2 } from 'lucide-vue-next'
 import type { Screen } from '../types'
 import { useConfigurations } from '../composables/useApi'
 import type { DeploymentConfiguration } from '../composables/useApi'
@@ -24,6 +24,9 @@ const warnings = ref<string[]>([])
 const showBatteryPlanning = ref(false)
 const showSaveModal = ref(false)
 const configurationName = ref('')
+const showDeleteModal = ref(false)
+const deleting = ref(false)
+const deleteError = ref('')
 const hasUnsavedChanges = ref(false)
 let suppressUnsavedTracking = false
 const showNavigationWarning = ref(false)
@@ -33,6 +36,7 @@ const {
   fetchConfigurations,
   loadConfiguration,
   saveConfiguration,
+  deleteConfiguration,
   error: configurationSaveError,
   clearError: clearConfigurationSaveError,
 } = useConfigurations()
@@ -712,6 +716,37 @@ async function handleConfigurationChange(value: string) {
   }
 }
 
+function requestDeleteConfiguration() {
+  if (!selectedConfiguration.value || selectedConfiguration.value === 'New Configuration') return
+  deleteError.value = ''
+  showDeleteModal.value = true
+}
+
+async function confirmDeleteConfiguration() {
+  const target = selectedConfiguration.value
+  if (!target || target === 'New Configuration') {
+    showDeleteModal.value = false
+    return
+  }
+  deleting.value = true
+  deleteError.value = ''
+  const ok = await deleteConfiguration(target)
+  deleting.value = false
+  if (!ok) {
+    deleteError.value = configurationSaveError.value || 'Failed to delete configuration.'
+    return
+  }
+  showDeleteModal.value = false
+  selectedConfiguration.value = ''
+  hasUnsavedChanges.value = false
+  resetToDefaults()
+}
+
+function cancelDeleteConfiguration() {
+  showDeleteModal.value = false
+  deleteError.value = ''
+}
+
 function handleBrightnessChange(value: number, phase: 'descent' | 'bottom' | 'ascent') {
   const currentBrightness = phase === 'descent' ? descentLightBrightness.value
     : phase === 'bottom' ? bottomLightBrightness.value
@@ -827,11 +862,24 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
       <!-- Configuration Profile -->
       <div class="mb-6">
         <label class="block mb-2" style="color: #96EEF2">Load Configuration</label>
-        <select :value="selectedConfiguration" @change="handleConfigurationChange(($event.target as HTMLSelectElement).value)" class="w-full px-4 py-3 text-white rounded-lg focus:outline-none mb-3" :style="inputStyle">
-          <option value="">-- Select Configuration --</option>
-          <option value="New Configuration">New Configuration</option>
-          <option v-for="(config, index) in savedConfigurations" :key="index" :value="config">{{ config }}</option>
-        </select>
+        <div class="flex items-stretch gap-2 mb-3">
+          <select :value="selectedConfiguration" @change="handleConfigurationChange(($event.target as HTMLSelectElement).value)" class="flex-1 px-4 py-3 text-white rounded-lg focus:outline-none" :style="inputStyle">
+            <option value="">-- Select Configuration --</option>
+            <option value="New Configuration">New Configuration</option>
+            <option v-for="(config, index) in savedConfigurations" :key="index" :value="config">{{ config }}</option>
+          </select>
+          <button
+            v-if="selectedConfiguration && selectedConfiguration !== 'New Configuration'"
+            type="button"
+            @click="requestDeleteConfiguration"
+            :title="`Delete configuration ${selectedConfiguration}`"
+            aria-label="Delete configuration"
+            class="px-4 rounded-lg text-white transition-all hover:opacity-90 flex items-center justify-center"
+            style="background-color: rgba(221, 44, 29, 0.2); border: 1px solid rgba(221, 44, 29, 0.5)"
+          >
+            <Trash2 class="w-5 h-5" style="color: #FF6B5E" />
+          </button>
+        </div>
       </div>
 
       <!-- ==================== DESCENT SECTION ==================== -->
@@ -1838,6 +1886,33 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
               </button>
             </div>
           </template>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Delete Configuration Modal -->
+    <Teleport to="body">
+      <div v-if="showDeleteModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div class="w-full max-w-md rounded-xl p-6" style="background-color: #0E2446; border: 2px solid #DD2C1D">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-white text-xl flex items-center gap-2">
+              <Trash2 class="w-5 h-5" style="color: #FF6B5E" />
+              Delete Configuration
+            </h2>
+            <button @click="cancelDeleteConfiguration" class="text-white hover:opacity-80 transition-opacity">
+              <X class="w-5 h-5" />
+            </button>
+          </div>
+          <p class="text-white mb-4">
+            Permanently delete <span class="font-semibold" style="color: #96EEF2">{{ selectedConfiguration }}</span>? This cannot be undone.
+          </p>
+          <p v-if="deleteError" class="text-sm mb-4 rounded-lg p-3" style="color: #FF9937; background-color: rgba(221, 44, 29, 0.15); border: 1px solid rgba(221, 44, 29, 0.4)">{{ deleteError }}</p>
+          <div class="flex gap-3">
+            <button @click="cancelDeleteConfiguration" :disabled="deleting" class="flex-1 px-4 py-3 rounded-lg transition-all disabled:opacity-50" style="background-color: rgba(65, 185, 195, 0.2); border: 1px solid rgba(65, 185, 195, 0.3); color: #96EEF2">Cancel</button>
+            <button @click="confirmDeleteConfiguration" :disabled="deleting" class="flex-1 px-4 py-3 text-white rounded-lg transition-all hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed" style="background-color: #DD2C1D">
+              <Trash2 class="w-4 h-4 inline mr-2" />{{ deleting ? 'Deleting…' : 'Delete' }}
+            </button>
+          </div>
         </div>
       </div>
     </Teleport>

--- a/extension/frontend/src/components/ViewMediaScreen.vue
+++ b/extension/frontend/src/components/ViewMediaScreen.vue
@@ -2,10 +2,11 @@
 import { ref, computed, onMounted } from 'vue'
 import {
   ArrowLeft, Calendar, Clock, Gauge, MapPin, User, Download,
-  Trash2, ZoomIn, Image, Video, Play, FileText, Loader2, AlertCircle
+  Trash2, ZoomIn, Image, Video, Play, Loader2, AlertCircle
 } from 'lucide-vue-next'
 import type { Screen, DiveData } from '../types'
 import { useMedia, type MediaFile } from '../composables/useApi'
+import { enqueueBulkDownload } from '../composables/useDownloads'
 import { parseBackendDateTime } from '../parseBackendTime'
 
 const API_V1 = '/api/v1'
@@ -37,6 +38,7 @@ const { files, loading, error, fetchFiles } = useMedia()
 
 const lightboxIndex = ref<number | null>(null)
 const showDeleteModal = ref(false)
+const downloadingAll = ref(false)
 
 const currentDive = computed<DiveData>(() => props.diveData ?? {
   name: 'Media',
@@ -153,6 +155,26 @@ const goBack = () => {
   emit('navigate', props.previousScreen)
 }
 
+const handleDownloadAll = async () => {
+  if (downloadingAll.value) return
+  const want = diveNameNorm.value
+  const items = files.value
+    .filter((f) => {
+      if (f.media_type !== 'image' && f.media_type !== 'video') return false
+      if (!want) return true
+      const dn = (f.dive_name ?? '').trim().toLowerCase()
+      return dn === want
+    })
+    .map((f) => ({ filePath: f.id, fileName: f.filename, sizeBytes: f.size_bytes }))
+  if (items.length === 0) return
+  downloadingAll.value = true
+  try {
+    await enqueueBulkDownload(items)
+  } finally {
+    downloadingAll.value = false
+  }
+}
+
 const imageCount = computed(() => mediaItems.value.filter(m => m.type === 'image').length)
 const videoCount = computed(() => mediaItems.value.filter(m => m.type === 'video').length)
 
@@ -194,18 +216,15 @@ onMounted(() => {
         </div>
         <div class="flex flex-wrap gap-2">
           <button
-            class="px-3 py-1.5 text-sm rounded-lg transition-all hover:opacity-90 flex items-center gap-1.5"
+            @click="handleDownloadAll"
+            :disabled="downloadingAll || mediaItems.length === 0"
+            :title="mediaItems.length === 0 ? 'No media to download' : `Download all ${mediaItems.length} media files`"
+            class="px-3 py-1.5 text-sm rounded-lg transition-all hover:opacity-90 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
             style="background: linear-gradient(135deg, #FF9937 0%, #FF621D 100%); color: white"
           >
-            <Download class="w-3.5 h-3.5" />
-            Download All
-          </button>
-          <button
-            class="px-3 py-1.5 text-sm rounded-lg transition-all hover:opacity-90 flex items-center gap-1.5"
-            style="background: linear-gradient(135deg, #41B9C3 0%, #187D8B 100%); color: white"
-          >
-            <FileText class="w-3.5 h-3.5" />
-            Open Log
+            <Loader2 v-if="downloadingAll" class="w-3.5 h-3.5 animate-spin" />
+            <Download v-else class="w-3.5 h-3.5" />
+            {{ downloadingAll ? 'Starting…' : 'Download All' }}
           </button>
           <button
             @click="confirmDelete"


### PR DESCRIPTION
## Summary

A batch of small DORIS UI quick-wins, one commit per issue:

- **#36 — Default light brightness 60%**: lowered the default brightness for descent/bottom/ascent (frontend + backend config default) and updated the low-brightness warning threshold/text.
- **#41 — Delete saved configurations**: added a trash button beside the configuration dropdown with a confirmation modal, wired to the existing `DELETE /api/v1/configurations/:name` endpoint. On delete, the selection clears and the form resets to defaults.
- **#40 — Previous Dives download buttons**: the previously grayed-out **Download Media** and **Download All Files** buttons now work. They stream the dive's files through the shared download queue (driving the global `DownloadToast`). *Download Media* grabs images + videos; *Download All Files* adds data files. Media is joined to the dive by `dive_name`, matching the View Media screen. Each button shows a spinner/disabled state while in flight, with inline error handling.
- **#39 — View Media page**: removed the non-functional **Open Log** button; wired up the **Download All** button (it previously had no click handler) to the shared download queue with spinner/progress feedback.

## Notes

- Frontend-only except the #36 backend default. The download buttons reuse the existing `useDownloads` queue / `DownloadToast` from the earlier media-download work.
- The per-dive media join is by display `dive_name` (consistent with the existing View Media screen), so two dives sharing an identical name would group together — matching current app-wide behavior.

## Test plan

- [ ] Delete a saved configuration from the dropdown; confirm it disappears and the form resets.
- [ ] On Previous Dives, click **Download Media** and **Download All Files**; confirm the download toast shows progress and files save.
- [ ] On View Media, confirm **Open Log** is gone and **Download All** downloads the dive's media with progress feedback.
- [ ] Confirm default light brightness is 60% on a fresh configuration and the warning appears below 60%.

Closes #36
Closes #41
Closes #40
Closes #39
