### PR TITLE
Chunk ascent/descent video (#33) and store timelapse stills in photos/ (#37)

### DIFF
--- a/extension/backend/scripts/doris.lua
+++ b/extension/backend/scripts/doris.lua
@@ -909,9 +909,10 @@ end
 -- right thing whether we're not-yet-recording (start), already recording
 -- in a different phase (rotate), or the phase is disabled (stop).
 -- ``seg_s`` (optional) clamps splitmuxsink's max-size-time at this
--- transition: pass 300 to switch on_bottom continuous to 5-min chunks,
--- pass 1800 to restore the default for descent/ascent so those phases
--- finalize as a single MP4.  Omit / pass nil to keep the prior policy.
+-- transition.  All continuous-video phases (descent, on_bottom in
+-- CONTINUOUS mode, ascent) pass 300 so splitmuxsink rotates every
+-- 5 minutes and finalize chunks each phase into 5-min MP4s (#33).
+-- Omit / pass nil to keep the prior policy.
 local function ipcam_begin_phase(phase_enabled, phase_name, seg_s)
     if not ipcam_cfg.rec_en then return end
     if phase_enabled then
@@ -1092,9 +1093,8 @@ function update()
             ascent_start_ms = now_ms
             init_ring(ar, DORIS_ASC_AVG:get() or 120)
             reset_light_cycle(now_ms)
-            -- Restore default segment so ascent finalizes as one MP4
-            -- (no chunking) regardless of bottom mode.
-            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 1800)
+            -- 5-min (300s) chunking for ascent too (#33).
+            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 300)
             state = STATE_ASCENT
             return update, UPDATE_INTERVAL_MS
         end
@@ -1137,10 +1137,10 @@ function update()
                     dive_start_ms = now_ms
                     init_ring(dr, DORIS_BTM_AVG:get())
                     reset_light_cycle(now_ms)
-                    -- Descent uses the default 1800s segment so the
-                    -- whole descent is one .ts -> one MP4 after
-                    -- finalize, regardless of bottom mode.
-                    ipcam_begin_phase(ipcam_cfg.dsc_rec, "descent", 1800)
+                    -- Descent rotates at 5-min (300s) boundaries so
+                    -- finalize chunks it into 5-min MP4s like the
+                    -- bottom phase, instead of one long file (#33).
+                    ipcam_begin_phase(ipcam_cfg.dsc_rec, "descent", 300)
                     state = STATE_DESCENT
                 end
             end
@@ -1152,7 +1152,8 @@ function update()
             ascent_start_ms = now_ms
             init_ring(ar, DORIS_ASC_AVG:get() or 120)
             reset_light_cycle(now_ms)
-            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 1800)
+            -- 5-min (300s) chunking for ascent too (#33).
+            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 300)
             state = STATE_ASCENT
             return update, UPDATE_INTERVAL_MS
         end
@@ -1224,9 +1225,9 @@ function update()
             ascent_start_ms = now_ms
             init_ring(ar, DORIS_ASC_AVG:get() or 120)
             reset_light_cycle(now_ms)
-            -- Restore default segment so ascent is one MP4 even after
-            -- continuous bottom (which set splitmuxsink to 300s).
-            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 1800)
+            -- Keep 5-min (300s) chunking for ascent (#33); the bottom
+            -- continuous path already set splitmuxsink to 300s.
+            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 300)
             state = STATE_ASCENT
             return update, UPDATE_INTERVAL_MS
         end
@@ -1439,9 +1440,9 @@ function update()
             ascent_start_ms = now_ms
             init_ring(ar, DORIS_ASC_AVG:get() or 120)
             reset_light_cycle(now_ms)
-            -- Restore default segment so ascent is one MP4 even after
-            -- continuous bottom (which set splitmuxsink to 300s).
-            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 1800)
+            -- Keep 5-min (300s) chunking for ascent (#33); the bottom
+            -- continuous path already set splitmuxsink to 300s.
+            ipcam_begin_phase(ipcam_cfg.asc_rec, "ascent", 300)
             state = STATE_ASCENT
         end
 

--- a/extension/backend/src/doris/services/dive_finalize.py
+++ b/extension/backend/src/doris/services/dive_finalize.py
@@ -797,6 +797,11 @@ async def finalize_dive(
     scan_dirs: list[Path] = []
     if dive_dir.is_dir():
         scan_dirs.append(dive_dir)
+        # TIMELAPSE/snapshot JPEGs now live in <dive_dir>/photos/ (issue
+        # #37); include it so the snapshot manifest still catalogs them.
+        photos_dir = dive_dir / iprec.SNAPSHOT_SUBDIR
+        if photos_dir.is_dir():
+            scan_dirs.append(photos_dir)
     scan_dirs.append(rec_root)
 
     # Bucket files by phase.  Snapshots and segments both embed the

--- a/extension/backend/src/doris/services/dive_finalize.py
+++ b/extension/backend/src/doris/services/dive_finalize.py
@@ -37,6 +37,11 @@ Bottom-phase output depends on the bottom camera mode
   of concatenating every bottom .ts into a single MP4 so older dives
   still finalize cleanly.
 
+The descent and ascent phases are recorded as a single continuous
+stream; they are re-segmented into 5-minute MP4 chunks via the same
+two-pass pipeline as continuous bottom (issue #33) so file sizes stay
+consistent and manageable regardless of phase duration.
+
 Output MP4s are named ``<recstart>_<phase>.mp4`` (e.g.
 ``20260528t171502_on_bottom.mp4``), where ``recstart`` is the UTC
 ``YYYYMMDDtHHMMSS`` the recording's footage started -- the earliest
@@ -373,18 +378,24 @@ async def _ffmpeg_segment_ts_to_mp4(
 
 async def _finalize_continuous_resegment(
     files: list[Path], rec_dir: Path, dive_stamp: str,
+    phase: str = "on_bottom",
 ) -> list[dict]:
-    """CONTINUOUS bottom: concat all .ts then slice into 5-min MP4s.
+    """Concat all of one phase's ``.ts`` then slice into 5-min MP4s.
+
+    Used for every continuously-recorded phase: CONTINUOUS bottom
+    (``DORIS_BTM_CMOD=1``) and the descent/ascent phases (issue #33),
+    which are recorded as a single continuous stream and should be
+    chunked into 5-minute segments for consistency and data management.
 
     Two-pass lossless ffmpeg pipeline:
 
-    1. Concat every bottom ``.ts`` into a staging
-       ``<rec_dir>/.bottom_full.ts`` (``-c copy -f mpegts``).
+    1. Concat every ``.ts`` for ``phase`` into a staging
+       ``<rec_dir>/.<phase>_full.ts`` (``-c copy -f mpegts``).
     2. Re-segment the staging file at 5-minute boundaries with
        ``-f segment -segment_time 300 -reset_timestamps 1`` directly
-       to ``dive_<stamp>_on_bottom_chunkNN.mp4``.
+       to ``dive_<stamp>_<phase>_chunkNN.mp4``.
 
-    The output count is therefore proportional to dive duration, not
+    The output count is therefore proportional to phase duration, not
     to how many times the camera-side RTSP server tore down the
     pipeline.  ffmpeg's segment muxer numbers outputs from 00; we
     rename ``chunk00`` -> ``chunk01`` etc. so the operator-visible
@@ -397,15 +408,17 @@ async def _finalize_continuous_resegment(
     if not files:
         return []
 
-    staging = rec_dir / ".bottom_full.ts"
+    # Per-phase staging name so descent/on_bottom/ascent re-segmentation
+    # in the same dive never collide on one shared staging file.
+    staging = rec_dir / f".{phase}_full.ts"
     src_bytes = sum((f.stat().st_size for f in files if f.exists()), 0)
     logger.info(
-        "FINALIZE on_bottom continuous: concat %d .ts (%d B) -> %s",
-        len(files), src_bytes, staging,
+        "FINALIZE %s continuous: concat %d .ts (%d B) -> %s",
+        phase, len(files), src_bytes, staging,
     )
 
     summary: dict = {
-        "phase": "on_bottom",
+        "phase": phase,
         "kind": "continuous_resegment",
         "input_count": len(files),
         "input_bytes": src_bytes,
@@ -428,7 +441,7 @@ async def _finalize_continuous_resegment(
         return [summary]
 
     out_pattern = str(
-        rec_dir / f"dive_{dive_stamp}_on_bottom_chunk%02d.mp4"
+        rec_dir / f"dive_{dive_stamp}_{phase}_chunk%02d.mp4"
     )
     ok, msg = await _ffmpeg_segment_ts_to_mp4(
         staging, out_pattern, 300, _FFMPEG_BIG_TIMEOUT_S,
@@ -447,10 +460,11 @@ async def _finalize_continuous_resegment(
     # Match the 0-based chunks ffmpeg just wrote (chunk00, chunk01, ...),
     # filtering out any chunk01+ a previous run may have left on disk.
     zero_based_re = re.compile(
-        r"^dive_" + re.escape(dive_stamp) + r"_on_bottom_chunk(\d{2})\.mp4$"
+        r"^dive_" + re.escape(dive_stamp)
+        + r"_" + re.escape(phase) + r"_chunk(\d{2})\.mp4$"
     )
     produced: list[tuple[int, Path]] = []
-    for p in rec_dir.glob(f"dive_{dive_stamp}_on_bottom_chunk*.mp4"):
+    for p in rec_dir.glob(f"dive_{dive_stamp}_{phase}_chunk*.mp4"):
         m = zero_based_re.match(p.name)
         if m:
             produced.append((int(m.group(1)), p))
@@ -458,7 +472,7 @@ async def _finalize_continuous_resegment(
 
     # Re-segmented chunks don't align to .ts fragment boundaries, so
     # derive each chunk's start by walking actual durations forward from
-    # when bottom footage began (the earliest fragment's open-stamp).
+    # when this phase's footage began (the earliest fragment's open-stamp).
     staging_start = _group_start_stamp(files)
     start_dt: datetime | None = None
     if staging_start:
@@ -472,7 +486,7 @@ async def _finalize_continuous_resegment(
     chunk_entries: list[dict] = []
     renamed: list[Path] = []
     if start_dt is not None:
-        # Timestamped names: <chunkstart>_on_bottom.mp4, where chunkstart
+        # Timestamped names: <chunkstart>_<phase>.mp4, where chunkstart
         # = footage start + cumulative duration of preceding chunks.
         cumulative = 0.0
         for idx, (_idx0, p) in enumerate(produced, start=1):
@@ -480,7 +494,7 @@ async def _finalize_continuous_resegment(
             stamp = (start_dt + timedelta(seconds=cumulative)).strftime(
                 _START_FMT,
             )
-            new_path = rec_dir / f"{stamp}_on_bottom.mp4"
+            new_path = rec_dir / f"{stamp}_{phase}.mp4"
             try:
                 p.rename(new_path)
             except OSError as e:
@@ -491,7 +505,7 @@ async def _finalize_continuous_resegment(
             renamed.append(new_path)
             out_bytes = new_path.stat().st_size if new_path.exists() else 0
             chunk_entries.append({
-                "phase": "on_bottom",
+                "phase": phase,
                 "kind": "chunk",
                 "index": idx,
                 "rec_start": stamp,
@@ -510,7 +524,7 @@ async def _finalize_continuous_resegment(
         # chunk(NN+1).
         for idx0, p in sorted(produced, key=lambda t: t[0], reverse=True):
             new_path = rec_dir / (
-                f"dive_{dive_stamp}_on_bottom_chunk{idx0 + 1:02d}.mp4"
+                f"dive_{dive_stamp}_{phase}_chunk{idx0 + 1:02d}.mp4"
             )
             try:
                 p.rename(new_path)
@@ -525,7 +539,7 @@ async def _finalize_continuous_resegment(
             out_bytes = out_path.stat().st_size if out_path.exists() else 0
             dur = await _ffprobe_duration_s(out_path)
             chunk_entries.append({
-                "phase": "on_bottom",
+                "phase": phase,
                 "kind": "chunk",
                 "index": idx,
                 "output": str(out_path),
@@ -842,6 +856,16 @@ async def finalize_dive(
             phase_results.extend(
                 await _finalize_interval_by_cyc(
                     files, rec_dir, dive_stamp,
+                )
+            )
+            continue
+        # Descent/ascent are recorded as a single continuous stream;
+        # chunk them into 5-min MP4s like continuous bottom (issue #33)
+        # so the operator gets consistent, manageable file sizes.
+        if phase in ("descent", "ascent"):
+            phase_results.extend(
+                await _finalize_continuous_resegment(
+                    files, rec_dir, dive_stamp, phase=phase,
                 )
             )
             continue

--- a/extension/backend/src/doris/services/ip_camera_recorder.py
+++ b/extension/backend/src/doris/services/ip_camera_recorder.py
@@ -91,6 +91,11 @@ _STOP_EOS_TIMEOUT_S = 5.0
 _PHASE_RE = re.compile(r"^[a-z0-9_]{1,32}$")
 PHASE_DEFAULT = "manual"
 
+# TIMELAPSE/snapshot JPEGs go in this subfolder of the per-dive directory
+# (rather than alongside the MP4s, manifest, and telemetry logs) so the
+# data files are easy to find when a dive captures many stills (issue #37).
+SNAPSHOT_SUBDIR = "photos"
+
 
 def sanitize_phase(raw: str | None) -> str:
     """Return ``raw`` if it's a valid phase label, else ``PHASE_DEFAULT``.
@@ -1074,7 +1079,7 @@ _fetch_camera_jpeg = fetch_camera_jpeg
 
 async def take_phase_snapshot(phase: str | None) -> dict:
     """Capture a single JPEG from the RTSP camera and save it under
-    ``<recordings>/radcam_<stamp>_<phase>_<seq>.jpg``.
+    ``<recordings>/dive_<stamp>/photos/radcam_<stamp>_<phase>_<seq>.jpg``.
 
     This is the TIMELAPSE primitive driven by the Lua dive script.
     Returns ``success=False, reason="recorder_active"`` (with an HTTP
@@ -1099,7 +1104,9 @@ async def take_phase_snapshot(phase: str | None) -> dict:
 
     out_root, storage = _output_dir()
     stamp = _ensure_dive_stamp()
-    out_dir = _dive_dir(out_root, stamp)
+    # Stills live in <dive_dir>/photos/ so they don't bury the dive's
+    # data files (manifest, MP4s, telemetry logs) -- issue #37.
+    out_dir = _dive_dir(out_root, stamp) / SNAPSHOT_SUBDIR
     seq = _next_snapshot_seq(stamp, phase_label)
     filename = f"radcam_{stamp}_{phase_label}_{seq:05d}.jpg"
     path = out_dir / filename

--- a/extension/backend/tests/test_storage_ipcam.py
+++ b/extension/backend/tests/test_storage_ipcam.py
@@ -46,6 +46,15 @@ def _make_recorder_file(svc: StorageService, mission: str) -> Path:
     return f
 
 
+def _make_ipcam_snapshot(svc: StorageService, dive: str) -> Path:
+    """Timelapse JPEG in the dive's photos/ subfolder (issue #37)."""
+    d = svc.ipcam_root / dive / "photos"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / f"radcam_{dive.replace('dive_', '')}_on_bottom_00001.jpg"
+    f.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 512)
+    return f
+
+
 async def test_flat_scan_includes_internal_ipcam(svc):
     _make_ipcam_recording(svc, "dive_20260601_120000")
 
@@ -106,3 +115,37 @@ async def test_empty_ipcam_tree_is_noop(svc):
 
     assert len(files) == 1
     assert all(m.mission_id == "mission_x" for m in missions)
+
+
+async def test_snapshot_in_photos_subfolder_is_discovered(svc):
+    """Issue #37: stills moved into <dive>/photos/ still appear as media,
+    grouped under their dive folder (recursive scan)."""
+    _make_ipcam_snapshot(svc, "dive_20260601_120000")
+
+    files = await svc.get_media_files()
+
+    assert len(files) == 1
+    mf = files[0]
+    assert mf.media_type == MediaType.IMAGE
+    assert mf.mission_id == "dive_20260601_120000"
+    assert mf.dive_name == "dive_20260601_120000"
+
+
+async def test_snapshot_in_photos_counts_toward_mission(svc):
+    """The per-dive image count includes stills nested in photos/."""
+    _make_ipcam_snapshot(svc, "dive_20260601_120000")
+
+    missions = await svc.get_missions_with_media()
+    by_id = {m.mission_id: m for m in missions}
+
+    assert by_id["dive_20260601_120000"].image_count == 1
+
+
+async def test_mission_filter_finds_snapshot_in_photos(svc):
+    """Filtering by the dive folder returns the nested still."""
+    _make_ipcam_snapshot(svc, "dive_20260601_120000")
+
+    files = await svc.get_media_files(mission_id="dive_20260601_120000")
+
+    assert len(files) == 1
+    assert files[0].filename.endswith(".jpg")


### PR DESCRIPTION
## Summary
Two data-management fixes for dive recordings, one commit each, branched fresh off the latest master (now includes the merged #45).

- **#33 ? Chunk ascent/descent videos into 5-minute segments.** Descent and ascent were each finalized as a single MP4, unlike the bottom phase. The continuous-bottom two-pass re-segmenter (_finalize_continuous_resegment) is generalized to take a `phase` argument and descent/ascent are routed through it regardless of bottom mode, producing `<recstart>_<phase>.mp4` / `dive_<stamp>_<phase>_chunkNN.mp4` 5-min chunks. The Lua dive script now rotates `splitmuxsink` at 300 s for descent and ascent (all transitions), matching the bottom-phase cadence.
- **#37 ? Timelapse JPEGs into a folder.** Snapshots now land in `<dive_dir>/photos/` instead of beside the MP4s, manifest, and telemetry logs, so the data files are easy to find on dives with many stills. Media discovery already scans recursively, so the data / View Media pages still list them under the right dive; finalize's (non-recursive) snapshot catalog now also scans the subfolder.

## Test plan
- [x] `pytest` backend suite passes (130 passed), incl. 3 new `test_storage_ipcam.py` tests confirming stills in `photos/` are still discovered, counted, and filterable.
- [x] `py_compile` passes for the GStreamer-dependent finalize/recorder modules (can't be imported locally without `gi`/`ffmpeg`); #33 reuses the already-proven continuous-bottom re-segmentation path.
- [ ] Hardware: confirm a dive produces 5-min descent/ascent MP4 chunks and that timelapse JPEGs land in `dive_<stamp>/photos/` while still appearing on the data/View Media pages.

Closes #33
Closes #37
