### PR TITLE
Arming pre-arm banner (#44/#8) and dive config-name recovery (#38)

### DIFF
--- a/extension/backend/src/doris/main.py
+++ b/extension/backend/src/doris/main.py
@@ -11,6 +11,7 @@ from .config import settings
 from .services.network import NetworkService
 from .services.persistent_log import setup_persistent_logging, start_dmesg_capture
 from .routes import (
+    register_arming_routes,
     register_artemis_routes,
     register_attitude_routes,
     register_blueos_routes,
@@ -127,6 +128,7 @@ def create_app() -> Robyn:
     register_configuration_routes(app)
     register_dive_routes(app)
     register_frame_routes(app)
+    register_arming_routes(app)
     register_notification_routes(app)
 
     register_log_routes(app)

--- a/extension/backend/src/doris/routes/__init__.py
+++ b/extension/backend/src/doris/routes/__init__.py
@@ -1,5 +1,6 @@
 """API routes for DORIS backend."""
 
+from .arming import register_arming_routes
 from .artemis import register_artemis_routes
 from .attitude import register_attitude_routes
 from .blueos import register_blueos_routes
@@ -16,6 +17,7 @@ from .sensors import register_sensor_routes
 from .system import register_system_routes
 
 __all__ = [
+    "register_arming_routes",
     "register_artemis_routes",
     "register_attitude_routes",
     "register_blueos_routes",

--- a/extension/backend/src/doris/routes/arming.py
+++ b/extension/backend/src/doris/routes/arming.py
@@ -1,0 +1,31 @@
+"""Vehicle arming-status API route.
+
+Exposes the autopilot's armed state and any failing pre-arm checks so the
+frontend can show a "waiting to arm" banner with the reason (issues #44,
+#8).
+"""
+
+import json
+
+from robyn import Response, Robyn
+
+from ..services.arming import ArmingService
+
+
+def register_arming_routes(app: Robyn) -> None:
+    """Register the vehicle arming-status endpoint."""
+
+    arming_service = ArmingService()
+
+    @app.get("/api/v1/vehicle/arming")
+    async def get_arming_status(request):
+        """Return armed state plus current failing pre-arm checks."""
+        try:
+            status = await arming_service.get_status()
+            return json.dumps(status)
+        except Exception as e:
+            return Response(
+                status_code=500,
+                description=json.dumps({"error": str(e)}),
+                headers={"Content-Type": "application/json"},
+            )

--- a/extension/backend/src/doris/routes/dive.py
+++ b/extension/backend/src/doris/routes/dive.py
@@ -24,6 +24,7 @@ from ..services import ip_camera_recorder as iprec
 from ..services.camera import CameraService
 from ..services.dive import DiveService
 from ..services.dive_finalize import finalize_dive
+from ..services.dive_records import find_latest_active_dive_record
 from ..services.storage import DATA_ROOT, StorageService, media_download_id_from_abs_path
 
 logger = logging.getLogger(__name__)
@@ -152,6 +153,12 @@ def _update_active_dive_record(new_status: str) -> Path | None:
         except Exception as e:
             logger.warning(f"Error reading {dive_file.name}: {e}")
     return None
+
+
+def _find_latest_active_dive_record() -> dict | None:
+    """Most recent 'active' dive record, used to reconstruct the banner
+    configuration name after a restart/reconnect (issue #38)."""
+    return find_latest_active_dive_record(DIVES_DIR)
 
 
 def _schedule_binlog_archive(dive_file: Path) -> None:
@@ -485,13 +492,44 @@ def register_dive_routes(app: Robyn) -> None:
     async def dive_mission():
         status = await dive_service.get_status()
         _sync_mission_state_from_vehicle(status)
-        if not MISSION_STATE_PATH.exists():
+        mission: dict | None = None
+        if MISSION_STATE_PATH.exists():
+            try:
+                mission = json.loads(MISSION_STATE_PATH.read_text())
+            except Exception:
+                mission = None
+
+        # Issue #38: after a vehicle restart or device reconnect the
+        # mission state can be missing or lose its configuration name while
+        # the dive is still active, so the banner falls back to a bare
+        # "Active Dive".  Reconstruct the configuration name from the
+        # persisted active dive record (which survives restarts) and heal
+        # mission_state.json so subsequent reads are consistent.
+        needs_config = mission is None or not str(
+            mission.get("configuration_name") or ""
+        ).strip()
+        if needs_config:
+            record = _find_latest_active_dive_record()
+            if record is not None:
+                config_name = str(record.get("configuration") or "").strip()
+                if config_name:
+                    if mission is None:
+                        mission = {
+                            "status": "active",
+                            "configuration_name": config_name,
+                            "loaded_at": record.get("started_at", ""),
+                            "profile_id": record.get("profile_id", 0),
+                            "dive_file": record.get("_dive_file", ""),
+                        }
+                    else:
+                        mission["configuration_name"] = config_name
+                    _write_mission_state(
+                        {k: v for k, v in mission.items() if not k.startswith("_")}
+                    )
+
+        if mission is None:
             return json.dumps({"mission": None})
-        try:
-            mission = json.loads(MISSION_STATE_PATH.read_text())
-            return json.dumps({"mission": mission})
-        except Exception:
-            return json.dumps({"mission": None})
+        return json.dumps({"mission": mission})
 
     @app.get("/api/v1/dive/status")
     async def dive_status():

--- a/extension/backend/src/doris/services/arming.py
+++ b/extension/backend/src/doris/services/arming.py
@@ -1,0 +1,267 @@
+"""Vehicle arming-status service.
+
+Surfaces the autopilot's arming state and any failing pre-arm checks so
+the extension can show a "waiting to arm" banner that explains *why* the
+vehicle won't arm (issues #44 and #8).
+
+How ArduPilot reports this
+──────────────────────────
+While disarmed with failing checks, ArduPilot streams the failure reasons
+as STATUSTEXT messages ("PreArm: <reason>") on a rotating ~30-60 s nag, and
+emits "Arm: <reason>" when an arm attempt is rejected.  mavlink2rest's HTTP
+message endpoint only caches the *latest* STATUSTEXT, so a single GET would
+miss most of the rotating reasons.  We therefore subscribe to the
+mavlink2rest STATUSTEXT WebSocket (mirroring ``ArtemisTrackerService``) and
+keep a de-duplicated, TTL-bounded view of the most recent failing checks.
+
+Armed state comes from the autopilot HEARTBEAT (``base_mode`` &
+``MAV_MODE_FLAG_SAFETY_ARMED``); when the vehicle is armed the failing-check
+list is cleared so the banner disappears.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+import httpx
+import websockets
+
+from ..config import blueos_services
+
+logger = logging.getLogger(__name__)
+
+AUTOPILOT_COMPONENT_ID = 1
+ARMED_FLAG = 128  # MAV_MODE_FLAG_SAFETY_ARMED
+
+# A failing pre-arm reason is considered "current" for this long after it
+# was last reported.  ArduPilot re-nags roughly every 30-60 s, so this is
+# generous enough to ride out a missed cycle without showing stale reasons.
+FAILURE_TTL_S = 150.0
+
+WS_RECONNECT_DELAY_S = 2.0
+MAX_FAILURES = 20
+
+# STATUSTEXT prefixes that indicate a failing arming / pre-arm check.
+_PREARM_PREFIXES = ("prearm:", "arm:")
+
+SEVERITY_MAP = {
+    "MAV_SEVERITY_EMERGENCY": 0,
+    "MAV_SEVERITY_ALERT": 1,
+    "MAV_SEVERITY_CRITICAL": 2,
+    "MAV_SEVERITY_ERROR": 3,
+    "MAV_SEVERITY_WARNING": 4,
+    "MAV_SEVERITY_NOTICE": 5,
+    "MAV_SEVERITY_INFO": 6,
+    "MAV_SEVERITY_DEBUG": 7,
+}
+
+
+def _m2r_base() -> str:
+    return blueos_services.mavlink2rest
+
+
+def _statustext_ws_url() -> str:
+    base = blueos_services.mavlink2rest
+    ws_base = base.replace("http://", "ws://").replace("https://", "wss://")
+    return f"{ws_base}/ws/mavlink?filter=STATUSTEXT"
+
+
+def _decode_text(raw_text) -> str:
+    """STATUSTEXT.text is a list of single-char strings padded with \\x00."""
+    if isinstance(raw_text, list):
+        raw_text = "".join(c for c in raw_text if c != "\x00")
+    return (raw_text or "").strip()
+
+
+def _decode_severity(raw_severity) -> int:
+    if isinstance(raw_severity, dict):
+        return SEVERITY_MAP.get(raw_severity.get("type", ""), 6)
+    if isinstance(raw_severity, int):
+        return raw_severity
+    return 6
+
+
+def _is_prearm_text(text: str) -> bool:
+    low = text.strip().lower()
+    return any(low.startswith(p) for p in _PREARM_PREFIXES)
+
+
+def _base_mode_bits(base_mode) -> int | None:
+    """Extract the integer bitfield from a HEARTBEAT base_mode value.
+
+    mavlink2rest serializes base_mode as ``{"bits": <int>}`` but older
+    builds may send a bare int; handle both, returning None if unknown.
+    """
+    if isinstance(base_mode, dict):
+        bits = base_mode.get("bits")
+        return int(bits) if isinstance(bits, (int, float)) else None
+    if isinstance(base_mode, (int, float)):
+        return int(base_mode)
+    return None
+
+
+class ArmingService:
+    """Tracks vehicle armed state and failing pre-arm checks."""
+
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+        self._ws_task: asyncio.Task | None = None
+        # reason text -> {"text", "severity", "last_seen", "timestamp"}
+        self._failures: dict[str, dict] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=5.0, follow_redirects=True)
+        return self._client
+
+    async def get_status(self) -> dict:
+        """Return armed state plus any current failing pre-arm checks.
+
+        Response shape::
+
+            {
+              "armed": bool,
+              "armed_known": bool,
+              "waiting_to_arm": bool,
+              "reasons": [{"text", "severity", "timestamp"}],
+              "checked_at": "<iso8601>",
+            }
+        """
+        self._ensure_statustext_subscriber()
+        armed, armed_known = await self._read_armed()
+
+        async with self._lock:
+            if armed:
+                # Vehicle is armed: pre-arm reasons are no longer relevant.
+                self._failures.clear()
+            else:
+                self._prune_locked()
+            reasons = sorted(
+                (
+                    {
+                        "text": f["text"],
+                        "severity": f["severity"],
+                        "timestamp": f["timestamp"],
+                    }
+                    for f in self._failures.values()
+                ),
+                key=lambda r: r["text"].lower(),
+            )
+
+        waiting = bool(armed_known and not armed and reasons)
+        return {
+            "armed": armed,
+            "armed_known": armed_known,
+            "waiting_to_arm": waiting,
+            "reasons": reasons,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    async def _read_armed(self) -> tuple[bool, bool]:
+        """Read armed state from the autopilot HEARTBEAT.
+
+        Returns ``(armed, armed_known)``; ``armed_known`` is False when the
+        heartbeat or its base_mode couldn't be read, so the caller can avoid
+        claiming the vehicle is disarmed on a transient mavlink2rest miss.
+        """
+        base = _m2r_base()
+        url = (
+            f"{base}/mavlink/vehicles/1/components/"
+            f"{AUTOPILOT_COMPONENT_ID}/messages/HEARTBEAT"
+        )
+        try:
+            resp = await self.client.get(url)
+            if resp.status_code == 404:
+                return False, False
+            resp.raise_for_status()
+            msg = resp.json().get("message", {})
+            if msg.get("type") != "HEARTBEAT":
+                return False, False
+            bits = _base_mode_bits(msg.get("base_mode"))
+            if bits is None:
+                return False, False
+            return bool(bits & ARMED_FLAG), True
+        except Exception as e:
+            logger.debug("Could not read HEARTBEAT for arming state: %s", e)
+            return False, False
+
+    def _prune_locked(self) -> None:
+        now = time.monotonic()
+        stale = [
+            key
+            for key, f in self._failures.items()
+            if now - f["last_seen"] > FAILURE_TTL_S
+        ]
+        for key in stale:
+            del self._failures[key]
+
+    async def _record_failure(self, text: str, severity: int) -> None:
+        key = text.strip().lower()
+        async with self._lock:
+            self._failures[key] = {
+                "text": text.strip(),
+                "severity": severity,
+                "last_seen": time.monotonic(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            # Bound memory: drop the oldest if we somehow accumulate many.
+            if len(self._failures) > MAX_FAILURES:
+                oldest = min(
+                    self._failures.items(), key=lambda kv: kv[1]["last_seen"]
+                )[0]
+                del self._failures[oldest]
+
+    # ── STATUSTEXT subscriber ───────────────────────────────────────
+
+    def _ensure_statustext_subscriber(self) -> None:
+        if self._ws_task is None or self._ws_task.done():
+            self._ws_task = asyncio.create_task(
+                self._statustext_ws_loop(),
+                name="arming-statustext-subscriber",
+            )
+
+    async def _statustext_ws_loop(self) -> None:
+        url = _statustext_ws_url()
+        logger.info("Arming STATUSTEXT subscriber starting (%s)", url)
+        while True:
+            try:
+                async with websockets.connect(url, close_timeout=5) as ws:
+                    async for raw in ws:
+                        if isinstance(raw, bytes):
+                            try:
+                                raw = raw.decode("utf-8")
+                            except UnicodeDecodeError:
+                                continue
+                        if not raw.startswith("{"):
+                            continue
+                        try:
+                            data = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+
+                        header = data.get("header", {}) or {}
+                        if header.get("component_id") != AUTOPILOT_COMPONENT_ID:
+                            continue
+                        msg = data.get("message", {}) or {}
+                        if msg.get("type") != "STATUSTEXT":
+                            continue
+
+                        text = _decode_text(msg.get("text", ""))
+                        if not text or not _is_prearm_text(text):
+                            continue
+                        await self._record_failure(
+                            text, _decode_severity(msg.get("severity"))
+                        )
+            except asyncio.CancelledError:
+                logger.info("Arming STATUSTEXT subscriber cancelled")
+                raise
+            except Exception as e:
+                logger.debug(
+                    "Arming STATUSTEXT WS disconnected (%s); reconnecting in %.1fs",
+                    e, WS_RECONNECT_DELAY_S,
+                )
+                await asyncio.sleep(WS_RECONNECT_DELAY_S)

--- a/extension/backend/src/doris/services/dive_records.py
+++ b/extension/backend/src/doris/services/dive_records.py
@@ -1,0 +1,43 @@
+"""Helpers for reading persisted dive records (dives/dive_NNNN.json).
+
+Kept free of web-framework imports so the logic is unit-testable without
+standing up the Robyn app.
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DIVE_FILE_RE = re.compile(r"^dive_(\d{4})\.json$")
+
+
+def find_latest_active_dive_record(dives_dir: Path) -> dict | None:
+    """Return the highest-numbered dive record still marked 'active'.
+
+    The persisted dive record reliably survives a vehicle restart, whereas
+    the derived mission state can be lost, so this is used to reconstruct
+    the active dive's configuration name for the banner (issue #38).  The
+    returned dict includes a ``_dive_file`` key with the source filename.
+    Returns ``None`` when there is no active record.
+    """
+    if not dives_dir.is_dir():
+        return None
+    candidates: list[tuple[int, Path]] = []
+    for f in dives_dir.iterdir():
+        m = _DIVE_FILE_RE.match(f.name)
+        if m:
+            candidates.append((int(m.group(1)), f))
+    candidates.sort(reverse=True)
+    for _, dive_file in candidates:
+        try:
+            record = json.loads(dive_file.read_text())
+        except Exception as e:
+            logger.warning("Error reading %s: %s", dive_file.name, e)
+            continue
+        if record.get("status") == "active":
+            record["_dive_file"] = dive_file.name
+            return record
+    return None

--- a/extension/backend/tests/test_arming.py
+++ b/extension/backend/tests/test_arming.py
@@ -1,0 +1,121 @@
+"""Tests for the vehicle arming-status service (issues #44, #8)."""
+
+import time
+
+from doris.services import arming
+from doris.services.arming import ArmingService
+
+
+def test_base_mode_bits_parsing() -> None:
+    assert arming._base_mode_bits({"bits": 209}) == 209
+    assert arming._base_mode_bits(81) == 81
+    assert arming._base_mode_bits({"nope": 1}) is None
+    assert arming._base_mode_bits(None) is None
+    assert arming._base_mode_bits("x") is None
+
+
+def test_is_prearm_text() -> None:
+    assert arming._is_prearm_text("PreArm: GPS horizontal error")
+    assert arming._is_prearm_text("prearm: 3D fix required")
+    assert arming._is_prearm_text("Arm: compass not calibrated")
+    # Unrelated / success messages are ignored.
+    assert not arming._is_prearm_text("EKF3 IMU0 is using GPS")
+    assert not arming._is_prearm_text("Throttle armed")
+    assert not arming._is_prearm_text("")
+
+
+def test_decode_text_joins_char_list() -> None:
+    chars = list("PreArm: bad") + ["\x00", "\x00"]
+    assert arming._decode_text(chars) == "PreArm: bad"
+
+
+async def _no_network(service: ArmingService) -> None:
+    # Stop get_status from spawning the WS subscriber during tests.
+    service._ensure_statustext_subscriber = lambda: None  # type: ignore[method-assign]
+
+
+async def test_disarmed_with_failures_reports_waiting() -> None:
+    service = ArmingService()
+    await _no_network(service)
+
+    async def fake_read_armed():
+        return False, True
+
+    service._read_armed = fake_read_armed  # type: ignore[assignment]
+
+    await service._record_failure("PreArm: GPS horizontal error", 4)
+    await service._record_failure("PreArm: 3D fix required", 4)
+
+    status = await service.get_status()
+    assert status["armed"] is False
+    assert status["armed_known"] is True
+    assert status["waiting_to_arm"] is True
+    texts = {r["text"] for r in status["reasons"]}
+    assert texts == {"PreArm: GPS horizontal error", "PreArm: 3D fix required"}
+
+
+async def test_duplicate_reasons_are_deduped() -> None:
+    service = ArmingService()
+    await _no_network(service)
+
+    async def fake_read_armed():
+        return False, True
+
+    service._read_armed = fake_read_armed  # type: ignore[assignment]
+
+    await service._record_failure("PreArm: GPS horizontal error", 4)
+    await service._record_failure("PreArm: GPS horizontal error", 4)
+
+    status = await service.get_status()
+    assert len(status["reasons"]) == 1
+
+
+async def test_armed_clears_failures() -> None:
+    service = ArmingService()
+    await _no_network(service)
+
+    async def fake_read_armed():
+        return True, True
+
+    service._read_armed = fake_read_armed  # type: ignore[assignment]
+
+    await service._record_failure("PreArm: GPS horizontal error", 4)
+    status = await service.get_status()
+    assert status["armed"] is True
+    assert status["waiting_to_arm"] is False
+    assert status["reasons"] == []
+
+
+async def test_unknown_armed_state_suppresses_banner() -> None:
+    service = ArmingService()
+    await _no_network(service)
+
+    async def fake_read_armed():
+        return False, False  # heartbeat unreadable
+
+    service._read_armed = fake_read_armed  # type: ignore[assignment]
+
+    await service._record_failure("PreArm: GPS horizontal error", 4)
+    status = await service.get_status()
+    # We can't confirm the vehicle is disarmed, so don't claim "waiting".
+    assert status["armed_known"] is False
+    assert status["waiting_to_arm"] is False
+
+
+async def test_stale_reasons_are_pruned() -> None:
+    service = ArmingService()
+    await _no_network(service)
+
+    async def fake_read_armed():
+        return False, True
+
+    service._read_armed = fake_read_armed  # type: ignore[assignment]
+
+    await service._record_failure("PreArm: old reason", 4)
+    # Force the reason to look older than the TTL.
+    key = "prearm: old reason"
+    service._failures[key]["last_seen"] = time.monotonic() - arming.FAILURE_TTL_S - 1
+
+    status = await service.get_status()
+    assert status["reasons"] == []
+    assert status["waiting_to_arm"] is False

--- a/extension/backend/tests/test_dive_mission_reconstruct.py
+++ b/extension/backend/tests/test_dive_mission_reconstruct.py
@@ -1,0 +1,50 @@
+"""Tests for active-dive config-name reconstruction (issue #38)."""
+
+import json
+from pathlib import Path
+
+from doris.services.dive_records import find_latest_active_dive_record
+
+
+def _write_record(dives_dir: Path, n: int, status: str, configuration: str) -> None:
+    dives_dir.mkdir(parents=True, exist_ok=True)
+    (dives_dir / f"dive_{n:04d}.json").write_text(
+        json.dumps(
+            {
+                "dive_name": f"Dive {n}",
+                "configuration": configuration,
+                "status": status,
+                "profile_id": n,
+                "started_at": "2026-06-01T00:00:00+00:00",
+            }
+        )
+    )
+
+
+def test_finds_latest_active_record(tmp_path: Path) -> None:
+    _write_record(tmp_path, 1, "completed", "Old Config")
+    _write_record(tmp_path, 2, "active", "Reef Survey")
+    _write_record(tmp_path, 3, "cancelled", "Aborted Config")
+
+    record = find_latest_active_dive_record(tmp_path)
+    assert record is not None
+    assert record["configuration"] == "Reef Survey"
+    assert record["_dive_file"] == "dive_0002.json"
+
+
+def test_no_active_record_returns_none(tmp_path: Path) -> None:
+    _write_record(tmp_path, 1, "completed", "Old Config")
+    assert find_latest_active_dive_record(tmp_path) is None
+
+
+def test_missing_dives_dir_returns_none(tmp_path: Path) -> None:
+    assert find_latest_active_dive_record(tmp_path / "does_not_exist") is None
+
+
+def test_picks_highest_numbered_active(tmp_path: Path) -> None:
+    _write_record(tmp_path, 5, "active", "First Active")
+    _write_record(tmp_path, 9, "active", "Latest Active")
+
+    record = find_latest_active_dive_record(tmp_path)
+    assert record is not None
+    assert record["configuration"] == "Latest Active"

--- a/extension/frontend/src/App.vue
+++ b/extension/frontend/src/App.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { HardDrive, Loader2, AlertTriangle, Clock } from 'lucide-vue-next'
 import type { Screen, DiveData } from './types'
-import { useDiveControl, useNotifications, useStorageMigration } from './composables/useApi'
+import { useDiveControl, useNotifications, useStorageMigration, useArmingStatus } from './composables/useApi'
 import Navigation from './components/Navigation.vue'
 import Footer from './components/Footer.vue'
 import HomeScreen from './components/HomeScreen.vue'
@@ -29,6 +29,14 @@ const activeConfigName = computed(() => diveMission.value?.configuration_name?.t
 
 const { unreadCount: notificationCount, fetchUnreadCount } = useNotifications()
 const { status: migrationStatus, isActive: migrationActive, isError: migrationError, fetchMigrationStatus } = useStorageMigration()
+
+const { status: armingStatus, fetchArmingStatus } = useArmingStatus()
+const showArmingBanner = computed(() => armingStatus.value?.waiting_to_arm === true)
+// Strip the redundant "PreArm:"/"Arm:" prefix since the banner heading
+// already says pre-arm checks are failing.
+const armingReasons = computed(() =>
+  (armingStatus.value?.reasons ?? []).map(r => r.text.replace(/^(PreArm:|Arm:)\s*/i, '').trim())
+)
 
 const clockSyncFailed = ref(false)
 const clockSyncMessage = ref('')
@@ -95,7 +103,8 @@ onMounted(() => {
   fetchDiveMission()
   fetchUnreadCount()
   fetchMigrationStatus()
-  divePolling = setInterval(() => { fetchDiveStatus(); fetchDiveMission() }, 5000) as unknown as number
+  fetchArmingStatus()
+  divePolling = setInterval(() => { fetchDiveStatus(); fetchDiveMission(); fetchArmingStatus() }, 5000) as unknown as number
   notifPolling = setInterval(fetchUnreadCount, 15000) as unknown as number
   migrationPolling = setInterval(fetchMigrationStatus, 3000) as unknown as number
   clockPolling = setInterval(syncVehicleClock, 60000) as unknown as number
@@ -160,6 +169,20 @@ const setConnected = (connected: boolean) => {
       style="background-color: #DD2C1D; font-family: Montserrat, sans-serif"
     >
       Active Dive<span v-if="activeConfigName"> — {{ activeConfigName }}</span>
+    </div>
+
+    <div
+      v-if="showArmingBanner"
+      class="w-full py-2.5 px-4 flex flex-col items-center gap-1"
+      style="background-color: rgba(255, 153, 55, 0.18); border-bottom: 1px solid rgba(255, 153, 55, 0.55); font-family: Montserrat, sans-serif"
+    >
+      <div class="flex items-center gap-2">
+        <AlertTriangle class="w-4 h-4 flex-shrink-0" style="color: #FF9937" />
+        <span class="text-sm font-semibold" style="color: #FFD180">Waiting to arm — pre-arm checks failing</span>
+      </div>
+      <ul class="text-xs text-center" style="color: #FFD180; opacity: 0.95">
+        <li v-for="(reason, idx) in armingReasons" :key="idx">{{ reason }}</li>
+      </ul>
     </div>
 
     <div

--- a/extension/frontend/src/composables/useApi.ts
+++ b/extension/frontend/src/composables/useApi.ts
@@ -1058,6 +1058,41 @@ export function useDiveControl() {
   }
 }
 
+// ── Vehicle arming status ────────────────────────────────────────────
+
+export interface ArmingReason {
+  text: string
+  severity: number
+  timestamp: string
+}
+
+export interface ArmingStatus {
+  armed: boolean
+  armed_known: boolean
+  waiting_to_arm: boolean
+  reasons: ArmingReason[]
+  checked_at: string
+}
+
+export function useArmingStatus() {
+  const status = ref<ArmingStatus | null>(null)
+  const error = ref<string | null>(null)
+
+  async function fetchArmingStatus() {
+    try {
+      status.value = await fetchApi<ArmingStatus>('/vehicle/arming')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to fetch arming status'
+    }
+  }
+
+  return {
+    status: readonly(status),
+    error: readonly(error),
+    fetchArmingStatus,
+  }
+}
+
 // ── Artemis composables ─────────────────────────────────────────────
 
 export interface SerialPortInfo {


### PR DESCRIPTION
## Summary
Two independent fixes, one commit each, rebased on the latest master (now includes #42, #43, #19).

- **#38 ? Active dive banner loses configuration name after restart/reconnect.** When mission_state.json is missing or incomplete after a vehicle restart, the /dive/mission handler now falls back to the latest active dive_NNNN.json record to heal the mission state and repopulate the configuration name. Record-reading logic moved to a new Robyn-free services/dive_records.py so it can be unit-tested.
- **#44 / #8 ? Surface failing pre-arm checks in a top banner.** New ArmingService subscribes to the mavlink2rest STATUSTEXT WebSocket, keeps a de-duplicated, TTL-bounded view of failing `PreArm:`/`Arm:` reasons, and reads armed state from the autopilot HEARTBEAT. A new /vehicle/arming endpoint drives a useArmingStatus composable and an amber "waiting to arm" banner in `App.vue` that lists why the vehicle won't arm. Reasons clear once armed; the banner stays hidden when armed state can't be read.

## Test plan
- [x] pytest backend suite passes (127 passed), including new `test_dive_mission_reconstruct.py` and `test_arming.py`.
- [ ] Hardware: confirm banner shows real pre-arm reasons while disarmed and disappears on arm.
- [ ] Hardware: confirm dive banner keeps its configuration name across a vehicle restart.

Closes #38
Closes #44
Closes #8
