### PR TITLE
feat(power): empirical dive power model + surface recovery time

### DIFF
--- a/extension/backend/src/doris/services/power_model.py
+++ b/extension/backend/src/doris/services/power_model.py
@@ -53,6 +53,9 @@ HOTEL_W = 8.0
 CAMERA_RECORDING_W = 1.5
 # Burn-wire / drop-weight release: no measurable draw in the logs.
 RELEASE_W = 0.0
+# Surface recovery draw (terminal RECOVERY state, disarmed on the surface):
+# measured ~9.2 W in-log = hotel electronics + recovery beacon/strobe.
+RECOVERY_HOTEL_W = 9.2
 # Whole-dive average draw measured in-log (~26 Wh over 140 min). Used as
 # the live time-remaining fallback when no instantaneous current is read.
 TYPICAL_DIVE_LOAD_W = 11.0
@@ -199,29 +202,97 @@ class PhaseConfig:
     record_s: float = 0.0
     pause_s: float = 0.0
     capture_period_s: float = 0.0
+    timelapse_pre_s: float = 0.0
+    timelapse_post_s: float = 0.0
 
 
-def phase_power(cfg: PhaseConfig, voltage: float = BATTERY_NOMINAL_V) -> float:
-    """Average power (W) for a phase given its light/camera configuration."""
-    ld = light_duty(
-        enabled=cfg.light_on,
-        mode=cfg.light_mode,
-        on_seconds=cfg.light_on_s,
-        off_seconds=cfg.light_off_s,
-    )
-    cd = camera_duty(
+# Default light strobe window (s) for a timelapse snapshot when no explicit
+# pre/post roll is configured (matches doris.lua's ~2 s pre + 1 s post).
+_TIMELAPSE_DEFAULT_STROBE_S = 3.0
+
+
+def effective_light_duty(cfg: PhaseConfig) -> float:
+    """Average-on fraction for the LED, accounting for camera coupling.
+
+    The firmware drives the light off during the camera pause in interval
+    mode and strobes it only around each snapshot in timelapse mode (see
+    doris.lua ``bottom_lgt_eff``). So when the camera is duty-cycled the
+    LED follows the *camera*, not its own on/off schedule. Increasing the
+    camera pause therefore reduces the (dominant) LED energy, not just the
+    small camera term.
+    """
+    if not cfg.light_on:
+        return 0.0
+    if cfg.camera_on and cfg.camera_type == "video-interval":
+        return interval_duty(cfg.record_s, cfg.pause_s)
+    if cfg.camera_on and cfg.camera_type == "timelapse":
+        if cfg.capture_period_s <= 0:
+            return 0.0
+        window = cfg.timelapse_pre_s + cfg.timelapse_post_s
+        if window <= 0:
+            window = _TIMELAPSE_DEFAULT_STROBE_S
+        return _clamp(window / cfg.capture_period_s, 0.0, 1.0)
+    if cfg.light_mode == "interval":
+        return interval_duty(cfg.light_on_s, cfg.light_off_s)
+    return 1.0
+
+
+def effective_camera_duty(cfg: PhaseConfig) -> float:
+    """Average video-pipeline-active fraction for the camera in a phase."""
+    return camera_duty(
         enabled=cfg.camera_on,
         mode=cfg.camera_type,
         record_seconds=cfg.record_s,
         pause_seconds=cfg.pause_s,
         capture_period_seconds=cfg.capture_period_s,
     )
+
+
+def phase_power(cfg: PhaseConfig, voltage: float = BATTERY_NOMINAL_V) -> float:
+    """Average power (W) for a phase given its light/camera configuration."""
     return phase_average_power_w(
         light_brightness_pct=cfg.brightness_pct,
-        light_duty_fraction=ld,
-        camera_duty_fraction=cd,
+        light_duty_fraction=effective_light_duty(cfg),
+        camera_duty_fraction=effective_camera_duty(cfg),
         voltage=voltage,
     )
+
+
+def phase_breakdown(
+    name: str, cfg: PhaseConfig, hours: float, voltage: float = BATTERY_NOMINAL_V
+) -> dict:
+    """Per-component energy (Wh) for one phase of a given duration."""
+    ld = effective_light_duty(cfg)
+    cd = effective_camera_duty(cfg)
+    hotel_wh = HOTEL_W * hours
+    light_wh = led_power_w(cfg.brightness_pct, voltage) * ld * hours
+    camera_wh = CAMERA_RECORDING_W * cd * hours
+    total_wh = hotel_wh + light_wh + camera_wh
+    return {
+        "name": name,
+        "hours": hours,
+        "brightness_pct": cfg.brightness_pct,
+        "light_duty": ld,
+        "camera_duty": cd,
+        "hotel_wh": hotel_wh,
+        "light_wh": light_wh,
+        "camera_wh": camera_wh,
+        "total_wh": total_wh,
+        "average_w": total_wh / hours if hours > 0 else 0.0,
+    }
+
+
+def reserve_energy_wh(
+    reserve_wh: float | None = None, reserve_pct: float = BATTERY_RESERVE_PCT
+) -> float:
+    """Energy (Wh) held back for recovery mode.
+
+    An explicit ``reserve_wh`` wins; otherwise it falls back to
+    ``reserve_pct`` of the pack capacity.
+    """
+    if reserve_wh is not None:
+        return max(0.0, reserve_wh)
+    return BATTERY_CAPACITY_WH * _clamp(reserve_pct, 0.0, 100.0) / 100.0
 
 
 def estimate_dive(
@@ -233,6 +304,7 @@ def estimate_dive(
     ascent: PhaseConfig,
     voltage: float = BATTERY_NOMINAL_V,
     reserve_pct: float = BATTERY_RESERVE_PCT,
+    reserve_wh: float | None = None,
 ) -> dict:
     """Estimate energy/time/battery usage for a planned dive.
 
@@ -247,17 +319,34 @@ def estimate_dive(
     ascent_h = ASCENT_BURN_MINUTES / 60.0 + rise_h
     bottom_h = max(0.0, bottom_time_hours)
 
-    p_desc = phase_power(descent, voltage)
-    p_btm = phase_power(bottom, voltage)
-    p_asc = phase_power(ascent, voltage)
+    phases = [
+        phase_breakdown("Descent", descent, descent_h, voltage),
+        phase_breakdown("On Bottom", bottom, bottom_h, voltage),
+        phase_breakdown("Ascent", ascent, ascent_h, voltage),
+    ]
+    p_desc = phases[0]["average_w"]
+    p_btm = phases[1]["average_w"]
+    p_asc = phases[2]["average_w"]
 
-    energy_wh = p_desc * descent_h + p_btm * bottom_h + p_asc * ascent_h
+    energy_wh = sum(p["total_wh"] for p in phases)
+    hotel_wh = sum(p["hotel_wh"] for p in phases)
+    light_wh = sum(p["light_wh"] for p in phases)
+    camera_wh = sum(p["camera_wh"] for p in phases)
     total_h = descent_h + bottom_h + ascent_h
     avg_w = energy_wh / total_h if total_h > 0 else 0.0
 
     usage_pct = (energy_wh / BATTERY_CAPACITY_WH) * 100.0 if BATTERY_CAPACITY_WH else 0.0
-    usable_wh = usable_capacity_wh(reserve_pct)
+    reserve_wh_val = reserve_energy_wh(reserve_wh, reserve_pct)
+    usable_wh = max(0.0, BATTERY_CAPACITY_WH - reserve_wh_val)
+    remaining_after_dive_wh = BATTERY_CAPACITY_WH - energy_wh
     battery_life_h = BATTERY_CAPACITY_WH / avg_w if avg_w > 0 else 0.0
+    # Time the vehicle can loiter on the surface in RECOVERY on whatever
+    # energy is left after the dive, running only the recovery hotel load.
+    recovery_hours = (
+        max(0.0, remaining_after_dive_wh) / RECOVERY_HOTEL_W
+        if RECOVERY_HOTEL_W > 0
+        else 0.0
+    )
 
     return {
         "descent_hours": descent_h,
@@ -272,5 +361,14 @@ def estimate_dive(
         "usage_percent": min(usage_pct, 100.0),
         "remaining_percent": max(0.0, 100.0 - usage_pct),
         "battery_life_hours": battery_life_h,
-        "fits_within_reserve": energy_wh <= usable_wh,
+        "reserve_wh": reserve_wh_val,
+        "usable_wh": usable_wh,
+        "remaining_after_dive_wh": remaining_after_dive_wh,
+        "fits_within_reserve": remaining_after_dive_wh >= reserve_wh_val,
+        "recovery_hotel_w": RECOVERY_HOTEL_W,
+        "recovery_hours": recovery_hours,
+        "phases": phases,
+        "hotel_wh": hotel_wh,
+        "light_wh": light_wh,
+        "camera_wh": camera_wh,
     }

--- a/extension/backend/src/doris/services/power_model.py
+++ b/extension/backend/src/doris/services/power_model.py
@@ -1,0 +1,276 @@
+"""Shared DORIS power model.
+
+Single source of truth for the vehicle's power budget, used by the live
+battery estimator (``system.py``) and mirrored by the frontend planner
+(``frontend/src/lib/powerModel.ts``) so the home screen, mission planner,
+and backend never disagree.
+
+All constants below were validated against a real 140-minute / 791 m dive
+log (recorder_20260528_165058.mcap) by joining MAVLink ``BATTERY_STATUS``
+(pack V/I) with the dive ``STATE``, the light PWM (RC9), and the release
+``RELAY`` named-value floats:
+
+* LED: measured pack-current rise at 1700 us was 1.28 A vs the bench table's
+  1.24 A (3% agreement), so the bench curve is trustworthy and the LED draws
+  on the monitored pack rail.
+* Hotel (everything except the LED, lights off, idle): ~0.49 A ≈ 7-8 W.
+* Camera recording adds only ~1.5 W over idle (descent/bottom/ascent
+  lights-off baseline rose from ~0.49 A to ~0.59 A).
+* Release/burn-wire relay showed no measurable current step at activation,
+  so release power is treated as negligible for planning.
+
+NOTE: these figures reflect whatever is on the autopilot's monitored power
+rail. The LED is definitely on it (delta matches the bench curve). If the
+Pi5/RadCAM are ever moved to a separate unmonitored converter, revisit
+``HOTEL_W`` / ``CAMERA_RECORDING_W``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Dive profile ─────────────────────────────────────────────────────
+# Static buoyancy descent / drop-weight ascent both ~1 m/s.
+DESCENT_RATE_M_S = 1.0
+# Drop-weight burn-wire release time before the vehicle starts rising.
+ASCENT_BURN_MINUTES = 45.0
+
+# ── Battery pack ─────────────────────────────────────────────────────
+# 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel.
+BATTERY_PACK_COUNT = 2
+BATTERY_PACK_AH = 10.0
+BATTERY_NOMINAL_V = 14.8
+BATTERY_TOTAL_AH = BATTERY_PACK_COUNT * BATTERY_PACK_AH       # 20 Ah
+BATTERY_CAPACITY_WH = BATTERY_TOTAL_AH * BATTERY_NOMINAL_V    # 296 Wh
+
+# Reserve held back from usable-energy estimates (surfacing margin).
+BATTERY_RESERVE_PCT = 15.0
+
+# ── Component loads (empirical, see module docstring) ────────────────
+# Hotel = Raspberry Pi 5 + autopilot + sensors, everything but the LED.
+HOTEL_W = 8.0
+# Extra draw while the camera pipeline is actively recording video.
+CAMERA_RECORDING_W = 1.5
+# Burn-wire / drop-weight release: no measurable draw in the logs.
+RELEASE_W = 0.0
+# Whole-dive average draw measured in-log (~26 Wh over 140 min). Used as
+# the live time-remaining fallback when no instantaneous current is read.
+TYPICAL_DIVE_LOAD_W = 11.0
+
+# ── LED light ────────────────────────────────────────────────────────
+# Single LED. Brightness 0-100 % maps linearly to the ArduPilot light
+# servo PWM, matching doris.lua ``brightness_to_pwm``.
+LIGHT_PWM_MIN = 1100
+LIGHT_PWM_MAX = 1900
+
+# Bench-measured LED current (A) vs PWM (us) at 15 V. Single LED.
+_LED_CURVE: list[tuple[float, float]] = [
+    (1100.0, 0.01),
+    (1200.0, 0.25),
+    (1500.0, 0.85),
+    (1700.0, 1.24),
+    (1900.0, 1.64),
+]
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def brightness_to_pwm(brightness_pct: float) -> float:
+    """Map a 0-100 % brightness to light servo PWM (matches doris.lua)."""
+    pct = _clamp(brightness_pct, 0.0, 100.0)
+    return LIGHT_PWM_MIN + (pct / 100.0) * (LIGHT_PWM_MAX - LIGHT_PWM_MIN)
+
+
+def led_current_at_pwm(pwm: float) -> float:
+    """Interpolate LED current (A) for a given PWM from the bench curve."""
+    if pwm <= _LED_CURVE[0][0]:
+        return _LED_CURVE[0][1]
+    if pwm >= _LED_CURVE[-1][0]:
+        return _LED_CURVE[-1][1]
+    for (p_lo, i_lo), (p_hi, i_hi) in zip(_LED_CURVE, _LED_CURVE[1:], strict=False):
+        if p_lo <= pwm <= p_hi:
+            frac = (pwm - p_lo) / (p_hi - p_lo)
+            return i_lo + frac * (i_hi - i_lo)
+    return _LED_CURVE[-1][1]
+
+
+def led_power_w(brightness_pct: float, voltage: float = BATTERY_NOMINAL_V) -> float:
+    """Power (W) drawn by the single LED at a given brightness.
+
+    LED current is roughly voltage-independent over the pack's operating
+    range (validated in-log), so power scales with the supply voltage.
+    A brightness of 50 % therefore draws meaningfully less than 75 %.
+    """
+    return led_current_at_pwm(brightness_to_pwm(brightness_pct)) * voltage
+
+
+# ── Duty cycles ──────────────────────────────────────────────────────
+def interval_duty(on_seconds: float, off_seconds: float) -> float:
+    """Fraction of time ON for an on/off interval cycle."""
+    total = on_seconds + off_seconds
+    if total <= 0:
+        return 1.0
+    return _clamp(on_seconds / total, 0.0, 1.0)
+
+
+def light_duty(
+    *,
+    enabled: bool,
+    mode: str = "continuous",
+    on_seconds: float = 0.0,
+    off_seconds: float = 0.0,
+) -> float:
+    """Average-on fraction for the LED in a phase."""
+    if not enabled:
+        return 0.0
+    if mode == "interval":
+        return interval_duty(on_seconds, off_seconds)
+    return 1.0
+
+
+def camera_duty(
+    *,
+    enabled: bool,
+    mode: str = "continuous-video",
+    record_seconds: float = 0.0,
+    pause_seconds: float = 0.0,
+    capture_period_seconds: float = 0.0,
+    snapshot_seconds: float = 3.0,
+) -> float:
+    """Average video-pipeline-active fraction for the camera in a phase.
+
+    * ``continuous-video`` -> always recording (duty 1).
+    * ``video-interval``   -> record/pause duty cycle.
+    * ``timelapse``        -> brief snapshots; the heavy video pipeline is
+      stopped, so the duty is roughly snapshot window / capture period.
+    """
+    if not enabled:
+        return 0.0
+    if mode == "video-interval":
+        return interval_duty(record_seconds, pause_seconds)
+    if mode == "timelapse":
+        if capture_period_seconds <= 0:
+            return 0.0
+        return _clamp(snapshot_seconds / capture_period_seconds, 0.0, 1.0)
+    return 1.0
+
+
+def phase_average_power_w(
+    *,
+    light_brightness_pct: float = 0.0,
+    light_duty_fraction: float = 0.0,
+    camera_duty_fraction: float = 0.0,
+    voltage: float = BATTERY_NOMINAL_V,
+) -> float:
+    """Average power (W) for a dive phase = hotel + LED + camera."""
+    led = led_power_w(light_brightness_pct, voltage) * _clamp(light_duty_fraction, 0.0, 1.0)
+    cam = CAMERA_RECORDING_W * _clamp(camera_duty_fraction, 0.0, 1.0)
+    return HOTEL_W + led + cam
+
+
+def usable_capacity_wh(reserve_pct: float = BATTERY_RESERVE_PCT) -> float:
+    """Energy (Wh) available above the safety reserve."""
+    return BATTERY_CAPACITY_WH * (1.0 - _clamp(reserve_pct, 0.0, 100.0) / 100.0)
+
+
+def hours_remaining(soc_pct: float, average_power_w: float) -> float:
+    """Hours until the reserve is hit at a given SOC and average load."""
+    if average_power_w <= 0:
+        return 0.0
+    usable_pct = max(0.0, soc_pct - BATTERY_RESERVE_PCT)
+    usable_wh = BATTERY_CAPACITY_WH * (usable_pct / 100.0)
+    return usable_wh / average_power_w
+
+
+# ── Per-phase planning ───────────────────────────────────────────────
+@dataclass
+class PhaseConfig:
+    """Light + camera settings for one dive phase (descent/bottom/ascent)."""
+
+    light_on: bool = False
+    brightness_pct: float = 0.0
+    light_mode: str = "continuous"  # "continuous" | "interval"
+    light_on_s: float = 0.0
+    light_off_s: float = 0.0
+    camera_on: bool = False
+    camera_type: str = "continuous-video"  # continuous-video|video-interval|timelapse
+    record_s: float = 0.0
+    pause_s: float = 0.0
+    capture_period_s: float = 0.0
+
+
+def phase_power(cfg: PhaseConfig, voltage: float = BATTERY_NOMINAL_V) -> float:
+    """Average power (W) for a phase given its light/camera configuration."""
+    ld = light_duty(
+        enabled=cfg.light_on,
+        mode=cfg.light_mode,
+        on_seconds=cfg.light_on_s,
+        off_seconds=cfg.light_off_s,
+    )
+    cd = camera_duty(
+        enabled=cfg.camera_on,
+        mode=cfg.camera_type,
+        record_seconds=cfg.record_s,
+        pause_seconds=cfg.pause_s,
+        capture_period_seconds=cfg.capture_period_s,
+    )
+    return phase_average_power_w(
+        light_brightness_pct=cfg.brightness_pct,
+        light_duty_fraction=ld,
+        camera_duty_fraction=cd,
+        voltage=voltage,
+    )
+
+
+def estimate_dive(
+    *,
+    depth_m: float,
+    bottom_time_hours: float,
+    descent: PhaseConfig,
+    bottom: PhaseConfig,
+    ascent: PhaseConfig,
+    voltage: float = BATTERY_NOMINAL_V,
+    reserve_pct: float = BATTERY_RESERVE_PCT,
+) -> dict:
+    """Estimate energy/time/battery usage for a planned dive.
+
+    Durations:
+      * descent = depth / DESCENT_RATE_M_S
+      * bottom  = operator's release-weight elapsed/datetime time
+      * ascent  = ASCENT_BURN_MINUTES burn + depth / DESCENT_RATE_M_S rise
+                  (ascent phase light/camera settings apply throughout)
+    """
+    rise_h = max(0.0, depth_m) / DESCENT_RATE_M_S / 3600.0
+    descent_h = rise_h
+    ascent_h = ASCENT_BURN_MINUTES / 60.0 + rise_h
+    bottom_h = max(0.0, bottom_time_hours)
+
+    p_desc = phase_power(descent, voltage)
+    p_btm = phase_power(bottom, voltage)
+    p_asc = phase_power(ascent, voltage)
+
+    energy_wh = p_desc * descent_h + p_btm * bottom_h + p_asc * ascent_h
+    total_h = descent_h + bottom_h + ascent_h
+    avg_w = energy_wh / total_h if total_h > 0 else 0.0
+
+    usage_pct = (energy_wh / BATTERY_CAPACITY_WH) * 100.0 if BATTERY_CAPACITY_WH else 0.0
+    usable_wh = usable_capacity_wh(reserve_pct)
+    battery_life_h = BATTERY_CAPACITY_WH / avg_w if avg_w > 0 else 0.0
+
+    return {
+        "descent_hours": descent_h,
+        "bottom_hours": bottom_h,
+        "ascent_hours": ascent_h,
+        "total_hours": total_h,
+        "descent_power_w": p_desc,
+        "bottom_power_w": p_btm,
+        "ascent_power_w": p_asc,
+        "average_power_w": avg_w,
+        "energy_wh": energy_wh,
+        "usage_percent": min(usage_pct, 100.0),
+        "remaining_percent": max(0.0, 100.0 - usage_pct),
+        "battery_life_hours": battery_life_h,
+        "fits_within_reserve": energy_wh <= usable_wh,
+    }

--- a/extension/backend/src/doris/services/system.py
+++ b/extension/backend/src/doris/services/system.py
@@ -8,6 +8,7 @@ import httpx
 
 from ..config import blueos_services
 from ..models.system import BatteryInfo, LocationInfo, StorageInfo, SystemStatus
+from . import power_model
 from .base import BlueOSClient
 from .external_storage import get_migration_status
 from .storage import DATA_ROOT
@@ -32,25 +33,6 @@ _SOC_CURVE_4S: list[tuple[float, float]] = [
     (14.44, 5.0),
     (13.20, 0.0),
 ]
-
-# Battery pack: 2× Blue Robotics 10 Ah 4S Li-ion packs wired in parallel.
-# Update these together with the matching constants in the frontend
-# (HomeScreen.vue / MissionProgramming.vue) if the hardware ever changes.
-_BATTERY_PACK_COUNT = 2
-_BATTERY_PACK_AH = 10.0
-_BATTERY_NOMINAL_V = 14.8  # 4S Li-ion nominal
-_BATTERY_TOTAL_AH = _BATTERY_PACK_COUNT * _BATTERY_PACK_AH      # 20 Ah
-_BATTERY_CAPACITY_WH = _BATTERY_TOTAL_AH * _BATTERY_NOMINAL_V   # 296 Wh
-
-# Reserve held back from the time-remaining estimate so the vehicle has
-# margin for surfacing, recovery, and unexpected loads. SOC% below this
-# value is reported as zero hours remaining.
-_BATTERY_RESERVE_PCT = 15.0
-
-# Standard platform load (W) used when no live current measurement is
-# available. Pi5 (15) + RadCAM (5) + 2× lumen lights (15 each) = 50 W.
-_STANDARD_LOAD_W = 50.0
-
 
 def _voltage_to_soc_4s(voltage: float) -> float:
     """Map a measured 4S pack voltage to State-of-Charge (0–100 %).
@@ -323,17 +305,18 @@ class SystemService:
     ) -> float | None:
         """Estimate remaining battery hours before hitting the safety reserve.
 
-        Assumes 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel (20 Ah
-        total) with `_BATTERY_RESERVE_PCT` of capacity held back as
-        margin. With a measured current draw the remaining usable
-        ampere-hours are divided by the instantaneous current; otherwise
-        we fall back to the standard DORIS platform load (~50 W).
+        Uses the shared :mod:`power_model` (2× 10 Ah 4S packs, 15% reserve).
+        With a measured current draw the remaining usable ampere-hours are
+        divided by the instantaneous current; otherwise we fall back to the
+        empirically-measured typical dive load (~11 W whole-dive average).
         """
-        usable_pct = max(0.0, percent - _BATTERY_RESERVE_PCT)
-        usable_ah = (usable_pct / 100.0) * _BATTERY_TOTAL_AH
+        usable_pct = max(0.0, percent - power_model.BATTERY_RESERVE_PCT)
+        usable_ah = (usable_pct / 100.0) * power_model.BATTERY_TOTAL_AH
         if current is None or current <= 0:
-            standard_current_a = _STANDARD_LOAD_W / _BATTERY_NOMINAL_V
-            return usable_ah / standard_current_a
+            fallback_current_a = (
+                power_model.TYPICAL_DIVE_LOAD_W / power_model.BATTERY_NOMINAL_V
+            )
+            return usable_ah / fallback_current_a
         return usable_ah / current
 
     def _format_time_remaining(self, hours: float | None) -> str:

--- a/extension/backend/tests/test_power_model.py
+++ b/extension/backend/tests/test_power_model.py
@@ -188,6 +188,140 @@ def test_reserve_flag():
     assert over["fits_within_reserve"] is False
 
 
+def test_phase_breakdown_components_sum():
+    cfg = pm.PhaseConfig(
+        light_on=True, brightness_pct=100, camera_on=True, camera_type="continuous-video"
+    )
+    b = pm.phase_breakdown("Bottom", cfg, hours=2.0)
+    assert b["hotel_wh"] == pytest.approx(pm.HOTEL_W * 2.0)
+    assert b["light_wh"] == pytest.approx(pm.led_power_w(100) * 2.0)
+    assert b["camera_wh"] == pytest.approx(pm.CAMERA_RECORDING_W * 2.0)
+    assert b["total_wh"] == pytest.approx(
+        b["hotel_wh"] + b["light_wh"] + b["camera_wh"]
+    )
+
+
+def test_estimate_dive_breakdown_totals_match():
+    est = pm.estimate_dive(
+        depth_m=500,
+        bottom_time_hours=4.0,
+        descent=pm.PhaseConfig(light_on=True, brightness_pct=50),
+        bottom=pm.PhaseConfig(light_on=True, brightness_pct=75, camera_on=True),
+        ascent=pm.PhaseConfig(),
+    )
+    assert len(est["phases"]) == 3
+    assert [p["name"] for p in est["phases"]] == ["Descent", "On Bottom", "Ascent"]
+    # Component totals reconcile with overall energy.
+    assert est["hotel_wh"] + est["light_wh"] + est["camera_wh"] == pytest.approx(
+        est["energy_wh"]
+    )
+    assert sum(p["total_wh"] for p in est["phases"]) == pytest.approx(est["energy_wh"])
+
+
+def test_interval_camera_gates_light():
+    # Light follows the camera record/pause duty in interval mode, so a
+    # longer pause cuts the (dominant) LED energy, not just the camera term.
+    short_pause = pm.PhaseConfig(
+        light_on=True,
+        brightness_pct=100,
+        camera_on=True,
+        camera_type="video-interval",
+        record_s=10,
+        pause_s=10,
+    )
+    long_pause = pm.PhaseConfig(
+        light_on=True,
+        brightness_pct=100,
+        camera_on=True,
+        camera_type="video-interval",
+        record_s=10,
+        pause_s=50,
+    )
+    assert pm.effective_light_duty(short_pause) == pytest.approx(0.5)
+    assert pm.effective_light_duty(long_pause) == pytest.approx(10 / 60)
+    # The light energy must drop substantially, not marginally.
+    b_short = pm.phase_breakdown("b", short_pause, hours=4.0)
+    b_long = pm.phase_breakdown("b", long_pause, hours=4.0)
+    assert b_long["light_wh"] < b_short["light_wh"] * 0.5
+
+
+def test_timelapse_light_uses_strobe_window():
+    cfg = pm.PhaseConfig(
+        light_on=True,
+        brightness_pct=100,
+        camera_on=True,
+        camera_type="timelapse",
+        capture_period_s=60,
+        timelapse_pre_s=2,
+        timelapse_post_s=1,
+    )
+    assert pm.effective_light_duty(cfg) == pytest.approx(3 / 60)
+
+
+def test_continuous_camera_keeps_light_own_mode():
+    cfg = pm.PhaseConfig(
+        light_on=True,
+        brightness_pct=100,
+        light_mode="interval",
+        light_on_s=10,
+        light_off_s=10,
+        camera_on=True,
+        camera_type="continuous-video",
+    )
+    assert pm.effective_light_duty(cfg) == pytest.approx(0.5)
+
+
+def test_reserve_wh_overrides_percent():
+    base = dict(
+        depth_m=100,
+        bottom_time_hours=2.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    est = pm.estimate_dive(reserve_wh=50.0, **base)
+    assert est["reserve_wh"] == pytest.approx(50.0)
+    assert est["usable_wh"] == pytest.approx(pm.BATTERY_CAPACITY_WH - 50.0)
+    assert est["remaining_after_dive_wh"] == pytest.approx(
+        pm.BATTERY_CAPACITY_WH - est["energy_wh"]
+    )
+
+
+def test_reserve_wh_fit_flag():
+    # Huge reserve makes even a tiny dive fail the reserve check.
+    est = pm.estimate_dive(
+        depth_m=50,
+        bottom_time_hours=1.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+        reserve_wh=290.0,
+    )
+    assert est["fits_within_reserve"] is False
+
+
+def test_recovery_hours_from_remaining_energy():
+    est = pm.estimate_dive(
+        depth_m=100,
+        bottom_time_hours=2.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    assert est["recovery_hotel_w"] == pytest.approx(pm.RECOVERY_HOTEL_W)
+    expected = est["remaining_after_dive_wh"] / pm.RECOVERY_HOTEL_W
+    assert est["recovery_hours"] == pytest.approx(expected)
+    # More energy consumed => less surface recovery time.
+    heavy = pm.estimate_dive(
+        depth_m=300,
+        bottom_time_hours=10.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(light_on=True, brightness_pct=100),
+        ascent=pm.PhaseConfig(),
+    )
+    assert heavy["recovery_hours"] < est["recovery_hours"]
+
+
 def test_pack_constants():
     assert pm.BATTERY_TOTAL_AH == pytest.approx(20.0)  # noqa: SIM300
     assert pm.BATTERY_CAPACITY_WH == pytest.approx(296.0)  # noqa: SIM300

--- a/extension/backend/tests/test_power_model.py
+++ b/extension/backend/tests/test_power_model.py
@@ -1,0 +1,193 @@
+"""Tests for the shared power model.
+
+The LED curve and component-load constants were validated against a real
+dive log (recorder_20260528_165058.mcap); these tests lock in the curve
+behaviour, duty-cycle math, and dive-energy estimation.
+"""
+
+import pytest
+
+from doris.services import power_model as pm
+
+
+# ── LED current curve ────────────────────────────────────────────────
+def test_brightness_to_pwm_endpoints():
+    assert pm.brightness_to_pwm(0) == pm.LIGHT_PWM_MIN
+    assert pm.brightness_to_pwm(100) == pm.LIGHT_PWM_MAX
+    assert pm.brightness_to_pwm(50) == pytest.approx(1500.0)
+
+
+def test_brightness_to_pwm_clamps():
+    assert pm.brightness_to_pwm(-10) == pm.LIGHT_PWM_MIN
+    assert pm.brightness_to_pwm(150) == pm.LIGHT_PWM_MAX
+
+
+@pytest.mark.parametrize(
+    "pwm,amps",
+    [(1100, 0.01), (1200, 0.25), (1500, 0.85), (1700, 1.24), (1900, 1.64)],
+)
+def test_led_curve_matches_bench_points(pwm, amps):
+    assert pm.led_current_at_pwm(pwm) == pytest.approx(amps)
+
+
+def test_led_curve_interpolates_midpoint():
+    # Halfway between 1200 (0.25 A) and 1500 (0.85 A) -> 1350 us ≈ 0.55 A
+    assert pm.led_current_at_pwm(1350) == pytest.approx(0.55, abs=1e-6)
+
+
+def test_led_curve_clamps_out_of_range():
+    assert pm.led_current_at_pwm(900) == 0.01
+    assert pm.led_current_at_pwm(2200) == 1.64
+
+
+def test_led_power_monotonic_in_brightness():
+    # The user's headline requirement: 50% draws less than 75%.
+    assert pm.led_power_w(50) < pm.led_power_w(75)
+    assert pm.led_power_w(0) < pm.led_power_w(50)
+
+
+def test_led_power_scales_with_voltage():
+    assert pm.led_power_w(75, voltage=15.0) == pytest.approx(1.24 * 15.0)
+
+
+# ── Duty cycles ──────────────────────────────────────────────────────
+def test_interval_duty():
+    assert pm.interval_duty(10, 0) == 1.0
+    assert pm.interval_duty(0, 10) == 0.0
+    assert pm.interval_duty(10, 30) == pytest.approx(0.25)
+    assert pm.interval_duty(0, 0) == 1.0
+
+
+def test_light_duty_modes():
+    assert pm.light_duty(enabled=False) == 0.0
+    assert pm.light_duty(enabled=True, mode="continuous") == 1.0
+    assert (
+        pm.light_duty(enabled=True, mode="interval", on_seconds=10, off_seconds=10)
+        == pytest.approx(0.5)
+    )
+
+
+def test_camera_duty_modes():
+    assert pm.camera_duty(enabled=False) == 0.0
+    assert pm.camera_duty(enabled=True, mode="continuous-video") == 1.0
+    assert (
+        pm.camera_duty(enabled=True, mode="video-interval", record_seconds=10, pause_seconds=10)
+        == pytest.approx(0.5)
+    )
+    tl = pm.camera_duty(
+        enabled=True, mode="timelapse", capture_period_seconds=60, snapshot_seconds=3
+    )
+    assert tl == pytest.approx(0.05)
+
+
+# ── Phase + dive estimation ──────────────────────────────────────────
+def test_phase_power_hotel_only():
+    cfg = pm.PhaseConfig()  # everything off
+    assert pm.phase_power(cfg) == pytest.approx(pm.HOTEL_W)
+
+
+def test_phase_power_full_light_and_camera():
+    cfg = pm.PhaseConfig(
+        light_on=True,
+        brightness_pct=100,
+        camera_on=True,
+        camera_type="continuous-video",
+    )
+    expected = pm.HOTEL_W + pm.led_power_w(100) + pm.CAMERA_RECORDING_W
+    assert pm.phase_power(cfg) == pytest.approx(expected)
+
+
+def test_estimate_dive_durations():
+    est = pm.estimate_dive(
+        depth_m=3600,  # 3600 m at 1 m/s = 1 h descent
+        bottom_time_hours=2.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    assert est["descent_hours"] == pytest.approx(1.0)
+    assert est["bottom_hours"] == pytest.approx(2.0)
+    # ascent = 45 min burn + 1 h rise = 1.75 h
+    assert est["ascent_hours"] == pytest.approx(1.75)
+    assert est["total_hours"] == pytest.approx(4.75)
+
+
+def test_estimate_dive_hotel_only_energy():
+    est = pm.estimate_dive(
+        depth_m=0,
+        bottom_time_hours=10.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    # depth 0 -> descent 0 h, ascent = 0.75 h burn, bottom 10 h
+    expected_wh = pm.HOTEL_W * (10.0 + 0.75)
+    assert est["energy_wh"] == pytest.approx(expected_wh)
+    assert est["average_power_w"] == pytest.approx(pm.HOTEL_W)
+
+
+def test_estimate_dive_brightness_affects_usage():
+    base = dict(
+        depth_m=1000,
+        bottom_time_hours=4.0,
+        descent=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    dim = pm.estimate_dive(
+        bottom=pm.PhaseConfig(light_on=True, brightness_pct=50), **base
+    )
+    bright = pm.estimate_dive(
+        bottom=pm.PhaseConfig(light_on=True, brightness_pct=75), **base
+    )
+    assert dim["energy_wh"] < bright["energy_wh"]
+    assert dim["usage_percent"] < bright["usage_percent"]
+
+
+def test_estimate_dive_interval_vs_continuous_lights():
+    base = dict(
+        depth_m=500,
+        bottom_time_hours=6.0,
+        descent=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    continuous = pm.estimate_dive(
+        bottom=pm.PhaseConfig(light_on=True, brightness_pct=100, light_mode="continuous"),
+        **base,
+    )
+    interval = pm.estimate_dive(
+        bottom=pm.PhaseConfig(
+            light_on=True,
+            brightness_pct=100,
+            light_mode="interval",
+            light_on_s=10,
+            light_off_s=30,
+        ),
+        **base,
+    )
+    assert interval["energy_wh"] < continuous["energy_wh"]
+
+
+def test_reserve_flag():
+    # A short, light-load dive fits within reserve.
+    ok = pm.estimate_dive(
+        depth_m=100,
+        bottom_time_hours=2.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    assert ok["fits_within_reserve"] is True
+    # An enormous bottom time blows past usable capacity.
+    over = pm.estimate_dive(
+        depth_m=100,
+        bottom_time_hours=200.0,
+        descent=pm.PhaseConfig(),
+        bottom=pm.PhaseConfig(),
+        ascent=pm.PhaseConfig(),
+    )
+    assert over["fits_within_reserve"] is False
+
+
+def test_pack_constants():
+    assert pm.BATTERY_TOTAL_AH == pytest.approx(20.0)  # noqa: SIM300
+    assert pm.BATTERY_CAPACITY_WH == pytest.approx(296.0)  # noqa: SIM300

--- a/extension/frontend/src/components/HomeScreen.vue
+++ b/extension/frontend/src/components/HomeScreen.vue
@@ -16,8 +16,18 @@ import {
 import { mdiCompassOutline } from '@mdi/js'
 import { useSystemStatus, useBattery, useStorage, useLocation, useSensors, useConfigurations, useDiveControl } from '../composables/useApi'
 import AttitudeVisualization from './AttitudeVisualization.vue'
-import type { SensorModule } from '../composables/useApi'
+import type { SensorModule, DeploymentConfiguration } from '../composables/useApi'
 import type { Screen } from '../types'
+import {
+  estimateDive,
+  phaseConfigFromSettings,
+  hoursRemainingFromSoc,
+  BATTERY_CAPACITY_WH,
+  BATTERY_RESERVE_PCT as PM_RESERVE_PCT,
+  BATTERY_PACK_COUNT,
+  BATTERY_PACK_AH,
+  TYPICAL_DIVE_LOAD_W,
+} from '../lib/powerModel'
 
 const props = defineProps<{
   isConnected: boolean
@@ -64,31 +74,19 @@ const storageUsed = computed(() => storage.value?.used_percent ?? systemStatus.v
 const storageTotal = computed(() => storage.value?.total_gb ?? systemStatus.value?.storage_total_gb ?? 100)
 const storageAvailableGb = computed(() => storage.value?.available_gb ?? (storageTotal.value - (storage.value?.used_gb ?? systemStatus.value?.storage_used_gb ?? 0)))
 const storageType = computed(() => storage.value?.storage_type ?? 'SD Card')
-// Pack: 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel (20 Ah / 296 Wh).
-// Keep these in sync with the backend (system.py) and the dive planner
-// (MissionProgramming.vue).
-const BATTERY_PACK_COUNT = 2
-const BATTERY_PACK_AH = 10
-const BATTERY_NOMINAL_V = 14.8
-const BATTERY_TOTAL_WH = BATTERY_PACK_COUNT * BATTERY_PACK_AH * BATTERY_NOMINAL_V
-const BATTERY_RESERVE_PCT = 15
-
+// Live time-remaining: prefer the backend estimate (uses measured pack
+// current); fall back to the shared power model's typical-load estimate.
+// All pack/power constants come from ../lib/powerModel (single source).
 const batteryTimeRemaining = computed(() => {
-  const powerRPi5_W = 15
-  const powerRadCAM_W = 5
-  const powerPerLumen_W = 15
-  const lumenCount = 2
-
-  const totalPower_W = powerRPi5_W + powerRadCAM_W + (powerPerLumen_W * lumenCount)
-  const usablePct = Math.max(0, batteryLevel.value - BATTERY_RESERVE_PCT)
-  const usableCapacity_Wh = BATTERY_TOTAL_WH * (usablePct / 100)
-  const hoursRemaining = totalPower_W > 0 ? usableCapacity_Wh / totalPower_W : 0
-  const h = Math.floor(hoursRemaining)
-  const m = Math.round((hoursRemaining - h) * 60)
+  const backend = battery.value?.time_remaining
+  if (backend && backend !== 'Unknown' && backend !== 'Unavailable') return backend
+  const hours = hoursRemainingFromSoc(batteryLevel.value, TYPICAL_DIVE_LOAD_W)
+  const h = Math.floor(hours)
+  const m = Math.round((hours - h) * 60)
   return `${h}h ${m}m`
 })
 
-const batteryEstimateAssumption = `Assumes ${BATTERY_PACK_COUNT}× ${BATTERY_PACK_AH} Ah Blue Robotics 4S packs (${BATTERY_TOTAL_WH.toFixed(0)} Wh) at ~50 W draw, ${BATTERY_RESERVE_PCT}% reserve held back`
+const batteryEstimateAssumption = `Assumes ${BATTERY_PACK_COUNT}× ${BATTERY_PACK_AH} Ah Blue Robotics 4S packs (${BATTERY_CAPACITY_WH.toFixed(0)} Wh), ${PM_RESERVE_PCT}% reserve held back; live estimate uses measured pack current`
 
 const gpsStatus = computed<'active' | 'searching' | 'inactive'>(() => {
   if (!location.value) return 'inactive'
@@ -195,6 +193,7 @@ const { configurations: savedConfigSummaries, fetchConfigurations, loadConfigura
 const savedConfigurations = computed(() => savedConfigSummaries.value.map(c => c.name))
 
 const loadedElapsedTimeHours = ref(0)
+const loadedConfig = ref<DeploymentConfiguration | null>(null)
 
 const depthWarningLevel = computed(() => {
   const depth = parseFloat(estimatedDepth.value)
@@ -210,46 +209,35 @@ const diveFeasibility = computed(() => {
   const depth = parseFloat(estimatedDepth.value)
   if (isNaN(depth) || depth <= 0) return null
 
-  // -- Descent / ascent parameters --
-  const descentRate_m_per_s = 1          // descent speed in meters per second
-  const descentRate_m_per_min = descentRate_m_per_s * 60  // converted to m/min for time calc
-
-  const descentTimeMinutes = depth / descentRate_m_per_min
-  const ascentTimeMinutes = depth / descentRate_m_per_min
-  const descentTimeHours = descentTimeMinutes / 60
-  const ascentTimeHours = ascentTimeMinutes / 60
-
+  // Bottom time comes from the operator's release-weight setting.
   let bottomTimeHours = 0
-  let totalDiveTimeHours = 0
-
   if (props.releaseWeightBy === 'datetime') {
-    if (estimatedBottomTime.value) {
-      bottomTimeHours = parseFloat(estimatedBottomTime.value)
-      if (isNaN(bottomTimeHours)) bottomTimeHours = 0
+    if (releaseWeightDate.value && releaseWeightTime.value) {
+      const release = new Date(`${releaseWeightDate.value}T${releaseWeightTime.value}:00Z`)
+      bottomTimeHours = Math.max(0, (release.getTime() - Date.now()) / 3_600_000)
+    } else if (estimatedBottomTime.value) {
+      bottomTimeHours = parseFloat(estimatedBottomTime.value) || 0
     }
-    totalDiveTimeHours = descentTimeHours + bottomTimeHours + ascentTimeHours
   } else {
-    totalDiveTimeHours = loadedElapsedTimeHours.value
-    bottomTimeHours = Math.max(0, totalDiveTimeHours - descentTimeHours - ascentTimeHours)
+    bottomTimeHours = loadedElapsedTimeHours.value
   }
 
-  // -- Power consumption (watts) --
-  const powerRPi5_W = 15                // Raspberry Pi 5 single-board computer
-  const powerRadCAM_W = 5               // RadCAM camera module
-  const powerPerLumen_W = 15            // each lumen light module
-  const lumenCount = 2                  // number of lumen lights installed
+  // Per-phase light/camera draw from the selected configuration's real
+  // settings, via the shared power model (single LED, brightness-scaled,
+  // duty-cycled by camera/light mode). descent = depth/1 m/s, ascent =
+  // 45 min burn + depth/1 m/s.
+  const cfg = loadedConfig.value
+  const estimate = estimateDive({
+    depthM: depth,
+    bottomTimeHours,
+    descent: phaseConfigFromSettings(cfg?.descent?.light, cfg?.descent?.camera),
+    bottom: phaseConfigFromSettings(cfg?.bottom?.light, cfg?.bottom?.camera),
+    ascent: phaseConfigFromSettings(cfg?.ascent?.light, cfg?.ascent?.camera),
+  })
 
-  // -- Battery --
-  const batteryCapacity_Wh = 266        // onboard battery capacity in watt-hours
-
-  // -- Derived values --
-  const totalPowerDraw = powerRPi5_W + powerRadCAM_W + (powerPerLumen_W * lumenCount)
-  const batteryLifeHours = totalPowerDraw > 0 ? batteryCapacity_Wh / totalPowerDraw : 0
-  const batteryUsagePercent = Math.min(
-    batteryLifeHours > 0 ? (totalDiveTimeHours / batteryLifeHours) * 100 : 100,
-    100
-  )
-  const batteryRemainingPercent = Math.max(0, 100 - batteryUsagePercent)
+  const totalDiveTimeHours = estimate.totalHours
+  const batteryUsagePercent = estimate.usagePercent
+  const batteryRemainingPercent = estimate.remainingPercent
   const batteryOk = batteryRemainingPercent >= 20
 
   const storagePerHour = 8
@@ -274,13 +262,13 @@ const diveFeasibility = computed(() => {
     batteryRemainingPercent: Math.round(batteryRemainingPercent),
     storageRemaining: Math.round(storageRemaining),
     totalDiveTimeHours: totalDiveTimeHours.toFixed(1),
-    descentTimeHours: descentTimeHours.toFixed(1),
-    bottomTimeHours: bottomTimeHours.toFixed(1),
-    ascentTimeHours: ascentTimeHours.toFixed(1),
+    descentTimeHours: estimate.descentHours.toFixed(1),
+    bottomTimeHours: estimate.bottomHours.toFixed(1),
+    ascentTimeHours: estimate.ascentHours.toFixed(1),
     batteryUsagePercent: Math.round(batteryUsagePercent),
     estimatedStorageNeeded: Math.round(estimatedStorageNeeded),
-    totalPowerDraw: totalPowerDraw.toFixed(1),
-    batteryLifeHours: batteryLifeHours.toFixed(1),
+    totalPowerDraw: estimate.averagePowerW.toFixed(1),
+    batteryLifeHours: estimate.batteryLifeHours.toFixed(1),
     surfaceTimeUTC,
     timeUntilRelease: timeUntilRelease !== null ? timeUntilRelease.toFixed(1) : null
   }
@@ -390,12 +378,14 @@ const handleConfigurationChange = async () => {
     releaseWeightDate.value = ''
     releaseWeightTime.value = ''
     loadedElapsedTimeHours.value = 0
+    loadedConfig.value = null
     emit('configurationSelect', '')
     return
   }
   if (selectedConfiguration.value) {
     const cfg = await loadConfiguration(selectedConfiguration.value)
     if (cfg) {
+      loadedConfig.value = cfg
       const rw = cfg.ascent.release_weight
       emit('update:releaseWeightBy', rw.method)
       if (rw.method === 'elapsed') {
@@ -849,7 +839,7 @@ const formatReleaseTime = (date: Date) => {
           Estimated: {{ batteryTimeRemaining }} remaining
         </p>
         <p class="text-xs mt-1 opacity-75" style="color: #96EEF2">
-          2× 10 Ah 4S packs · 50 W draw · 15% reserve
+          2× 10 Ah 4S packs · live current · 15% reserve
         </p>
       </div>
 

--- a/extension/frontend/src/components/HomeScreen.vue
+++ b/extension/frontend/src/components/HomeScreen.vue
@@ -267,7 +267,7 @@ const diveFeasibility = computed(() => {
     ascentTimeHours: estimate.ascentHours.toFixed(1),
     batteryUsagePercent: Math.round(batteryUsagePercent),
     estimatedStorageNeeded: Math.round(estimatedStorageNeeded),
-    totalPowerDraw: estimate.averagePowerW.toFixed(1),
+    totalPowerConsumedWh: estimate.energyWh.toFixed(1),
     batteryLifeHours: estimate.batteryLifeHours.toFixed(1),
     surfaceTimeUTC,
     timeUntilRelease: timeUntilRelease !== null ? timeUntilRelease.toFixed(1) : null
@@ -685,8 +685,8 @@ const formatReleaseTime = (date: Date) => {
       <!-- Power & Battery Metrics -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div class="rounded-lg p-4" style="background-color: rgba(14, 36, 70, 0.5)">
-          <p class="text-xs mb-1" style="color: #96EEF2">Power Draw</p>
-          <p class="text-xl font-bold text-white">{{ diveFeasibility.totalPowerDraw }} W</p>
+          <p class="text-xs mb-1" style="color: #96EEF2">Total Power Consumed</p>
+          <p class="text-xl font-bold text-white">{{ diveFeasibility.totalPowerConsumedWh }} Wh</p>
         </div>
         <div class="rounded-lg p-4" style="background-color: rgba(14, 36, 70, 0.5)">
           <p class="text-xs mb-1" style="color: #96EEF2">Battery Life</p>

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -4,6 +4,7 @@ import { Settings, Save, Copy, AlertTriangle, ChevronDown, ChevronUp, Camera as 
 import type { Screen } from '../types'
 import { useConfigurations } from '../composables/useApi'
 import type { DeploymentConfiguration } from '../composables/useApi'
+import { estimateDive, type PhaseConfig, type CameraType, type LightMode } from '../lib/powerModel'
 
 const props = withDefaults(defineProps<{
   releaseWeightBy: 'datetime' | 'elapsed'
@@ -155,43 +156,81 @@ const updateFrequency = ref('5min')
 const useIridium = ref(false)
 const useLoRA = ref(false)
 
-const batteryData = computed(() => {
-  // -- Descent / ascent parameters --
-  const descentRate_m_per_s = 1          // descent speed in meters per second
-  const descentRate_m_per_min = descentRate_m_per_s * 60
+// Convert a {number, unit} pair from the planner UI into seconds.
+function toSeconds(value: string | number, unit: string): number {
+  const n = Number(value) || 0
+  if (unit === 'hours') return n * 3600
+  if (unit === 'minutes') return n * 60
+  return n
+}
 
-  // -- Power consumption (watts) --
-  const powerRPi5_W = 15                // Raspberry Pi 5 single-board computer
-  const powerRadCAM_W = 5               // RadCAM camera module
-  const powerPerLumen_W = 15            // each lumen light module
-  const lumenCount = 2                  // number of lumen lights installed
-
-  // -- Battery --
-  // 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel @ 14.8 V nominal.
-  // Keep in sync with HomeScreen.vue and backend system.py.
-  const batteryCapacity_Wh = 2 * 10 * 14.8   // 296 Wh total
-
-  // -- Dive duration from depth + release weight settings --
-  const depth = parseFloat(estimatedDepth.value) || 0
-  const descentTimeHours = depth / descentRate_m_per_min / 60
-  const ascentTimeHours = depth / descentRate_m_per_min / 60
-
-  let diveDuration = 0
+// Bottom time (hours) from the operator's release-weight setting.
+const bottomTimeHours = computed(() => {
   if (props.releaseWeightBy === 'elapsed') {
-    const num = Number(releaseWeightElapsedNumber.value) || 0
-    const unit = releaseWeightElapsedUnit.value
-    diveDuration = unit === 'hours' ? num : unit === 'minutes' ? num / 60 : num / 3600
-  } else {
-    diveDuration = descentTimeHours + ascentTimeHours
+    return toSeconds(releaseWeightElapsedNumber.value, releaseWeightElapsedUnit.value) / 3600
   }
+  if (releaseWeightDate.value && releaseWeightTime.value) {
+    const release = new Date(`${releaseWeightDate.value}T${releaseWeightTime.value}:00Z`)
+    const hrs = (release.getTime() - Date.now()) / 3_600_000
+    return Math.max(0, hrs)
+  }
+  return 0
+})
 
-  // -- Derived values --
-  const totalPower = powerRPi5_W + powerRadCAM_W + (powerPerLumen_W * lumenCount)
-  const batteryLife = totalPower > 0 ? batteryCapacity_Wh / totalPower : 0
-  const batteryUsagePercent = batteryLife > 0
-    ? Math.min((diveDuration / batteryLife) * 100, 100)
-    : 0
-  return { totalPower, batteryLife, batteryUsagePercent, diveDuration }
+const descentPhase = computed<PhaseConfig>(() => ({
+  lightOn: descentLightOn.value,
+  brightnessPct: descentLightBrightness.value,
+  lightMode: descentLightMode.value as LightMode,
+  lightOnS: toSeconds(descentLightOnNumber.value, descentLightOnUnit.value),
+  lightOffS: toSeconds(descentLightOffNumber.value, descentLightOffUnit.value),
+  cameraOn: descentCameraOn.value,
+  cameraType: descentCameraType.value as CameraType,
+  recordS: toSeconds(descentVideoRecordNumber.value, descentVideoRecordUnit.value),
+  pauseS: toSeconds(descentVideoPauseNumber.value, descentVideoPauseUnit.value),
+  capturePeriodS: toSeconds(descentCaptureFrequency.value, descentCaptureFrequencyUnit.value),
+}))
+
+const bottomPhase = computed<PhaseConfig>(() => ({
+  lightOn: bottomLightOn.value,
+  brightnessPct: bottomLightBrightness.value,
+  lightMode: bottomLightMode.value as LightMode,
+  lightOnS: toSeconds(bottomLightOnNumber.value, bottomLightOnUnit.value),
+  lightOffS: toSeconds(bottomLightOffNumber.value, bottomLightOffUnit.value),
+  cameraOn: bottomCameraOn.value,
+  cameraType: bottomCameraType.value as CameraType,
+  recordS: toSeconds(bottomVideoRecordNumber.value, bottomVideoRecordUnit.value),
+  pauseS: toSeconds(bottomVideoPauseNumber.value, bottomVideoPauseUnit.value),
+  capturePeriodS: toSeconds(bottomCaptureFrequency.value, bottomCaptureFrequencyUnit.value),
+}))
+
+const ascentPhase = computed<PhaseConfig>(() => ({
+  lightOn: ascentLightOn.value,
+  brightnessPct: ascentLightBrightness.value,
+  lightMode: ascentLightMode.value as LightMode,
+  lightOnS: toSeconds(ascentLightOnNumber.value, ascentLightOnUnit.value),
+  lightOffS: toSeconds(ascentLightOffNumber.value, ascentLightOffUnit.value),
+  cameraOn: ascentCameraOn.value,
+  cameraType: ascentCameraType.value as CameraType,
+  recordS: toSeconds(ascentVideoRecordNumber.value, ascentVideoRecordUnit.value),
+  pauseS: toSeconds(ascentVideoPauseNumber.value, ascentVideoPauseUnit.value),
+  capturePeriodS: toSeconds(ascentCaptureFrequency.value, ascentCaptureFrequencyUnit.value),
+}))
+
+const batteryData = computed(() => {
+  const estimate = estimateDive({
+    depthM: parseFloat(estimatedDepth.value) || 0,
+    bottomTimeHours: bottomTimeHours.value,
+    descent: descentPhase.value,
+    bottom: bottomPhase.value,
+    ascent: ascentPhase.value,
+  })
+  return {
+    totalPower: estimate.averagePowerW,
+    batteryLife: estimate.batteryLifeHours,
+    batteryUsagePercent: estimate.usagePercent,
+    diveDuration: estimate.totalHours,
+    estimate,
+  }
 })
 
 // Bottom timelapse strobe helpers.  Both pre/post are stored in

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -4,7 +4,18 @@ import { Settings, Save, Copy, AlertTriangle, ChevronDown, ChevronUp, Camera as 
 import type { Screen } from '../types'
 import { useConfigurations } from '../composables/useApi'
 import type { DeploymentConfiguration } from '../composables/useApi'
-import { estimateDive, type PhaseConfig, type CameraType, type LightMode } from '../lib/powerModel'
+import {
+  estimateDive,
+  HOTEL_W,
+  CAMERA_RECORDING_W,
+  BATTERY_CAPACITY_WH,
+  ASCENT_BURN_MINUTES,
+  type PhaseConfig,
+  type CameraType,
+  type LightMode,
+} from '../lib/powerModel'
+
+const POWER = { HOTEL_W, CAMERA_RECORDING_W, BATTERY_CAPACITY_WH, ASCENT_BURN_MINUTES }
 
 const props = withDefaults(defineProps<{
   releaseWeightBy: 'datetime' | 'elapsed'
@@ -23,6 +34,7 @@ const selectedConfiguration = ref(props.initialConfiguration || '')
 const estimatedDepth = ref('')
 const warnings = ref<string[]>([])
 const showBatteryPlanning = ref(false)
+const showBatteryBreakdown = ref(false)
 const showSaveModal = ref(false)
 const configurationName = ref('')
 const hasUnsavedChanges = ref(false)
@@ -201,6 +213,8 @@ const bottomPhase = computed<PhaseConfig>(() => ({
   recordS: toSeconds(bottomVideoRecordNumber.value, bottomVideoRecordUnit.value),
   pauseS: toSeconds(bottomVideoPauseNumber.value, bottomVideoPauseUnit.value),
   capturePeriodS: toSeconds(bottomCaptureFrequency.value, bottomCaptureFrequencyUnit.value),
+  timelapsePreS: toSeconds(bottomTimelapseLightPreNumber.value, 'seconds'),
+  timelapsePostS: toSeconds(bottomTimelapseLightPostNumber.value, 'seconds'),
 }))
 
 const ascentPhase = computed<PhaseConfig>(() => ({
@@ -226,6 +240,7 @@ const batteryData = computed(() => {
   })
   return {
     totalPower: estimate.averagePowerW,
+    energyWh: estimate.energyWh,
     batteryLife: estimate.batteryLifeHours,
     batteryUsagePercent: estimate.usagePercent,
     diveDuration: estimate.totalHours,
@@ -1769,14 +1784,14 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
           <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
             <div class="p-4 rounded-lg" style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.2)">
               <div class="flex items-center justify-between mb-2">
-                <span style="color: #96EEF2">Estimated Dive Depth</span>
-                <span class="text-white text-xl">{{ estimatedDepth || '--' }}m</span>
+                <span style="color: #96EEF2">Average Power Draw</span>
+                <span class="text-white text-xl">{{ batteryData.totalPower.toFixed(1) }} W</span>
               </div>
             </div>
             <div class="p-4 rounded-lg" style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.2)">
               <div class="flex items-center justify-between mb-2">
-                <span style="color: #96EEF2">Total Power Draw</span>
-                <span class="text-white text-xl">{{ batteryData.totalPower.toFixed(1) }}W</span>
+                <span style="color: #96EEF2">Total Power Consumed</span>
+                <span class="text-white text-xl">{{ batteryData.energyWh.toFixed(1) }} Wh</span>
               </div>
             </div>
             <div class="p-4 rounded-lg" style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.2)">
@@ -1794,6 +1809,76 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
             </div>
             <div class="w-full bg-gray-700 rounded-full h-4 overflow-hidden">
               <div class="h-full rounded-full transition-all" :style="{ width: `${batteryData.batteryUsagePercent}%`, background: batteryData.batteryUsagePercent > 80 ? 'linear-gradient(90deg, #DD2C1D 0%, #FF9937 100%)' : batteryData.batteryUsagePercent > 50 ? 'linear-gradient(90deg, #FF9937 0%, #FCD869 100%)' : 'linear-gradient(90deg, #41B9C3 0%, #96EEF2 100%)' }"></div>
+            </div>
+
+            <!-- Surface recovery time on remaining energy -->
+            <div class="flex items-center justify-between mt-3 pt-3 text-sm" style="border-top: 1px solid rgba(65, 185, 195, 0.2)">
+              <span style="color: #96EEF2">Surface recovery time</span>
+              <span class="text-white">
+                {{ batteryData.estimate.recoveryHours.toFixed(1) }} h
+                <span style="color: rgba(150, 238, 242, 0.6)">({{ batteryData.estimate.remainingAfterDiveWh.toFixed(0) }} Wh left ÷ {{ batteryData.estimate.recoveryHotelW.toFixed(1) }} W hotel)</span>
+              </span>
+            </div>
+
+            <!-- Breakdown dropdown -->
+            <button
+              type="button"
+              @click="showBatteryBreakdown = !showBatteryBreakdown"
+              class="mt-3 flex items-center gap-1 text-xs"
+              style="color: #96EEF2"
+            >
+              <ChevronDown v-if="!showBatteryBreakdown" class="w-4 h-4" />
+              <ChevronUp v-else class="w-4 h-4" />
+              {{ showBatteryBreakdown ? 'Hide' : 'Show' }} calculation &amp; component breakdown
+            </button>
+
+            <div v-if="showBatteryBreakdown" class="mt-3 text-xs" style="color: #96EEF2">
+              <p class="mb-2" style="color: rgba(150, 238, 242, 0.75)">
+                Energy per phase = (Hotel {{ POWER.HOTEL_W }} W + LED×brightness×duty + Camera {{ POWER.CAMERA_RECORDING_W }} W×duty) × phase&nbsp;hours.
+                Usage % = total energy ÷ {{ POWER.BATTERY_CAPACITY_WH.toFixed(0) }} Wh pack.
+                Durations: descent = depth ÷ 1 m/s, bottom = release-weight time, ascent = {{ POWER.ASCENT_BURN_MINUTES }} min burn + depth ÷ 1 m/s.
+              </p>
+              <div class="overflow-x-auto">
+                <table class="w-full text-left" style="border-collapse: collapse">
+                  <thead>
+                    <tr style="color: rgba(150, 238, 242, 0.9)">
+                      <th class="py-1 pr-3">Phase</th>
+                      <th class="py-1 pr-3">Dur (h)</th>
+                      <th class="py-1 pr-3">Hotel</th>
+                      <th class="py-1 pr-3">Lights</th>
+                      <th class="py-1 pr-3">Camera</th>
+                      <th class="py-1">Total (Wh)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr
+                      v-for="phase in batteryData.estimate.phases"
+                      :key="phase.name"
+                      style="border-top: 1px solid rgba(65, 185, 195, 0.2)"
+                    >
+                      <td class="py-1 pr-3 text-white">
+                        {{ phase.name }}
+                        <span v-if="phase.lightWh > 0" style="color: rgba(150, 238, 242, 0.6)">
+                          ({{ phase.brightnessPct }}% · {{ Math.round(phase.lightDuty * 100) }}% on)
+                        </span>
+                      </td>
+                      <td class="py-1 pr-3">{{ phase.hours.toFixed(2) }}</td>
+                      <td class="py-1 pr-3">{{ phase.hotelWh.toFixed(1) }}</td>
+                      <td class="py-1 pr-3">{{ phase.lightWh.toFixed(1) }}</td>
+                      <td class="py-1 pr-3">{{ phase.cameraWh.toFixed(1) }}</td>
+                      <td class="py-1 text-white">{{ phase.totalWh.toFixed(1) }}</td>
+                    </tr>
+                    <tr style="border-top: 1px solid rgba(65, 185, 195, 0.4)">
+                      <td class="py-1 pr-3 text-white">Total</td>
+                      <td class="py-1 pr-3 text-white">{{ batteryData.estimate.totalHours.toFixed(2) }}</td>
+                      <td class="py-1 pr-3 text-white">{{ batteryData.estimate.hotelWh.toFixed(1) }}</td>
+                      <td class="py-1 pr-3 text-white">{{ batteryData.estimate.lightWh.toFixed(1) }}</td>
+                      <td class="py-1 pr-3 text-white">{{ batteryData.estimate.cameraWh.toFixed(1) }}</td>
+                      <td class="py-1 text-white">{{ batteryData.estimate.energyWh.toFixed(1) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
 

--- a/extension/frontend/src/lib/powerModel.ts
+++ b/extension/frontend/src/lib/powerModel.ts
@@ -1,0 +1,287 @@
+/**
+ * Shared DORIS power model (frontend mirror of backend
+ * services/power_model.py). Single source of truth for the power budget
+ * used by HomeScreen and MissionProgramming so the planners and the live
+ * battery estimator never disagree.
+ *
+ * Constants were validated against a real 140 min / 791 m dive log
+ * (recorder_20260528_165058.mcap):
+ *  - LED: measured pack-current rise at 1700 us = 1.28 A vs bench 1.24 A.
+ *  - Hotel (Pi5 + autopilot + sensors, lights off): ~8 W.
+ *  - Camera recording adder: ~1.5 W.
+ *  - Release/burn-wire relay: no measurable draw.
+ */
+
+// ── Dive profile ─────────────────────────────────────────────────────
+export const DESCENT_RATE_M_S = 1.0
+export const ASCENT_BURN_MINUTES = 45.0
+
+// ── Battery pack: 2× Blue Robotics 10 Ah 4S Li-ion packs in parallel ─
+export const BATTERY_PACK_COUNT = 2
+export const BATTERY_PACK_AH = 10.0
+export const BATTERY_NOMINAL_V = 14.8
+export const BATTERY_TOTAL_AH = BATTERY_PACK_COUNT * BATTERY_PACK_AH // 20 Ah
+export const BATTERY_CAPACITY_WH = BATTERY_TOTAL_AH * BATTERY_NOMINAL_V // 296 Wh
+export const BATTERY_RESERVE_PCT = 15.0
+
+// ── Component loads (empirical) ──────────────────────────────────────
+export const HOTEL_W = 8.0
+export const CAMERA_RECORDING_W = 1.5
+export const RELEASE_W = 0.0
+export const TYPICAL_DIVE_LOAD_W = 11.0
+
+// ── LED (single) ─────────────────────────────────────────────────────
+export const LIGHT_PWM_MIN = 1100
+export const LIGHT_PWM_MAX = 1900
+
+// Bench-measured LED current (A) vs PWM (us) at 15 V.
+const LED_CURVE: ReadonlyArray<readonly [number, number]> = [
+  [1100, 0.01],
+  [1200, 0.25],
+  [1500, 0.85],
+  [1700, 1.24],
+  [1900, 1.64],
+]
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+
+export function brightnessToPwm(brightnessPct: number): number {
+  const pct = clamp(brightnessPct, 0, 100)
+  return LIGHT_PWM_MIN + (pct / 100) * (LIGHT_PWM_MAX - LIGHT_PWM_MIN)
+}
+
+export function ledCurrentAtPwm(pwm: number): number {
+  if (pwm <= LED_CURVE[0][0]) return LED_CURVE[0][1]
+  if (pwm >= LED_CURVE[LED_CURVE.length - 1][0]) return LED_CURVE[LED_CURVE.length - 1][1]
+  for (let i = 0; i < LED_CURVE.length - 1; i++) {
+    const [pLo, iLo] = LED_CURVE[i]
+    const [pHi, iHi] = LED_CURVE[i + 1]
+    if (pwm >= pLo && pwm <= pHi) {
+      return iLo + ((iHi - iLo) * (pwm - pLo)) / (pHi - pLo)
+    }
+  }
+  return LED_CURVE[LED_CURVE.length - 1][1]
+}
+
+/** Power (W) drawn by the single LED at a given brightness (50% < 75%). */
+export function ledPowerW(brightnessPct: number, voltage = BATTERY_NOMINAL_V): number {
+  return ledCurrentAtPwm(brightnessToPwm(brightnessPct)) * voltage
+}
+
+// ── Duty cycles ──────────────────────────────────────────────────────
+export function intervalDuty(onSeconds: number, offSeconds: number): number {
+  const total = onSeconds + offSeconds
+  if (total <= 0) return 1
+  return clamp(onSeconds / total, 0, 1)
+}
+
+export type LightMode = 'continuous' | 'interval'
+export type CameraType = 'continuous-video' | 'video-interval' | 'timelapse'
+
+export function lightDuty(opts: {
+  enabled: boolean
+  mode?: LightMode
+  onSeconds?: number
+  offSeconds?: number
+}): number {
+  if (!opts.enabled) return 0
+  if (opts.mode === 'interval') return intervalDuty(opts.onSeconds ?? 0, opts.offSeconds ?? 0)
+  return 1
+}
+
+export function cameraDuty(opts: {
+  enabled: boolean
+  mode?: CameraType
+  recordSeconds?: number
+  pauseSeconds?: number
+  capturePeriodSeconds?: number
+  snapshotSeconds?: number
+}): number {
+  if (!opts.enabled) return 0
+  if (opts.mode === 'video-interval') {
+    return intervalDuty(opts.recordSeconds ?? 0, opts.pauseSeconds ?? 0)
+  }
+  if (opts.mode === 'timelapse') {
+    const period = opts.capturePeriodSeconds ?? 0
+    if (period <= 0) return 0
+    return clamp((opts.snapshotSeconds ?? 3) / period, 0, 1)
+  }
+  return 1
+}
+
+// ── Per-phase planning ───────────────────────────────────────────────
+export interface PhaseConfig {
+  lightOn?: boolean
+  brightnessPct?: number
+  lightMode?: LightMode
+  lightOnS?: number
+  lightOffS?: number
+  cameraOn?: boolean
+  cameraType?: CameraType
+  recordS?: number
+  pauseS?: number
+  capturePeriodS?: number
+}
+
+export function phaseAveragePowerW(opts: {
+  brightnessPct?: number
+  lightDutyFraction?: number
+  cameraDutyFraction?: number
+  voltage?: number
+}): number {
+  const v = opts.voltage ?? BATTERY_NOMINAL_V
+  const led = ledPowerW(opts.brightnessPct ?? 0, v) * clamp(opts.lightDutyFraction ?? 0, 0, 1)
+  const cam = CAMERA_RECORDING_W * clamp(opts.cameraDutyFraction ?? 0, 0, 1)
+  return HOTEL_W + led + cam
+}
+
+export function phasePower(cfg: PhaseConfig, voltage = BATTERY_NOMINAL_V): number {
+  const ld = lightDuty({
+    enabled: !!cfg.lightOn,
+    mode: cfg.lightMode,
+    onSeconds: cfg.lightOnS,
+    offSeconds: cfg.lightOffS,
+  })
+  const cd = cameraDuty({
+    enabled: !!cfg.cameraOn,
+    mode: cfg.cameraType,
+    recordSeconds: cfg.recordS,
+    pauseSeconds: cfg.pauseS,
+    capturePeriodSeconds: cfg.capturePeriodS,
+  })
+  return phaseAveragePowerW({
+    brightnessPct: cfg.brightnessPct,
+    lightDutyFraction: ld,
+    cameraDutyFraction: cd,
+    voltage,
+  })
+}
+
+export function usableCapacityWh(reservePct = BATTERY_RESERVE_PCT): number {
+  return BATTERY_CAPACITY_WH * (1 - clamp(reservePct, 0, 100) / 100)
+}
+
+/** Hours until the reserve is hit at a given SOC (%) and average load (W). */
+export function hoursRemainingFromSoc(socPct: number, averagePowerW: number): number {
+  if (averagePowerW <= 0) return 0
+  const usablePct = Math.max(0, socPct - BATTERY_RESERVE_PCT)
+  const usableWh = BATTERY_CAPACITY_WH * (usablePct / 100)
+  return usableWh / averagePowerW
+}
+
+// ── Mapping from saved DeploymentConfiguration shapes ────────────────
+interface TimeValueLike {
+  number: string | number
+  unit: string
+}
+interface LightSettingsLike {
+  enabled: boolean
+  mode: LightMode
+  brightness: number
+  on_time?: TimeValueLike
+  off_time?: TimeValueLike
+}
+interface CameraSettingsLike {
+  enabled: boolean
+  camera_type: CameraType
+  capture_frequency: number
+  capture_frequency_unit: string
+  video_record?: TimeValueLike
+  video_pause?: TimeValueLike
+}
+
+export function timeValueToSeconds(tv?: TimeValueLike | null): number {
+  if (!tv) return 0
+  const n = Number(tv.number) || 0
+  if (tv.unit === 'hours') return n * 3600
+  if (tv.unit === 'minutes') return n * 60
+  return n
+}
+
+/** Build a PhaseConfig from saved light/camera settings objects. */
+export function phaseConfigFromSettings(
+  light?: LightSettingsLike,
+  camera?: CameraSettingsLike,
+): PhaseConfig {
+  return {
+    lightOn: !!light?.enabled,
+    brightnessPct: light?.brightness ?? 0,
+    lightMode: light?.mode ?? 'continuous',
+    lightOnS: timeValueToSeconds(light?.on_time),
+    lightOffS: timeValueToSeconds(light?.off_time),
+    cameraOn: !!camera?.enabled,
+    cameraType: camera?.camera_type ?? 'continuous-video',
+    recordS: timeValueToSeconds(camera?.video_record),
+    pauseS: timeValueToSeconds(camera?.video_pause),
+    capturePeriodS: camera
+      ? timeValueToSeconds({
+          number: camera.capture_frequency,
+          unit: camera.capture_frequency_unit,
+        })
+      : 0,
+  }
+}
+
+export interface DiveEstimate {
+  descentHours: number
+  bottomHours: number
+  ascentHours: number
+  totalHours: number
+  descentPowerW: number
+  bottomPowerW: number
+  ascentPowerW: number
+  averagePowerW: number
+  energyWh: number
+  usagePercent: number
+  remainingPercent: number
+  batteryLifeHours: number
+  fitsWithinReserve: boolean
+}
+
+/**
+ * Estimate energy/time/battery usage for a planned dive.
+ * descent = depth / 1 m/s; bottom = operator release-weight time;
+ * ascent = 45 min burn + depth / 1 m/s (ascent settings apply throughout).
+ */
+export function estimateDive(opts: {
+  depthM: number
+  bottomTimeHours: number
+  descent: PhaseConfig
+  bottom: PhaseConfig
+  ascent: PhaseConfig
+  voltage?: number
+  reservePct?: number
+}): DiveEstimate {
+  const v = opts.voltage ?? BATTERY_NOMINAL_V
+  const riseH = Math.max(0, opts.depthM) / DESCENT_RATE_M_S / 3600
+  const descentHours = riseH
+  const ascentHours = ASCENT_BURN_MINUTES / 60 + riseH
+  const bottomHours = Math.max(0, opts.bottomTimeHours)
+
+  const descentPowerW = phasePower(opts.descent, v)
+  const bottomPowerW = phasePower(opts.bottom, v)
+  const ascentPowerW = phasePower(opts.ascent, v)
+
+  const energyWh =
+    descentPowerW * descentHours + bottomPowerW * bottomHours + ascentPowerW * ascentHours
+  const totalHours = descentHours + bottomHours + ascentHours
+  const averagePowerW = totalHours > 0 ? energyWh / totalHours : 0
+  const usagePercent = BATTERY_CAPACITY_WH ? (energyWh / BATTERY_CAPACITY_WH) * 100 : 0
+  const batteryLifeHours = averagePowerW > 0 ? BATTERY_CAPACITY_WH / averagePowerW : 0
+
+  return {
+    descentHours,
+    bottomHours,
+    ascentHours,
+    totalHours,
+    descentPowerW,
+    bottomPowerW,
+    ascentPowerW,
+    averagePowerW,
+    energyWh,
+    usagePercent: Math.min(usagePercent, 100),
+    remainingPercent: Math.max(0, 100 - usagePercent),
+    batteryLifeHours,
+    fitsWithinReserve: energyWh <= usableCapacityWh(opts.reservePct),
+  }
+}

--- a/extension/frontend/src/lib/powerModel.ts
+++ b/extension/frontend/src/lib/powerModel.ts
@@ -28,6 +28,9 @@ export const BATTERY_RESERVE_PCT = 15.0
 export const HOTEL_W = 8.0
 export const CAMERA_RECORDING_W = 1.5
 export const RELEASE_W = 0.0
+// Surface recovery draw (terminal RECOVERY state, disarmed): measured
+// ~9.2 W in-log = hotel electronics + recovery beacon/strobe.
+export const RECOVERY_HOTEL_W = 9.2
 export const TYPICAL_DIVE_LOAD_W = 11.0
 
 // ── LED (single) ─────────────────────────────────────────────────────
@@ -121,6 +124,46 @@ export interface PhaseConfig {
   recordS?: number
   pauseS?: number
   capturePeriodS?: number
+  timelapsePreS?: number
+  timelapsePostS?: number
+}
+
+// Default light strobe window (s) for a timelapse snapshot with no
+// explicit pre/post roll (matches doris.lua ~2 s pre + 1 s post).
+const TIMELAPSE_DEFAULT_STROBE_S = 3.0
+
+/**
+ * Average-on fraction for the LED, accounting for camera coupling.
+ * In interval/timelapse the firmware gates the LED to the recorder
+ * (doris.lua bottom_lgt_eff), so the LED follows the camera duty — not
+ * its own on/off. Increasing the camera pause cuts the dominant LED term.
+ */
+export function effectiveLightDuty(cfg: PhaseConfig): number {
+  if (!cfg.lightOn) return 0
+  if (cfg.cameraOn && cfg.cameraType === 'video-interval') {
+    return intervalDuty(cfg.recordS ?? 0, cfg.pauseS ?? 0)
+  }
+  if (cfg.cameraOn && cfg.cameraType === 'timelapse') {
+    const period = cfg.capturePeriodS ?? 0
+    if (period <= 0) return 0
+    let window = (cfg.timelapsePreS ?? 0) + (cfg.timelapsePostS ?? 0)
+    if (window <= 0) window = TIMELAPSE_DEFAULT_STROBE_S
+    return clamp(window / period, 0, 1)
+  }
+  if (cfg.lightMode === 'interval') {
+    return intervalDuty(cfg.lightOnS ?? 0, cfg.lightOffS ?? 0)
+  }
+  return 1
+}
+
+export function effectiveCameraDuty(cfg: PhaseConfig): number {
+  return cameraDuty({
+    enabled: !!cfg.cameraOn,
+    mode: cfg.cameraType,
+    recordSeconds: cfg.recordS,
+    pauseSeconds: cfg.pauseS,
+    capturePeriodSeconds: cfg.capturePeriodS,
+  })
 }
 
 export function phaseAveragePowerW(opts: {
@@ -136,23 +179,10 @@ export function phaseAveragePowerW(opts: {
 }
 
 export function phasePower(cfg: PhaseConfig, voltage = BATTERY_NOMINAL_V): number {
-  const ld = lightDuty({
-    enabled: !!cfg.lightOn,
-    mode: cfg.lightMode,
-    onSeconds: cfg.lightOnS,
-    offSeconds: cfg.lightOffS,
-  })
-  const cd = cameraDuty({
-    enabled: !!cfg.cameraOn,
-    mode: cfg.cameraType,
-    recordSeconds: cfg.recordS,
-    pauseSeconds: cfg.pauseS,
-    capturePeriodSeconds: cfg.capturePeriodS,
-  })
   return phaseAveragePowerW({
     brightnessPct: cfg.brightnessPct,
-    lightDutyFraction: ld,
-    cameraDutyFraction: cd,
+    lightDutyFraction: effectiveLightDuty(cfg),
+    cameraDutyFraction: effectiveCameraDuty(cfg),
     voltage,
   })
 }
@@ -188,6 +218,8 @@ interface CameraSettingsLike {
   capture_frequency_unit: string
   video_record?: TimeValueLike
   video_pause?: TimeValueLike
+  timelapse_light_pre?: TimeValueLike
+  timelapse_light_post?: TimeValueLike
 }
 
 export function timeValueToSeconds(tv?: TimeValueLike | null): number {
@@ -219,6 +251,48 @@ export function phaseConfigFromSettings(
           unit: camera.capture_frequency_unit,
         })
       : 0,
+    timelapsePreS: timeValueToSeconds(camera?.timelapse_light_pre),
+    timelapsePostS: timeValueToSeconds(camera?.timelapse_light_post),
+  }
+}
+
+export interface PhaseBreakdown {
+  name: string
+  hours: number
+  brightnessPct: number
+  lightDuty: number
+  cameraDuty: number
+  hotelWh: number
+  lightWh: number
+  cameraWh: number
+  totalWh: number
+  averageW: number
+}
+
+/** Per-component energy (Wh) for a single phase of a given duration. */
+export function phaseBreakdown(
+  name: string,
+  cfg: PhaseConfig,
+  hours: number,
+  voltage = BATTERY_NOMINAL_V,
+): PhaseBreakdown {
+  const ld = effectiveLightDuty(cfg)
+  const cd = effectiveCameraDuty(cfg)
+  const hotelWh = HOTEL_W * hours
+  const lightWh = ledPowerW(cfg.brightnessPct ?? 0, voltage) * ld * hours
+  const cameraWh = CAMERA_RECORDING_W * cd * hours
+  const totalWh = hotelWh + lightWh + cameraWh
+  return {
+    name,
+    hours,
+    brightnessPct: cfg.brightnessPct ?? 0,
+    lightDuty: ld,
+    cameraDuty: cd,
+    hotelWh,
+    lightWh,
+    cameraWh,
+    totalWh,
+    averageW: hours > 0 ? totalWh / hours : 0,
   }
 }
 
@@ -235,7 +309,22 @@ export interface DiveEstimate {
   usagePercent: number
   remainingPercent: number
   batteryLifeHours: number
+  reserveWh: number
+  usableWh: number
+  remainingAfterDiveWh: number
   fitsWithinReserve: boolean
+  recoveryHotelW: number
+  recoveryHours: number
+  phases: PhaseBreakdown[]
+  hotelWh: number
+  lightWh: number
+  cameraWh: number
+}
+
+/** Energy (Wh) held back for recovery mode (explicit Wh wins over %). */
+export function reserveEnergyWh(reserveWh?: number, reservePct = BATTERY_RESERVE_PCT): number {
+  if (reserveWh !== undefined && reserveWh !== null) return Math.max(0, reserveWh)
+  return (BATTERY_CAPACITY_WH * clamp(reservePct, 0, 100)) / 100
 }
 
 /**
@@ -251,6 +340,7 @@ export function estimateDive(opts: {
   ascent: PhaseConfig
   voltage?: number
   reservePct?: number
+  reserveWh?: number
 }): DiveEstimate {
   const v = opts.voltage ?? BATTERY_NOMINAL_V
   const riseH = Math.max(0, opts.depthM) / DESCENT_RATE_M_S / 3600
@@ -258,16 +348,28 @@ export function estimateDive(opts: {
   const ascentHours = ASCENT_BURN_MINUTES / 60 + riseH
   const bottomHours = Math.max(0, opts.bottomTimeHours)
 
-  const descentPowerW = phasePower(opts.descent, v)
-  const bottomPowerW = phasePower(opts.bottom, v)
-  const ascentPowerW = phasePower(opts.ascent, v)
+  const phases = [
+    phaseBreakdown('Descent', opts.descent, descentHours, v),
+    phaseBreakdown('On Bottom', opts.bottom, bottomHours, v),
+    phaseBreakdown('Ascent', opts.ascent, ascentHours, v),
+  ]
+  const descentPowerW = phases[0].averageW
+  const bottomPowerW = phases[1].averageW
+  const ascentPowerW = phases[2].averageW
 
-  const energyWh =
-    descentPowerW * descentHours + bottomPowerW * bottomHours + ascentPowerW * ascentHours
+  const energyWh = phases.reduce((s, p) => s + p.totalWh, 0)
+  const hotelWh = phases.reduce((s, p) => s + p.hotelWh, 0)
+  const lightWh = phases.reduce((s, p) => s + p.lightWh, 0)
+  const cameraWh = phases.reduce((s, p) => s + p.cameraWh, 0)
   const totalHours = descentHours + bottomHours + ascentHours
   const averagePowerW = totalHours > 0 ? energyWh / totalHours : 0
   const usagePercent = BATTERY_CAPACITY_WH ? (energyWh / BATTERY_CAPACITY_WH) * 100 : 0
   const batteryLifeHours = averagePowerW > 0 ? BATTERY_CAPACITY_WH / averagePowerW : 0
+  const reserveWh = reserveEnergyWh(opts.reserveWh, opts.reservePct)
+  const usableWh = Math.max(0, BATTERY_CAPACITY_WH - reserveWh)
+  const remainingAfterDiveWh = BATTERY_CAPACITY_WH - energyWh
+  const recoveryHours =
+    RECOVERY_HOTEL_W > 0 ? Math.max(0, remainingAfterDiveWh) / RECOVERY_HOTEL_W : 0
 
   return {
     descentHours,
@@ -282,6 +384,15 @@ export function estimateDive(opts: {
     usagePercent: Math.min(usagePercent, 100),
     remainingPercent: Math.max(0, 100 - usagePercent),
     batteryLifeHours,
-    fitsWithinReserve: energyWh <= usableCapacityWh(opts.reservePct),
+    reserveWh,
+    usableWh,
+    remainingAfterDiveWh,
+    fitsWithinReserve: remainingAfterDiveWh >= reserveWh,
+    recoveryHotelW: RECOVERY_HOTEL_W,
+    recoveryHours,
+    phases,
+    hotelWh,
+    lightWh,
+    cameraWh,
   }
 }


### PR DESCRIPTION
## Summary

Makes the dive battery planner accurate by replacing assumed power numbers with values derived from a real dive log (`recorder_20260528_165058.mcap`), and adds a surface-recovery readout. Backend (`power_model.py`) and frontend (`powerModel.ts`) share one model so the home screen, mission planner, and live estimator never disagree.

- **Empirical power model**: single LED via the bench PWM→current curve, hotel load `8.0 W`, camera recording `+1.5 W`, negligible release, `296 Wh` pack (2×10 Ah 4S). All cross-checked against `BATTERY_STATUS` joined with dive `STATE` from the log.
- **Light/camera coupling fix**: the LED duty now follows the camera record/pause (interval) or strobe window (timelapse), matching firmware behavior — so increasing camera pause actually reduces the dominant LED energy.
- **Surface recovery time**: new line under the battery usage bar = remaining energy ÷ `RECOVERY_HOTEL_W` (9.2 W, measured in `STATE_RECOVERY`). Replaces the manual reserve-Wh field.
- **UI**: "Total Power Consumed" (Wh), "Average Power Draw" (W), and a collapsible per-phase component breakdown (hotel / lights / camera) on the planner.

## How the numbers are derived

- Durations: descent = depth ÷ 1 m/s, bottom = release-weight time, ascent = 45 min burn + depth ÷ 1 m/s.
- Per-phase energy = (hotel + LED×brightness×duty + camera×duty) × phase hours.
- LED power = interpolated bench current (0.01–1.64 A over 1100–1900 µs) × supply voltage.

## Test plan

- [x] Backend unit tests pass (`pytest tests/test_power_model.py`, 30 passing) covering LED curve, duty cycles, light/camera coupling, timelapse strobe window, dive energy/usage, and recovery hours.
- [x] `ruff` clean on the model and tests.
- [x] Frontend type-checks via `vue-tsc` in the Docker build.
- [x] Verified locally in SITL (`docker compose up --build`): UI serves at `:8095`, planner shows recovery time and breakdown.
- [ ] Reconfirm `RECOVERY_HOTEL_W` on a log with a longer recovery phase (current value from a short 2-sample window).
