### PR TITLE
feat(network): AP <-> STA WiFi switching on the Network Setup page

### DIFF
--- a/extension/backend/src/doris/main.py
+++ b/extension/backend/src/doris/main.py
@@ -8,7 +8,7 @@ from robyn import ALLOW_CORS, Robyn
 from robyn.openapi import Contact, OpenAPI, OpenAPIInfo
 
 from .config import settings
-from .services.network import NetworkService
+from .services.network import get_network_service
 from .services.persistent_log import setup_persistent_logging, start_dmesg_capture
 from .routes import (
     register_arming_routes,
@@ -170,13 +170,21 @@ def create_app() -> Robyn:
         except Exception as e:
             logger.warning("doris.local setup skipped: %s", e)
 
-        network_service = NetworkService()
+        network_service = get_network_service()
         hotspot_changed = False
         try:
             await network_service.configure_hotspot()
             hotspot_changed = True
         except Exception as e:
             logger.warning("Hotspot configuration skipped: %s", e)
+
+        # Force the AP/STA intent back to AP and pre-emptively disconnect
+        # any client association so a saved client WLAN can't quietly
+        # auto-join behind our back. Power cycle == AP, always.
+        try:
+            await network_service.reset_wlan_to_ap_on_boot()
+        except Exception as e:
+            logger.warning("WLAN intent reset skipped: %s", e)
 
         try:
             await start_hotspot_dns()

--- a/extension/backend/src/doris/models/network.py
+++ b/extension/backend/src/doris/models/network.py
@@ -1,5 +1,8 @@
 """Network-related models."""
 
+from datetime import datetime
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -39,4 +42,41 @@ class NetworkCredentials(BaseModel):
 
     ssid: str
     password: str | None = None
+
+
+# ── WLAN mode switching (single external radio AP <-> STA) ──────────
+
+WlanMode = Literal["ap", "sta_pending", "sta_connected"]
+WlanAttemptStatus = Literal["success", "failed"]
+
+
+class WlanLastAttempt(BaseModel):
+    """Outcome of the most recent AP <-> STA switch attempt.
+
+    Surfaced in the UI when the user reconnects to the AP after a failed
+    STA switch — without this they would have no way of knowing why their
+    browser session went dead and what to fix.
+    """
+
+    ssid: str
+    status: WlanAttemptStatus
+    error: str | None = None
+    timestamp: datetime
+
+
+class WlanState(BaseModel):
+    """Current state of the external radio (uap0) for AP/STA switching.
+
+    ``mode`` is the *intent* recorded by the DORIS extension:
+      - ``ap``: external radio is broadcasting the DORIS hotspot
+      - ``sta_pending``: switch initiated, connection attempt in flight
+      - ``sta_connected``: external radio is associated to a client WLAN
+    The intent always resets to ``ap`` on backend startup so a power
+    cycle reliably reverts to the hotspot.
+    """
+
+    mode: WlanMode
+    target_ssid: str | None = None
+    ip_address: str | None = None
+    last_attempt: WlanLastAttempt | None = None
 

--- a/extension/backend/src/doris/routes/network.py
+++ b/extension/backend/src/doris/routes/network.py
@@ -5,13 +5,13 @@ import json
 from robyn import Response, Robyn
 
 from ..models.network import NetworkCredentials
-from ..services.network import NetworkService
+from ..services.network import get_network_service
 
 
 def register_network_routes(app: Robyn) -> None:
     """Register network-related API routes."""
 
-    network_service = NetworkService()
+    network_service = get_network_service()
 
     @app.get("/api/v1/network")
     async def get_network_info(request):
@@ -96,6 +96,78 @@ def register_network_routes(app: Robyn) -> None:
             ssid = request.path_params.get("ssid")
             success = await network_service.forget_network(ssid)
             return json.dumps({"success": success})
+        except Exception as e:
+            return Response(
+                status_code=500,
+                description=json.dumps({"error": str(e)}),
+                headers={"Content-Type": "application/json"},
+            )
+
+    # ── WLAN AP <-> STA mode switching ───────────────────────────────
+    #
+    # The external Realtek radio (uap0) is the only reliable interface
+    # in the assembled vehicle. These three endpoints let the user flip
+    # it between hotspot mode (default) and client (STA) mode without
+    # having to power-cycle to recover, since the actual mode-flip
+    # happens asynchronously and the user's browser session dies the
+    # moment the AP goes down. The status endpoint is what the
+    # post-failure UI polls when the user reconnects to the hotspot.
+
+    @app.get("/api/v1/network/wlan/status")
+    async def get_wlan_status(request):
+        """Return AP/STA intent and the most recent switch attempt."""
+        try:
+            state = await network_service.get_wlan_state()
+            return json.dumps(state.model_dump(mode="json"))
+        except Exception as e:
+            return Response(
+                status_code=500,
+                description=json.dumps({"error": str(e)}),
+                headers={"Content-Type": "application/json"},
+            )
+
+    @app.post("/api/v1/network/wlan/connect")
+    async def switch_to_sta(request):
+        """Initiate an asynchronous switch from AP mode to STA mode.
+
+        Returns immediately with the new ``sta_pending`` state. The
+        actual outcome is observable via ``GET /network/wlan/status``
+        after the user's browser regains a connection (either by
+        finding DORIS on the new WLAN or by reconnecting to the
+        restored hotspot on failure).
+        """
+        try:
+            data = json.loads(request.body)
+            ssid = data.get("ssid")
+            password = data.get("password") or ""
+            if not ssid:
+                return Response(
+                    status_code=400,
+                    description=json.dumps({"error": "ssid is required"}),
+                    headers={"Content-Type": "application/json"},
+                )
+            state = await network_service.begin_switch_to_sta(ssid, password)
+            return json.dumps(state.model_dump(mode="json"))
+        except json.JSONDecodeError:
+            return Response(
+                status_code=400,
+                description=json.dumps({"error": "Invalid JSON"}),
+                headers={"Content-Type": "application/json"},
+            )
+        except Exception as e:
+            return Response(
+                status_code=500,
+                description=json.dumps({"error": str(e)}),
+                headers={"Content-Type": "application/json"},
+            )
+
+    @app.post("/api/v1/network/wlan/disconnect")
+    async def switch_to_ap(request):
+        """Tear down any STA association and put the external radio
+        back into hotspot mode. Returns immediately."""
+        try:
+            state = await network_service.begin_switch_to_ap()
+            return json.dumps(state.model_dump(mode="json"))
         except Exception as e:
             return Response(
                 status_code=500,

--- a/extension/backend/src/doris/services/network.py
+++ b/extension/backend/src/doris/services/network.py
@@ -1,18 +1,42 @@
 """Network/WiFi service."""
 
 import asyncio
+import json
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from ..config import blueos_services
-from ..models.network import ConnectionStatus, NetworkCredentials, NetworkInfo, WifiNetwork
+from ..models.network import (
+    ConnectionStatus,
+    NetworkCredentials,
+    NetworkInfo,
+    WifiNetwork,
+    WlanLastAttempt,
+    WlanState,
+)
 from .base import BlueOSClient
 from .blueos.network import NetworkClient
+from .storage import DATA_ROOT
 
 logger = logging.getLogger(__name__)
 
 AP_WATCHDOG_INTERVAL_S = 60
 AP_WATCHDOG_SETTLE_S = 15
+
+# Intent file lives under DATA_ROOT (bind-mounted /tmp/storage/userdata
+# in production) so the last-attempt record survives container restarts
+# and can be shown to the user when they reconnect to the hotspot after
+# a failed switch attempt. The ``mode`` field is always reset to ``ap``
+# on backend startup regardless of what was previously persisted.
+WLAN_INTENT_FILE = DATA_ROOT / "network_intent.json"
+
+# Total wall time we'll wait for a STA association after flipping the
+# external radio out of hotspot mode. The mode change itself eats ~5-15s
+# (driver re-init), then the supplicant + DHCP add another ~5-20s on a
+# typical home router. 60s is a comfortable upper bound.
+STA_CONNECT_TIMEOUT_S = 60.0
+STA_POLL_INTERVAL_S = 2.0
 
 
 class NetworkService:
@@ -27,6 +51,15 @@ class NetworkService:
         self._linux2rest = BlueOSClient(blueos_services.linux2rest)
         self._cached_mac: str | None = None
         self._cached_serial: str | None = None
+
+        # WLAN AP<->STA switching state. Loaded lazily on first read so
+        # tests don't touch the filesystem just by instantiating the
+        # service. The lock guards against concurrent switch attempts —
+        # the user could spam the Connect button or two clients could
+        # race when both have the page open.
+        self._wlan_state: WlanState | None = None
+        self._wlan_switch_lock = asyncio.Lock()
+        self._wlan_switch_task: asyncio.Task[None] | None = None
 
     async def get_network_info(self) -> NetworkInfo:
         """Get current network information including device identity."""
@@ -473,11 +506,20 @@ class NetworkService:
         After a dive the vehicle loses all WiFi connections.  BlueOS /
         NetworkManager may not automatically restart the AP on wlan1.
         This watchdog detects that and brings it back.
+
+        Suppressed while WLAN intent is ``sta_pending`` or
+        ``sta_connected``: in those states the external radio is
+        intentionally *not* hosting an AP (it's associated to a client
+        WLAN), so re-asserting hotspot mode would tear down the user's
+        chosen connection.
         """
         await asyncio.sleep(AP_WATCHDOG_SETTLE_S)
         while True:
             await asyncio.sleep(AP_WATCHDOG_INTERVAL_S)
             try:
+                state = await self.get_wlan_state()
+                if state.mode != "ap":
+                    continue
                 iface = await self._get_secondary_interface_name()
                 if not iface:
                     continue
@@ -494,7 +536,293 @@ class NetworkService:
             except Exception as e:
                 logger.debug("AP watchdog check error: %s", e)
 
+    # ── WLAN AP <-> STA mode switching ───────────────────────────────
+    #
+    # On this hardware the *only* reliable radio when the vehicle is
+    # fully assembled is the external USB Realtek (renamed to ``uap0``
+    # by udev). It can be either an AP (hotspot mode) or a client (STA
+    # / "normal" mode) but not both at once. The user switches between
+    # them from the Network Setup tab; the AP is the safe default and
+    # is restored on every backend startup.
+
+    def _load_wlan_state(self) -> WlanState:
+        """Read the persisted intent file. ``mode`` is always force-reset
+        to ``ap`` on load — only ``last_attempt`` is kept across boots
+        for UX feedback."""
+        try:
+            raw = WLAN_INTENT_FILE.read_text()
+            data = json.loads(raw)
+            persisted = WlanState.model_validate(data)
+            return WlanState(mode="ap", last_attempt=persisted.last_attempt)
+        except FileNotFoundError:
+            return WlanState(mode="ap")
+        except Exception as e:
+            logger.warning("Could not load WLAN intent (%s); defaulting to ap", e)
+            return WlanState(mode="ap")
+
+    def _save_wlan_state(self, state: WlanState) -> None:
+        try:
+            WLAN_INTENT_FILE.parent.mkdir(parents=True, exist_ok=True)
+            WLAN_INTENT_FILE.write_text(state.model_dump_json(indent=2))
+        except OSError as e:
+            logger.warning("Could not persist WLAN intent: %s", e)
+
+    async def get_wlan_state(self) -> WlanState:
+        """Return the current AP/STA state, refreshing IP from the
+        WiFi Manager if we're in an STA mode."""
+        if self._wlan_state is None:
+            self._wlan_state = self._load_wlan_state()
+
+        state = self._wlan_state
+        if state.mode == "sta_connected":
+            try:
+                status = await self._client.get_status()
+                if status.get("state") == "connected":
+                    ip = status.get("ip_address")
+                    ssid = status.get("ssid") or state.target_ssid
+                    if ip != state.ip_address or ssid != state.target_ssid:
+                        state = state.model_copy(
+                            update={"ip_address": ip, "target_ssid": ssid}
+                        )
+                        self._wlan_state = state
+                else:
+                    # Connection dropped out from under us. The user
+                    # would otherwise see "connected" in the UI forever
+                    # while actually being unreachable.
+                    logger.warning(
+                        "STA connection lost (status=%s), treating as ap",
+                        status.get("state"),
+                    )
+                    state = WlanState(mode="ap", last_attempt=state.last_attempt)
+                    self._wlan_state = state
+                    self._save_wlan_state(state)
+            except Exception as e:
+                logger.debug("get_wlan_state status refresh failed: %s", e)
+
+        return state
+
+    async def reset_wlan_to_ap_on_boot(self) -> None:
+        """Force WLAN intent back to ``ap`` and proactively disconnect
+        any client association so NetworkManager can't quietly auto-join
+        a saved network behind our back. Called once at startup *after*
+        ``configure_hotspot()``.
+
+        Saved networks are *kept* (option (b)) so the user can pick a
+        previously-used SSID from the scan list and reconnect with one
+        click during the same session.
+        """
+        last_attempt: WlanLastAttempt | None = None
+        try:
+            persisted = self._load_wlan_state()
+            last_attempt = persisted.last_attempt
+        except Exception:
+            pass
+
+        try:
+            await self._client.disconnect()
+        except Exception as e:
+            logger.debug("Boot-time WLAN disconnect failed (likely no STA): %s", e)
+
+        self._wlan_state = WlanState(mode="ap", last_attempt=last_attempt)
+        self._save_wlan_state(self._wlan_state)
+        logger.info("WLAN intent reset to AP on startup")
+
+    async def begin_switch_to_sta(
+        self, ssid: str, password: str
+    ) -> WlanState:
+        """Initiate an asynchronous switch from AP mode to STA mode.
+
+        Returns immediately with ``mode=sta_pending``. The user's browser
+        will lose its AP connection within a few seconds of this call —
+        the actual outcome (success / failure) is recorded in the
+        persisted state file and surfaced via :meth:`get_wlan_state`.
+
+        Concurrent switch requests are rejected (returns the existing
+        in-flight state). To re-attempt after a failure, the previous
+        task must have completed.
+        """
+        if not ssid:
+            raise ValueError("ssid is required")
+
+        async with self._wlan_switch_lock:
+            current = await self.get_wlan_state()
+            if current.mode == "sta_pending":
+                return current
+            if (
+                self._wlan_switch_task is not None
+                and not self._wlan_switch_task.done()
+            ):
+                return current
+
+            new_state = WlanState(
+                mode="sta_pending",
+                target_ssid=ssid,
+                last_attempt=current.last_attempt,
+            )
+            self._wlan_state = new_state
+            self._save_wlan_state(new_state)
+            self._wlan_switch_task = asyncio.create_task(
+                self._run_switch_to_sta(ssid, password)
+            )
+            return new_state
+
+    async def begin_switch_to_ap(self) -> WlanState:
+        """Tear down any STA connection and put the external radio back
+        into hotspot mode. Same async pattern as :meth:`begin_switch_to_sta`
+        — the call returns immediately while the work runs in the
+        background.
+
+        Saved networks are kept (option (b)).
+        """
+        async with self._wlan_switch_lock:
+            current = await self.get_wlan_state()
+            if (
+                self._wlan_switch_task is not None
+                and not self._wlan_switch_task.done()
+            ):
+                return current
+            self._wlan_switch_task = asyncio.create_task(
+                self._run_switch_to_ap()
+            )
+            return current
+
+    async def _run_switch_to_sta(self, ssid: str, password: str) -> None:
+        """Background task that performs the AP -> STA flip."""
+        iface = await self._resolve_hotspot_interface_name()
+        if not iface:
+            logger.warning("No external WiFi interface; aborting STA switch")
+            self._record_failure(ssid, "External WiFi interface not found")
+            return
+
+        logger.info("Switching %s from AP to STA, target SSID=%r", iface, ssid)
+
+        try:
+            await self._client.set_interface_mode(iface, "normal", timeout=30.0)
+        except Exception as e:
+            logger.warning("Failed to switch %s to normal mode: %s", iface, e)
+            await self._restore_ap_after_failure(iface)
+            self._record_failure(ssid, f"Could not disable hotspot: {e}")
+            return
+
+        await asyncio.sleep(2)
+
+        try:
+            await self._client.connect(ssid, password, interface=iface)
+        except Exception as e:
+            logger.warning("Connect call to %r failed: %s", ssid, e)
+            await self._client.forget_network(ssid)
+            await self._restore_ap_after_failure(iface)
+            self._record_failure(ssid, f"Connect rejected: {e}")
+            return
+
+        deadline = asyncio.get_event_loop().time() + STA_CONNECT_TIMEOUT_S
+        last_status: dict[str, Any] = {}
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                last_status = await self._client.get_status()
+                if (
+                    last_status.get("state") == "connected"
+                    and last_status.get("ssid") == ssid
+                ):
+                    break
+            except Exception as e:
+                logger.debug("STA poll error: %s", e)
+            await asyncio.sleep(STA_POLL_INTERVAL_S)
+        else:
+            logger.warning(
+                "STA association to %r timed out after %.0fs (last status=%s)",
+                ssid, STA_CONNECT_TIMEOUT_S, last_status,
+            )
+            await self._client.forget_network(ssid)
+            await self._restore_ap_after_failure(iface)
+            self._record_failure(
+                ssid,
+                "Timed out waiting for association — check password / signal.",
+            )
+            return
+
+        ip = last_status.get("ip_address")
+        logger.info("STA connected to %r (ip=%s)", ssid, ip)
+        success = WlanLastAttempt(
+            ssid=ssid,
+            status="success",
+            timestamp=datetime.now(timezone.utc),
+        )
+        self._wlan_state = WlanState(
+            mode="sta_connected",
+            target_ssid=ssid,
+            ip_address=ip,
+            last_attempt=success,
+        )
+        self._save_wlan_state(self._wlan_state)
+
+    async def _run_switch_to_ap(self) -> None:
+        """Background task that performs the STA -> AP flip."""
+        iface = await self._resolve_hotspot_interface_name()
+        if not iface:
+            logger.warning("No external WiFi interface; cannot restore AP")
+            return
+
+        logger.info("Restoring %s to hotspot mode", iface)
+        try:
+            await self._client.disconnect(interface=iface)
+        except Exception as e:
+            logger.debug("Disconnect call failed (may already be disconnected): %s", e)
+
+        await self._restore_ap_after_failure(iface)
+
+        self._wlan_state = WlanState(
+            mode="ap",
+            last_attempt=self._wlan_state.last_attempt if self._wlan_state else None,
+        )
+        self._save_wlan_state(self._wlan_state)
+
+    async def _restore_ap_after_failure(self, iface: str) -> None:
+        """Best-effort: put ``iface`` back into hotspot mode. Used both
+        on the failure path of a STA switch and on user-initiated
+        switch-back."""
+        try:
+            ok = await self._ensure_secondary_hotspot(iface)
+            if not ok:
+                logger.warning(
+                    "Could not restore hotspot on %s after failed switch", iface,
+                )
+        except Exception as e:
+            logger.warning("Hotspot restore failed: %s", e)
+
+    def _record_failure(self, ssid: str, error: str) -> None:
+        """Persist a failure outcome so the UI can surface it once the
+        user reconnects to the AP."""
+        failure = WlanLastAttempt(
+            ssid=ssid,
+            status="failed",
+            error=error,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self._wlan_state = WlanState(mode="ap", last_attempt=failure)
+        self._save_wlan_state(self._wlan_state)
+
     async def close(self) -> None:
         """Close HTTP clients."""
         await self._client.close()
         await self._linux2rest.close()
+
+
+# ── Module-level singleton ──────────────────────────────────────────
+#
+# WLAN switch state (the in-memory lock, the task handle, the cached
+# WlanState) lives on the ``NetworkService`` instance. Routes and the
+# startup handler must therefore share the *same* instance, otherwise
+# the watchdog thread and the HTTP handler disagree on whether a switch
+# is in flight and could race into a double-switch. The persisted intent
+# file mitigates the worst of it but the in-flight lock is needed too.
+
+_NETWORK_SERVICE_SINGLETON: NetworkService | None = None
+
+
+def get_network_service() -> NetworkService:
+    """Return the process-wide :class:`NetworkService` instance."""
+    global _NETWORK_SERVICE_SINGLETON
+    if _NETWORK_SERVICE_SINGLETON is None:
+        _NETWORK_SERVICE_SINGLETON = NetworkService()
+    return _NETWORK_SERVICE_SINGLETON

--- a/extension/backend/src/doris/services/network.py
+++ b/extension/backend/src/doris/services/network.py
@@ -603,13 +603,20 @@ class NetworkService:
 
     async def reset_wlan_to_ap_on_boot(self) -> None:
         """Force WLAN intent back to ``ap`` and proactively disconnect
-        any client association so NetworkManager can't quietly auto-join
-        a saved network behind our back. Called once at startup *after*
-        ``configure_hotspot()``.
+        any STA association *on the external interface only*. Called
+        once at startup *after* ``configure_hotspot()``.
 
         Saved networks are *kept* (option (b)) so the user can pick a
         previously-used SSID from the scan list and reconnect with one
         click during the same session.
+
+        IMPORTANT: This must NEVER use the legacy global disconnect
+        endpoint. On a vehicle where the onboard radio (``wlan0``) is
+        actively connected upstream — common during development and
+        possible in production if the user wires it up — that endpoint
+        can disconnect ``wlan0`` and silently nuke the only management
+        link to the vehicle. Always pass an explicit interface so the
+        scope is unambiguous.
         """
         last_attempt: WlanLastAttempt | None = None
         try:
@@ -618,10 +625,23 @@ class NetworkService:
         except Exception:
             pass
 
-        try:
-            await self._client.disconnect()
-        except Exception as e:
-            logger.debug("Boot-time WLAN disconnect failed (likely no STA): %s", e)
+        iface = await self._resolve_hotspot_interface_name()
+        if iface:
+            try:
+                # Only disconnect if the external radio is actually
+                # associated to a STA. configure_hotspot() ran just
+                # before us so under normal startup it's already in
+                # hotspot mode and there's nothing to do here — but
+                # if a previous run left it in STA mode we want to
+                # break that association cleanly.
+                hs = await self._client._v2.wifi_hotspot_status(iface)
+                if not hs.get("enabled"):
+                    await self._client.disconnect(interface=iface)
+                    logger.info("Boot-time STA disconnect issued on %s", iface)
+            except Exception as e:
+                logger.debug(
+                    "Boot-time WLAN disconnect skipped on %s: %s", iface, e,
+                )
 
         self._wlan_state = WlanState(mode="ap", last_attempt=last_attempt)
         self._save_wlan_state(self._wlan_state)

--- a/extension/backend/src/doris/services/network.py
+++ b/extension/backend/src/doris/services/network.py
@@ -17,6 +17,7 @@ from ..models.network import (
 )
 from .base import BlueOSClient
 from .blueos.network import NetworkClient
+from .hotspot_radio import _run_host_command
 from .storage import DATA_ROOT
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,19 @@ WLAN_INTENT_FILE = DATA_ROOT / "network_intent.json"
 # typical home router. 60s is a comfortable upper bound.
 STA_CONNECT_TIMEOUT_S = 60.0
 STA_POLL_INTERVAL_S = 2.0
+
+# ── v1 fallback constants ────────────────────────────────────────────
+#
+# BlueOS WiFi Manager v1 has no per-interface mode API, so on v1 we
+# bypass it: we briefly transfer ``uap0`` from create_ap (hostapd) over
+# to NetworkManager + nmcli for the duration of the STA session, then
+# hand it back. The unmanaged-devices conf file has to move out of the
+# way for NM to be willing to drive the interface; we stash it in /tmp
+# and put it back when we restore the hotspot.
+V1_NM_UNMANAGED_CONF = "/etc/NetworkManager/conf.d/99-blueos-hotspot-uap0.conf"
+V1_NM_UNMANAGED_STASH = "/tmp/doris-99-blueos-hotspot-uap0.conf.stash"
+V1_UAP0_CONNECTION_PREFIX = "doris-uap0-sta-"
+V1_DHCP_TIMEOUT_S = 30
 
 
 class NetworkService:
@@ -568,13 +582,27 @@ class NetworkService:
             logger.warning("Could not persist WLAN intent: %s", e)
 
     async def get_wlan_state(self) -> WlanState:
-        """Return the current AP/STA state, refreshing IP from the
-        WiFi Manager if we're in an STA mode."""
+        """Return the current AP/STA state, refreshing IP / liveness
+        from the appropriate place for the active code path.
+
+        v2 path: BlueOS WiFi Manager ``/status`` is interface-aware and
+        reports the right thing.
+
+        v1 path: ``/v1.0/status`` reflects whatever interface BlueOS
+        treats as primary (typically ``wlan0``), which would lie to us
+        about ``uap0``. We probe the host directly via ``ip``/``iw``
+        instead.
+        """
         if self._wlan_state is None:
             self._wlan_state = self._load_wlan_state()
 
         state = self._wlan_state
-        if state.mode == "sta_connected":
+        if state.mode != "sta_connected":
+            return state
+
+        # v2 first.
+        v2_iface = await self._resolve_hotspot_interface_name()
+        if v2_iface:
             try:
                 status = await self._client.get_status()
                 if status.get("state") == "connected":
@@ -586,9 +614,6 @@ class NetworkService:
                         )
                         self._wlan_state = state
                 else:
-                    # Connection dropped out from under us. The user
-                    # would otherwise see "connected" in the UI forever
-                    # while actually being unreachable.
                     logger.warning(
                         "STA connection lost (status=%s), treating as ap",
                         status.get("state"),
@@ -597,7 +622,31 @@ class NetworkService:
                     self._wlan_state = state
                     self._save_wlan_state(state)
             except Exception as e:
-                logger.debug("get_wlan_state status refresh failed: %s", e)
+                logger.debug("get_wlan_state v2 status refresh failed: %s", e)
+            return state
+
+        # v1: probe host directly.
+        v1_iface = await self._resolve_external_iface_v1()
+        if not v1_iface:
+            return state
+        try:
+            ok, ip_out = await _run_host_command(
+                f"ip -4 -o addr show dev {v1_iface} 2>/dev/null "
+                f"| awk '{{print $4}}' | cut -d/ -f1 | head -1"
+            )
+            ip = ip_out.strip() if ok else ""
+            if not ip:
+                logger.warning(
+                    "[v1] STA on %s lost its IP, treating as ap", v1_iface,
+                )
+                state = WlanState(mode="ap", last_attempt=state.last_attempt)
+                self._wlan_state = state
+                self._save_wlan_state(state)
+            elif ip != state.ip_address:
+                state = state.model_copy(update={"ip_address": ip})
+                self._wlan_state = state
+        except Exception as e:
+            logger.debug("get_wlan_state v1 IP probe failed: %s", e)
 
         return state
 
@@ -625,8 +674,8 @@ class NetworkService:
         except Exception:
             pass
 
-        iface = await self._resolve_hotspot_interface_name()
-        if iface:
+        v2_iface = await self._resolve_hotspot_interface_name()
+        if v2_iface:
             try:
                 # Only disconnect if the external radio is actually
                 # associated to a STA. configure_hotspot() ran just
@@ -634,14 +683,48 @@ class NetworkService:
                 # hotspot mode and there's nothing to do here — but
                 # if a previous run left it in STA mode we want to
                 # break that association cleanly.
-                hs = await self._client._v2.wifi_hotspot_status(iface)
+                hs = await self._client._v2.wifi_hotspot_status(v2_iface)
                 if not hs.get("enabled"):
-                    await self._client.disconnect(interface=iface)
-                    logger.info("Boot-time STA disconnect issued on %s", iface)
+                    await self._client.disconnect(interface=v2_iface)
+                    logger.info("Boot-time STA disconnect issued on %s", v2_iface)
             except Exception as e:
                 logger.debug(
-                    "Boot-time WLAN disconnect skipped on %s: %s", iface, e,
+                    "Boot-time WLAN disconnect skipped on %s: %s", v2_iface, e,
                 )
+        else:
+            # v1 fallback: if a previous run crashed mid-switch we may
+            # still have an unmanaged-conf stash sitting in /tmp and a
+            # leftover doris-uap0-sta-* nmcli profile holding the
+            # interface. Roll back so configure_hotspot() (which the
+            # caller just ran) can actually drive create_ap.
+            v1_iface = await self._resolve_external_iface_v1()
+            if v1_iface:
+                # Tear down any stale doris-uap0-sta-* profiles.
+                ok, out = await _run_host_command(
+                    "nmcli -t -f NAME connection show 2>/dev/null"
+                )
+                if ok:
+                    for name in out.splitlines():
+                        name = name.strip()
+                        if name.startswith(V1_UAP0_CONNECTION_PREFIX):
+                            await _run_host_command(
+                                f"sudo nmcli connection down '{name}' 2>/dev/null; "
+                                f"sudo nmcli connection delete '{name}' 2>/dev/null; "
+                                f"true"
+                            )
+                            logger.info(
+                                "[v1] cleaned up leftover STA profile %r", name,
+                            )
+                # Restore stashed unmanaged conf if present.
+                ok, _ = await _run_host_command(
+                    f"test -f {V1_NM_UNMANAGED_STASH} && "
+                    f"sudo mv {V1_NM_UNMANAGED_STASH} {V1_NM_UNMANAGED_CONF} && "
+                    f"sudo nmcli general reload conf"
+                )
+                if ok:
+                    logger.info(
+                        "[v1] restored stashed unmanaged conf for %s", v1_iface,
+                    )
 
         self._wlan_state = WlanState(mode="ap", last_attempt=last_attempt)
         self._save_wlan_state(self._wlan_state)
@@ -707,14 +790,43 @@ class NetworkService:
             return current
 
     async def _run_switch_to_sta(self, ssid: str, password: str) -> None:
-        """Background task that performs the AP -> STA flip."""
-        iface = await self._resolve_hotspot_interface_name()
-        if not iface:
-            logger.warning("No external WiFi interface; aborting STA switch")
-            self._record_failure(ssid, "External WiFi interface not found")
+        """Background task that performs the AP -> STA flip.
+
+        Dispatches between the v2 path (BlueOS WiFi Manager v2 with
+        per-interface mode + connect APIs) and the v1 host-shell path
+        (nmcli driving uap0 directly while the BlueOS hotspot is paused).
+        """
+        # Fast path: if v2 is available, use it.
+        v2_iface = await self._resolve_hotspot_interface_name()
+        if v2_iface:
+            await self._v2_switch_to_sta(v2_iface, ssid, password)
             return
 
-        logger.info("Switching %s from AP to STA, target SSID=%r", iface, ssid)
+        # Slow path: v1 fallback driving uap0 ourselves via Commander.
+        v1_iface = await self._resolve_external_iface_v1()
+        if not v1_iface:
+            logger.warning("No external WiFi interface (v1 probe); aborting STA switch")
+            self._record_failure(ssid, "External WiFi interface not found")
+            return
+        await self._v1_switch_to_sta(v1_iface, ssid, password)
+
+    async def _run_switch_to_ap(self) -> None:
+        """Background task that performs the STA -> AP flip."""
+        v2_iface = await self._resolve_hotspot_interface_name()
+        if v2_iface:
+            await self._v2_switch_to_ap(v2_iface)
+            return
+
+        v1_iface = await self._resolve_external_iface_v1()
+        if not v1_iface:
+            logger.warning("No external WiFi interface (v1 probe); cannot restore AP")
+            return
+        await self._v1_switch_to_ap(v1_iface)
+
+    # ── v2 path (BlueOS WiFi Manager v2) ─────────────────────────────
+
+    async def _v2_switch_to_sta(self, iface: str, ssid: str, password: str) -> None:
+        logger.info("[v2] Switching %s from AP to STA, target SSID=%r", iface, ssid)
 
         try:
             await self._client.set_interface_mode(iface, "normal", timeout=30.0)
@@ -767,7 +879,7 @@ class NetworkService:
             return
 
         ip = last_status.get("ip_address")
-        logger.info("STA connected to %r (ip=%s)", ssid, ip)
+        logger.info("[v2] STA connected to %r (ip=%s)", ssid, ip)
         success = WlanLastAttempt(
             ssid=ssid,
             status="success",
@@ -781,14 +893,8 @@ class NetworkService:
         )
         self._save_wlan_state(self._wlan_state)
 
-    async def _run_switch_to_ap(self) -> None:
-        """Background task that performs the STA -> AP flip."""
-        iface = await self._resolve_hotspot_interface_name()
-        if not iface:
-            logger.warning("No external WiFi interface; cannot restore AP")
-            return
-
-        logger.info("Restoring %s to hotspot mode", iface)
+    async def _v2_switch_to_ap(self, iface: str) -> None:
+        logger.info("[v2] Restoring %s to hotspot mode", iface)
         try:
             await self._client.disconnect(interface=iface)
         except Exception as e:
@@ -801,6 +907,225 @@ class NetworkService:
             last_attempt=self._wlan_state.last_attempt if self._wlan_state else None,
         )
         self._save_wlan_state(self._wlan_state)
+
+    # ── v1 path (BlueOS WiFi Manager v1, nmcli on host) ──────────────
+
+    async def _resolve_external_iface_v1(self) -> str | None:
+        """Best-guess for the external WiFi interface on v1 systems.
+
+        On DORIS hardware the Realtek RTL88x2BU is renamed to ``uap0``
+        by udev (see services/hotspot_radio.py). On a stock setup it
+        would be ``wlan1``. Probe both via /sys/class/net.
+        """
+        for cand in ("uap0", "wlan1"):
+            ok, out = await _run_host_command(
+                f"test -d /sys/class/net/{cand} && echo {cand}"
+            )
+            if ok and cand in out:
+                return cand
+        return None
+
+    async def _v1_switch_to_sta(self, iface: str, ssid: str, password: str) -> None:
+        """Drive *iface* from AP mode to STA mode without the v2 mode API.
+
+        Sequence:
+
+          1. Stash ``unmanaged-devices=uap0`` NM conf so NM can take
+             ownership of the interface; reload NM.
+          2. Disable BlueOS hotspot (legacy v1 toggle) — this kills
+             ``create_ap`` / hostapd on the interface.
+          3. Bring the iface link down/up to clear hostapd state.
+          4. Create + activate an nmcli connection profile bound to
+             *iface*, autoconnect off so it never auto-rejoins on its
+             own.
+          5. Poll ``ip addr show`` for a DHCP lease.
+
+        Any failure step rolls back via :meth:`_v1_restore_hotspot`.
+        """
+        conn_name = f"{V1_UAP0_CONNECTION_PREFIX}{ssid}"
+        logger.info(
+            "[v1] Switching %s from AP to STA, target SSID=%r (conn=%r)",
+            iface, ssid, conn_name,
+        )
+
+        # 1. Stash unmanaged conf and reload NM so NM is willing to drive uap0.
+        await _run_host_command(
+            f"if [ -f {V1_NM_UNMANAGED_CONF} ]; then "
+            f"  sudo mv {V1_NM_UNMANAGED_CONF} {V1_NM_UNMANAGED_STASH}; "
+            f"fi"
+        )
+        await _run_host_command("sudo nmcli general reload conf")
+        await asyncio.sleep(1)
+
+        # 2. Disable BlueOS hotspot (kills create_ap on uap0).
+        try:
+            await self._client.set_hotspot(False)
+        except Exception as e:
+            logger.warning("[v1] set_hotspot(False) failed: %s", e)
+            await self._v1_restore_hotspot(iface, conn_name)
+            self._record_failure(ssid, f"Could not disable hotspot: {e}")
+            return
+
+        await asyncio.sleep(3)
+
+        # 3. Force the link down/up to flush hostapd state cleanly.
+        await _run_host_command(
+            f"sudo ip link set {iface} down; sleep 1; sudo ip link set {iface} up"
+        )
+        await asyncio.sleep(2)
+
+        # 4. Create + activate the nmcli connection.
+        # Single-quote-escape SSID/password by replacing ' with '\''
+        safe_ssid = ssid.replace("'", "'\\''")
+        safe_pwd = password.replace("'", "'\\''")
+
+        # Clean any prior profile with the same name (e.g. from a
+        # previous failed attempt to the same SSID).
+        await _run_host_command(
+            f"sudo nmcli connection delete '{conn_name}' 2>/dev/null; true"
+        )
+
+        if password:
+            add_cmd = (
+                f"sudo nmcli connection add type wifi ifname {iface} "
+                f"con-name '{conn_name}' ssid '{safe_ssid}' "
+                f"connection.autoconnect no "
+                f"wifi-sec.key-mgmt wpa-psk wifi-sec.psk '{safe_pwd}'"
+            )
+        else:
+            add_cmd = (
+                f"sudo nmcli connection add type wifi ifname {iface} "
+                f"con-name '{conn_name}' ssid '{safe_ssid}' "
+                f"connection.autoconnect no"
+            )
+        ok, err = await _run_host_command(add_cmd)
+        if not ok:
+            logger.warning("[v1] nmcli connection add failed: %s", err)
+            await self._v1_restore_hotspot(iface, conn_name)
+            self._record_failure(ssid, f"nmcli add failed: {err[:200]}")
+            return
+
+        ok, err = await _run_host_command(
+            f"sudo nmcli --wait 30 connection up '{conn_name}'", timeout=45.0,
+        )
+        if not ok:
+            logger.warning("[v1] nmcli connection up failed: %s", err)
+            await _run_host_command(
+                f"sudo nmcli connection delete '{conn_name}' 2>/dev/null; true"
+            )
+            await self._v1_restore_hotspot(iface, conn_name)
+            self._record_failure(
+                ssid,
+                f"Association failed — check password / signal: {err[:200]}",
+            )
+            return
+
+        # 5. Poll for DHCP lease.
+        ip: str | None = None
+        deadline = asyncio.get_event_loop().time() + V1_DHCP_TIMEOUT_S
+        while asyncio.get_event_loop().time() < deadline:
+            ok, ip_out = await _run_host_command(
+                f"ip -4 -o addr show dev {iface} 2>/dev/null "
+                f"| awk '{{print $4}}' | cut -d/ -f1 | head -1"
+            )
+            if ok and ip_out.strip():
+                ip = ip_out.strip()
+                break
+            await asyncio.sleep(STA_POLL_INTERVAL_S)
+
+        if not ip:
+            logger.warning(
+                "[v1] %s associated to %r but never got a DHCP lease",
+                iface, ssid,
+            )
+            await _run_host_command(
+                f"sudo nmcli connection down '{conn_name}' 2>/dev/null; true"
+            )
+            await _run_host_command(
+                f"sudo nmcli connection delete '{conn_name}' 2>/dev/null; true"
+            )
+            await self._v1_restore_hotspot(iface, conn_name)
+            self._record_failure(ssid, "Associated but no DHCP lease in 30s")
+            return
+
+        logger.info("[v1] STA on %s connected to %r (ip=%s)", iface, ssid, ip)
+        success = WlanLastAttempt(
+            ssid=ssid,
+            status="success",
+            timestamp=datetime.now(timezone.utc),
+        )
+        self._wlan_state = WlanState(
+            mode="sta_connected",
+            target_ssid=ssid,
+            ip_address=ip,
+            last_attempt=success,
+        )
+        self._save_wlan_state(self._wlan_state)
+
+    async def _v1_switch_to_ap(self, iface: str) -> None:
+        """Tear down the nmcli STA connection on *iface* and restart
+        the BlueOS hotspot."""
+        logger.info("[v1] Restoring %s to hotspot mode", iface)
+
+        # Find any active nmcli connection on iface to bring down.
+        # Format from `nmcli -t -f NAME,DEVICE connection show --active`
+        # is one ``NAME:DEVICE`` per line.
+        ok, out = await _run_host_command(
+            "nmcli -t -f NAME,DEVICE connection show --active 2>/dev/null"
+        )
+        conn_name = ""
+        if ok:
+            for line in out.splitlines():
+                parts = line.rsplit(":", 1)
+                if len(parts) == 2 and parts[1].strip() == iface:
+                    conn_name = parts[0].strip()
+                    break
+
+        await self._v1_restore_hotspot(iface, conn_name)
+
+        self._wlan_state = WlanState(
+            mode="ap",
+            last_attempt=self._wlan_state.last_attempt if self._wlan_state else None,
+        )
+        self._save_wlan_state(self._wlan_state)
+
+    async def _v1_restore_hotspot(self, iface: str, conn_name: str = "") -> None:
+        """Roll back any v1 STA state on *iface* and re-enable the
+        BlueOS hotspot. Used both in failure paths and from
+        :meth:`_v1_switch_to_ap`. Idempotent — safe to call when
+        nothing was set up yet."""
+        if conn_name:
+            await _run_host_command(
+                f"sudo nmcli connection down '{conn_name}' 2>/dev/null; true"
+            )
+            await _run_host_command(
+                f"sudo nmcli connection delete '{conn_name}' 2>/dev/null; true"
+            )
+
+        # Restore the unmanaged-devices conf so future NM reloads
+        # leave uap0 alone for create_ap to drive.
+        await _run_host_command(
+            f"if [ -f {V1_NM_UNMANAGED_STASH} ]; then "
+            f"  sudo mv {V1_NM_UNMANAGED_STASH} {V1_NM_UNMANAGED_CONF}; "
+            f"fi"
+        )
+        await _run_host_command("sudo nmcli general reload conf")
+        await asyncio.sleep(1)
+
+        # Bounce the link to clear any nmcli-supplicant state still
+        # attached so create_ap can take over cleanly.
+        await _run_host_command(
+            f"sudo ip addr flush dev {iface} 2>/dev/null; "
+            f"sudo ip link set {iface} down; sleep 1; "
+            f"sudo ip link set {iface} up"
+        )
+        await asyncio.sleep(2)
+
+        try:
+            await self._client.set_hotspot(True)
+            logger.info("[v1] BlueOS hotspot re-enabled on %s", iface)
+        except Exception as e:
+            logger.warning("[v1] set_hotspot(True) failed: %s", e)
 
     async def _restore_ap_after_failure(self, iface: str) -> None:
         """Best-effort: put ``iface`` back into hotspot mode. Used both

--- a/extension/backend/src/doris/services/network.py
+++ b/extension/backend/src/doris/services/network.py
@@ -730,7 +730,6 @@ class NetworkService:
             await self._client.connect(ssid, password, interface=iface)
         except Exception as e:
             logger.warning("Connect call to %r failed: %s", ssid, e)
-            await self._client.forget_network(ssid)
             await self._restore_ap_after_failure(iface)
             self._record_failure(ssid, f"Connect rejected: {e}")
             return
@@ -753,7 +752,13 @@ class NetworkService:
                 "STA association to %r timed out after %.0fs (last status=%s)",
                 ssid, STA_CONNECT_TIMEOUT_S, last_status,
             )
-            await self._client.forget_network(ssid)
+            # Deliberately NOT calling forget_network(ssid) here. Saved
+            # networks in BlueOS WiFi Manager are global, not per-
+            # interface — so forgetting the SSID we just tried would
+            # also clear it from wlan0's saved list, silently breaking
+            # any lab-internet connection the user has set up there.
+            # The user can clean stale credentials manually via the
+            # BlueOS UI if they really need to.
             await self._restore_ap_after_failure(iface)
             self._record_failure(
                 ssid,

--- a/extension/backend/tests/test_models.py
+++ b/extension/backend/tests/test_models.py
@@ -1,10 +1,15 @@
 """Tests for Pydantic models."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 
 from doris.models.system import SystemStatus, BatteryInfo, StorageInfo, LocationInfo
-from doris.models.network import WifiNetwork, ConnectionStatus
+from doris.models.network import (
+    ConnectionStatus,
+    WifiNetwork,
+    WlanLastAttempt,
+    WlanState,
+)
 from doris.models.sensors import ModuleInfo
 from doris.models.missions import Mission, MissionConfig, MissionStatus, TriggerConfig, TriggerType
 
@@ -76,6 +81,42 @@ def test_connection_status():
     )
     assert status.is_connected is True
     assert status.ssid == "TestNetwork"
+
+
+def test_wlan_state_default_is_ap():
+    """Default WlanState is the safe ``ap`` mode with no last attempt."""
+    state = WlanState(mode="ap")
+    assert state.mode == "ap"
+    assert state.target_ssid is None
+    assert state.ip_address is None
+    assert state.last_attempt is None
+
+
+def test_wlan_state_round_trips_through_json():
+    """The persisted intent file is JSON; verify it survives a round-trip."""
+    attempt = WlanLastAttempt(
+        ssid="HomeWiFi",
+        status="failed",
+        error="Timed out waiting for association",
+        timestamp=datetime(2026, 5, 11, 22, 30, tzinfo=timezone.utc),
+    )
+    state = WlanState(
+        mode="sta_connected",
+        target_ssid="HomeWiFi",
+        ip_address="192.168.1.42",
+        last_attempt=attempt,
+    )
+    blob = state.model_dump_json()
+    restored = WlanState.model_validate_json(blob)
+    assert restored == state
+    assert restored.last_attempt is not None
+    assert restored.last_attempt.status == "failed"
+
+
+def test_wlan_state_rejects_unknown_mode():
+    """Mode is a Literal; bad values must fail validation."""
+    with pytest.raises(Exception):
+        WlanState(mode="sideways")  # type: ignore[arg-type]
 
 
 def test_module_info():

--- a/extension/frontend/src/components/NetworkSetup.vue
+++ b/extension/frontend/src/components/NetworkSetup.vue
@@ -317,15 +317,10 @@ const formatTimestamp = (iso: string): string => {
           <AlertCircle class="w-5 h-5 flex-shrink-0 mt-0.5" style="color: #41B9C3" />
           <div class="space-y-2">
             <p class="text-sm" style="color: #96EEF2">
-              This page controls the <strong>external</strong> WiFi radio only. That radio can
-              either broadcast the DORIS hotspot <strong>or</strong> connect to a local WLAN —
-              not both at the same time. Joining a local network gives DORIS internet access at
-              the cost of taking the hotspot down for the duration of the session.
-            </p>
-            <p class="text-sm" style="color: #96EEF2">
-              <strong>The Pi's built-in WiFi adapter is not touched here.</strong> Use the BlueOS
-              WiFi page if you want to connect that adapter to a lab network for updates or
-              debugging — it operates independently and the DORIS extension will leave it alone.
+              The DORIS hotspot radio can either broadcast the DORIS hotspot <strong>or</strong>
+              connect to a local WLAN — not both at the same time. Joining a local network gives
+              DORIS internet access at the cost of taking the hotspot down for the duration of
+              the session.
             </p>
             <p class="text-sm" style="color: #96EEF2">
               <strong>2.4 GHz networks only.</strong> The external antenna is single-band 2.4 GHz,
@@ -334,7 +329,7 @@ const formatTimestamp = (iso: string): string => {
               2.4 GHz radio is enabled.
             </p>
             <p class="text-sm" style="color: #96EEF2">
-              <strong>Startup behavior:</strong> Every time DORIS is restarted, the external radio
+              <strong>Startup behavior:</strong> Every time DORIS is restarted, the hotspot radio
               reverts to hotspot mode. Saved networks are kept and will appear in the scan list,
               but they are never auto-joined.
             </p>

--- a/extension/frontend/src/components/NetworkSetup.vue
+++ b/extension/frontend/src/components/NetworkSetup.vue
@@ -317,14 +317,26 @@ const formatTimestamp = (iso: string): string => {
           <AlertCircle class="w-5 h-5 flex-shrink-0 mt-0.5" style="color: #41B9C3" />
           <div class="space-y-2">
             <p class="text-sm" style="color: #96EEF2">
-              DORIS uses a single external WiFi radio that can either broadcast the DORIS hotspot
-              <strong>or</strong> connect to a local WLAN — not both at the same time. Joining a
-              local network gives DORIS internet access at the cost of taking the hotspot down for
-              the duration of the session.
+              This page controls the <strong>external</strong> WiFi radio only. That radio can
+              either broadcast the DORIS hotspot <strong>or</strong> connect to a local WLAN —
+              not both at the same time. Joining a local network gives DORIS internet access at
+              the cost of taking the hotspot down for the duration of the session.
             </p>
             <p class="text-sm" style="color: #96EEF2">
-              <strong>Startup behavior:</strong> Every time DORIS is restarted, it automatically reverts to hotspot mode.
-              Saved networks are kept and will appear in the scan list, but they are never auto-joined.
+              <strong>The Pi's built-in WiFi adapter is not touched here.</strong> Use the BlueOS
+              WiFi page if you want to connect that adapter to a lab network for updates or
+              debugging — it operates independently and the DORIS extension will leave it alone.
+            </p>
+            <p class="text-sm" style="color: #96EEF2">
+              <strong>2.4 GHz networks only.</strong> The external antenna is single-band 2.4 GHz,
+              so 5 GHz access points cannot be joined even when they appear in the scan list. Pick a
+              2.4 GHz SSID; if your router broadcasts both bands under the same name, make sure the
+              2.4 GHz radio is enabled.
+            </p>
+            <p class="text-sm" style="color: #96EEF2">
+              <strong>Startup behavior:</strong> Every time DORIS is restarted, the external radio
+              reverts to hotspot mode. Saved networks are kept and will appear in the scan list,
+              but they are never auto-joined.
             </p>
           </div>
         </div>

--- a/extension/frontend/src/components/NetworkSetup.vue
+++ b/extension/frontend/src/components/NetworkSetup.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { Wifi, Lock, RefreshCw, Signal, AlertCircle, CheckCircle, Smartphone } from 'lucide-vue-next'
-import { mdiIpOutline } from '@mdi/js'
+import { Wifi, Lock, RefreshCw, Signal, AlertCircle, CheckCircle, Smartphone, ArrowLeftRight } from 'lucide-vue-next'
 import { useWifiNetworks } from '../composables/useApi'
 
 const emit = defineEmits<{
@@ -13,11 +12,14 @@ const {
   connectionStatus: apiConnectionStatus,
   serialNumber: apiSerialNumber,
   hotspotSsid: apiHotspotSsid,
+  wlanState,
   scanning,
+  switching,
   fetchNetworks,
+  fetchWlanState,
   scanNetworks,
-  connectToNetwork,
-  disconnectFromNetwork,
+  switchToStaMode,
+  switchToApMode,
 } = useWifiNetworks()
 
 const dorisMACAddress = computed(() => apiConnectionStatus.value?.mac_address ?? '—')
@@ -26,14 +28,13 @@ const dorisHotspotName = computed(() => apiHotspotSsid.value ?? 'DORIS')
 const showAdvanced = ref(true)
 const selectedNetwork = ref<DisplayNetwork | null>(null)
 const password = ref('')
-const connectionStatus = ref<'idle' | 'connecting' | 'connected' | 'failed'>('idle')
 const manualSSID = ref('')
 const manualPassword = ref('')
-const useStaticIP = ref(false)
-const staticIPAddress = ref('')
-const subnetMask = ref('255.255.255.0')
-const gateway = ref('')
-const dnsServer = ref('')
+
+// AP/STA switch UX state
+const pendingSwitch = ref<{ ssid: string; password: string } | null>(null)
+const showSwitchConfirm = ref(false)
+const dismissedAttemptTimestamp = ref<string | null>(null)
 
 interface DisplayNetwork {
   ssid: string
@@ -46,78 +47,107 @@ interface DisplayNetwork {
 
 const networks = computed<DisplayNetwork[]>(() => {
   if (apiNetworks.value.length > 0) {
-    return apiNetworks.value.map((n) => ({
-      ssid: n.ssid,
-      signal: n.signal_strength,
-      frequency: n.frequency,
-      security: n.security,
-      saved: n.is_saved,
-      connected: n.is_connected,
-    }))
+    return apiNetworks.value
+      // Don't list our own AP as a join target — the user can't STA into
+      // their own hotspot, and showing it just invites confusion.
+      .filter(n => n.ssid !== dorisHotspotName.value)
+      .map((n) => ({
+        ssid: n.ssid,
+        signal: n.signal_strength,
+        frequency: n.frequency,
+        security: n.security,
+        saved: n.is_saved,
+        connected: n.is_connected,
+      }))
   }
   return []
 })
 
-const connectedNetwork = computed(() => networks.value.find((n) => n.connected))
-
 let pollInterval: number | undefined
+let stateInterval: number | undefined
 
 onMounted(() => {
   fetchNetworks()
+  fetchWlanState()
   if (apiConnectionStatus.value?.is_connected) {
-    connectionStatus.value = 'connected'
     emit('connect', true)
   }
   pollInterval = setInterval(fetchNetworks, 10000) as unknown as number
+  // Faster cadence for WLAN state so the user gets prompt UI feedback
+  // while a switch is in flight, and so the post-failure banner appears
+  // quickly when they reconnect to the AP.
+  stateInterval = setInterval(fetchWlanState, 3000) as unknown as number
 })
 
 onUnmounted(() => {
   if (pollInterval) clearInterval(pollInterval)
+  if (stateInterval) clearInterval(stateInterval)
 })
 
 const isScanning = computed(() => scanning.value)
+
+const currentMode = computed(() => wlanState.value?.mode ?? 'ap')
+const isApMode = computed(() => currentMode.value === 'ap')
+const isStaPending = computed(() => currentMode.value === 'sta_pending')
+const isStaConnected = computed(() => currentMode.value === 'sta_connected')
+
+// Show the failure banner only when:
+//   - we're back on the AP (sta_pending wouldn't be reachable anyway)
+//   - the most recent attempt was a failure
+//   - the user hasn't already dismissed *this* failure
+const failureBanner = computed(() => {
+  const attempt = wlanState.value?.last_attempt
+  if (!attempt || attempt.status !== 'failed') return null
+  if (!isApMode.value) return null
+  if (dismissedAttemptTimestamp.value === attempt.timestamp) return null
+  return attempt
+})
 
 const handleScan = async () => {
   await scanNetworks()
 }
 
-const handleConnect = async () => {
+const requestSwitch = (ssid: string, pwd: string) => {
+  pendingSwitch.value = { ssid, password: pwd }
+  showSwitchConfirm.value = true
+}
+
+const cancelSwitch = () => {
+  pendingSwitch.value = null
+  showSwitchConfirm.value = false
+}
+
+const confirmSwitch = async () => {
+  if (!pendingSwitch.value) return
+  const { ssid, password: pwd } = pendingSwitch.value
+  showSwitchConfirm.value = false
+  await switchToStaMode(ssid, pwd)
+  // Don't clear pendingSwitch yet — we want to remember what SSID we
+  // tried so the in-flight banner can show it. The poll loop will
+  // refresh wlanState; the AP-side connection will die any moment now.
+  password.value = ''
+  manualPassword.value = ''
+}
+
+const handleConnectFromList = () => {
   if (!selectedNetwork.value) return
-  connectionStatus.value = 'connecting'
   const ssid = selectedNetwork.value.ssid
   const pwd = selectedNetwork.value.saved ? '' : password.value
-  const success = await connectToNetwork(ssid, pwd)
-  if (success) {
-    connectionStatus.value = 'connected'
-    emit('connect', true)
-    await fetchNetworks()
-  } else {
-    connectionStatus.value = 'failed'
-  }
+  requestSwitch(ssid, pwd)
 }
 
-const handleDisconnect = async () => {
-  connectionStatus.value = 'connecting'
-  const success = await disconnectFromNetwork()
-  if (success) {
-    connectionStatus.value = 'idle'
-    selectedNetwork.value = null
-    emit('connect', false)
-    await fetchNetworks()
-  } else {
-    connectionStatus.value = 'failed'
-  }
+const handleManualConnect = () => {
+  if (!manualSSID.value) return
+  requestSwitch(manualSSID.value, manualPassword.value)
 }
 
-const handleManualConnect = async () => {
-  if (!manualSSID.value || !manualPassword.value) return
-  connectionStatus.value = 'connecting'
-  const success = await connectToNetwork(manualSSID.value, manualPassword.value)
-  if (success) {
-    connectionStatus.value = 'connected'
-    emit('connect', true)
-  } else {
-    connectionStatus.value = 'failed'
+const handleRestoreHotspot = async () => {
+  await switchToApMode()
+}
+
+const dismissFailureBanner = () => {
+  if (failureBanner.value) {
+    dismissedAttemptTimestamp.value = failureBanner.value.timestamp
   }
 }
 
@@ -127,10 +157,12 @@ const getSignalColor = (signal: number) => {
   return '#DD2C1D'
 }
 
-const manualConnectDisabled = () => {
-  if (!manualSSID.value || !manualPassword.value) return true
-  if (useStaticIP.value && (!staticIPAddress.value || !subnetMask.value || !gateway.value)) return true
-  return false
+const formatTimestamp = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleTimeString()
+  } catch {
+    return iso
+  }
 }
 </script>
 
@@ -145,7 +177,111 @@ const manualConnectDisabled = () => {
         Network Setup & Connection
       </h1>
 
-      <!-- Device Information -->
+      <!-- ── Current Mode Banner ────────────────────────────────── -->
+      <div
+        v-if="isApMode"
+        class="rounded-lg p-4 mb-4 flex items-center gap-3"
+        style="background-color: rgba(252, 216, 105, 0.1); border: 1px solid rgba(252, 216, 105, 0.3)"
+      >
+        <Smartphone class="w-5 h-5 flex-shrink-0" style="color: #FCD869" />
+        <div class="flex-1">
+          <p style="color: #FCD869">Hotspot mode</p>
+          <p class="text-sm" style="color: #96EEF2">Broadcasting <span class="font-mono">{{ dorisHotspotName }}</span> — connect a client to reach DORIS.</p>
+        </div>
+      </div>
+
+      <div
+        v-if="isStaPending"
+        class="rounded-lg p-4 mb-4 flex items-center gap-3"
+        style="background-color: rgba(65, 185, 195, 0.1); border: 1px solid rgba(65, 185, 195, 0.3)"
+      >
+        <RefreshCw class="w-5 h-5 animate-spin flex-shrink-0" style="color: #41B9C3" />
+        <div class="flex-1">
+          <p style="color: #41B9C3">Switching to client mode…</p>
+          <p class="text-sm" style="color: #96EEF2">
+            Joining <span class="font-mono">{{ wlanState?.target_ssid ?? pendingSwitch?.ssid ?? '…' }}</span>.
+            The DORIS hotspot is going down — your browser will lose this page within seconds.
+          </p>
+          <p class="text-sm mt-1" style="color: #96EEF2">
+            On success, find DORIS at <span class="font-mono">http://doris.local:8095</span> on the same network.
+            On failure, the hotspot will restart and you can reconnect here to see what went wrong.
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-if="isStaConnected"
+        class="rounded-lg p-4 mb-4"
+        style="background-color: rgba(150, 238, 242, 0.1); border: 1px solid rgba(150, 238, 242, 0.4)"
+      >
+        <div class="flex items-center gap-3 mb-3">
+          <CheckCircle class="w-5 h-5 flex-shrink-0" style="color: #96EEF2" />
+          <div class="flex-1">
+            <p style="color: #96EEF2">Connected to client WLAN</p>
+            <p class="text-sm" style="color: #96EEF2">
+              Network: <span class="font-mono">{{ wlanState?.target_ssid ?? '—' }}</span>
+            </p>
+            <p v-if="wlanState?.ip_address" class="text-sm mt-1" style="color: #96EEF2">
+              Reach DORIS at
+              <span class="font-mono">http://doris.local:8095</span>
+              or
+              <span class="font-mono">http://{{ wlanState.ip_address }}:8095</span>
+            </p>
+          </div>
+        </div>
+        <div
+          class="rounded-lg p-3 mb-3"
+          style="background-color: rgba(255, 153, 55, 0.1); border: 1px solid rgba(255, 153, 55, 0.3)"
+        >
+          <div class="flex items-start gap-2">
+            <AlertCircle class="w-4 h-4 flex-shrink-0 mt-0.5" style="color: #FF9937" />
+            <p class="text-xs" style="color: #FF9937">
+              The DORIS hotspot is down while in client mode. Power-cycling DORIS will always restore the hotspot.
+            </p>
+          </div>
+        </div>
+        <button
+          @click="handleRestoreHotspot"
+          :disabled="switching"
+          class="w-full px-4 py-2 text-white rounded-lg transition-all disabled:opacity-50 hover:opacity-90 flex items-center justify-center gap-2"
+          style="background: linear-gradient(135deg, #FCD869 0%, #FF9937 100%)"
+        >
+          <ArrowLeftRight class="w-4 h-4" />
+          {{ switching ? 'Restoring…' : 'Restore DORIS Hotspot' }}
+        </button>
+      </div>
+
+      <!-- ── Last Attempt Failure Banner ───────────────────────── -->
+      <div
+        v-if="failureBanner"
+        class="rounded-lg p-4 mb-4"
+        style="background-color: rgba(221, 44, 29, 0.1); border: 1px solid rgba(221, 44, 29, 0.3)"
+      >
+        <div class="flex items-start gap-3">
+          <AlertCircle class="w-5 h-5 flex-shrink-0 mt-0.5" style="color: #DD2C1D" />
+          <div class="flex-1">
+            <p style="color: #DD2C1D">
+              Last attempt to join <span class="font-mono">{{ failureBanner.ssid }}</span> failed
+              <span class="text-xs" style="opacity: 0.7">({{ formatTimestamp(failureBanner.timestamp) }})</span>
+            </p>
+            <p v-if="failureBanner.error" class="text-sm mt-1" style="color: #DD2C1D; opacity: 0.85">
+              {{ failureBanner.error }}
+            </p>
+            <p class="text-sm mt-2" style="color: #DD2C1D; opacity: 0.85">
+              Hotspot has been restored. Double-check the password and signal strength, then try again.
+            </p>
+          </div>
+          <button
+            @click="dismissFailureBanner"
+            class="text-xs px-2 py-1 rounded hover:bg-white/10"
+            style="color: #DD2C1D"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+
+      <!-- ── Device Information ─────────────────────────────────── -->
       <div
         class="rounded-lg p-4 mb-4"
         style="background-color: rgba(14, 36, 70, 0.6); border: 1px solid rgba(65, 185, 195, 0.3)"
@@ -172,54 +308,7 @@ const manualConnectDisabled = () => {
         </div>
       </div>
 
-      <!-- Connection Status: Connected -->
-      <div
-        v-if="connectionStatus === 'connected' || connectedNetwork"
-        class="rounded-lg p-4 mb-4 flex items-center gap-3"
-        style="background-color: rgba(252, 216, 105, 0.1); border: 1px solid rgba(252, 216, 105, 0.3)"
-      >
-        <CheckCircle class="w-5 h-5 flex-shrink-0" style="color: #FCD869" />
-        <div class="flex-1">
-          <p style="color: #FCD869">Connected</p>
-          <p class="text-sm" style="color: #96EEF2">Network: {{ connectedNetwork?.ssid || selectedNetwork?.ssid || manualSSID }}</p>
-        </div>
-        <div v-if="apiConnectionStatus?.ip_address" class="flex items-center gap-1.5 flex-shrink-0">
-          <svg class="w-4 h-4" viewBox="0 0 24 24" style="color: #FCD869">
-            <path :d="mdiIpOutline" fill="currentColor" />
-          </svg>
-          <span class="text-sm font-mono" style="color: #FCD869">{{ apiConnectionStatus.ip_address }}</span>
-        </div>
-      </div>
-
-      <!-- Connection Status: Connecting -->
-      <div
-        v-if="connectionStatus === 'connecting'"
-        class="rounded-lg p-4 mb-4 flex items-center gap-3"
-        style="background-color: rgba(65, 185, 195, 0.1); border: 1px solid rgba(65, 185, 195, 0.3)"
-      >
-        <RefreshCw class="w-5 h-5 animate-spin" style="color: #41B9C3" />
-        <p style="color: #41B9C3">Connecting to network...</p>
-      </div>
-
-      <!-- Connection Status: Failed -->
-      <div
-        v-if="connectionStatus === 'failed'"
-        class="rounded-lg p-4 mb-4"
-        style="background-color: rgba(221, 44, 29, 0.1); border: 1px solid rgba(221, 44, 29, 0.3)"
-      >
-        <div class="flex items-center gap-3 mb-2">
-          <AlertCircle class="w-5 h-5" style="color: #DD2C1D" />
-          <p style="color: #DD2C1D">Connection Failed</p>
-        </div>
-        <p class="text-sm" style="color: #DD2C1D; opacity: 0.8">Troubleshooting tips:</p>
-        <ul class="text-sm list-disc ml-5 mt-1" style="color: #DD2C1D; opacity: 0.8">
-          <li>Check SSID and password are correct</li>
-          <li>Ensure router supports 2.4GHz (if 5GHz not supported)</li>
-          <li>Try restarting the system and router</li>
-        </ul>
-      </div>
-
-      <!-- Info Box -->
+      <!-- ── Info Box ────────────────────────────────────────────── -->
       <div
         class="rounded-lg p-4 mb-6"
         style="background-color: rgba(65, 185, 195, 0.1); border: 1px solid rgba(65, 185, 195, 0.3)"
@@ -228,21 +317,24 @@ const manualConnectDisabled = () => {
           <AlertCircle class="w-5 h-5 flex-shrink-0 mt-0.5" style="color: #41B9C3" />
           <div class="space-y-2">
             <p class="text-sm" style="color: #96EEF2">
-              DORIS supports both 2.4GHz and 5GHz networks. For best compatibility, 2.4GHz is recommended.
-              Previously connected networks will reconnect automatically when available.
+              DORIS uses a single external WiFi radio that can either broadcast the DORIS hotspot
+              <strong>or</strong> connect to a local WLAN — not both at the same time. Joining a
+              local network gives DORIS internet access at the cost of taking the hotspot down for
+              the duration of the session.
             </p>
             <p class="text-sm" style="color: #96EEF2">
-              <strong>Startup Behavior:</strong> Every time DORIS is restarted, it automatically starts in hotspot mode. After startup, you will need to reconnect it to your preferred network.
+              <strong>Startup behavior:</strong> Every time DORIS is restarted, it automatically reverts to hotspot mode.
+              Saved networks are kept and will appear in the scan list, but they are never auto-joined.
             </p>
           </div>
         </div>
       </div>
 
-      <!-- Scan Button -->
+      <!-- ── Scan Button ────────────────────────────────────────── -->
       <div class="flex items-center gap-3 mb-6">
         <button
           @click="handleScan"
-          :disabled="isScanning"
+          :disabled="isScanning || isStaPending"
           class="flex items-center gap-2 px-4 py-2 text-white rounded-lg transition-all disabled:opacity-50 hover:opacity-90"
           style="background: linear-gradient(135deg, #41B9C3 0%, #187D8B 100%)"
         >
@@ -254,7 +346,7 @@ const manualConnectDisabled = () => {
         </span>
       </div>
 
-      <!-- Available Networks -->
+      <!-- ── Available Networks ────────────────────────────────── -->
       <div class="space-y-2 mb-6">
         <h2 class="text-white mb-3">Available Networks</h2>
         <div
@@ -301,41 +393,13 @@ const manualConnectDisabled = () => {
             <span class="text-sm" style="color: #41B9C3">{{ network.signal }}%</span>
           </div>
 
-          <!-- Disconnect button for connected network -->
+          <!-- Password Input + Switch button for unsaved selected network -->
           <div
-            v-if="selectedNetwork?.ssid === network.ssid && network.connected"
+            v-if="selectedNetwork?.ssid === network.ssid && !network.saved"
             class="mt-4 pt-4"
             style="border-top: 1px solid rgba(65, 185, 195, 0.2)"
             @click.stop
           >
-            <button
-              @click="handleDisconnect"
-              class="w-full px-4 py-2 text-white rounded-lg transition-all hover:opacity-90"
-              style="background: linear-gradient(135deg, #DD2C1D 0%, #a82215 100%)"
-            >
-              Disconnect
-            </button>
-          </div>
-
-          <!-- Password Input for unsaved, not-connected selected network -->
-          <div
-            v-else-if="selectedNetwork?.ssid === network.ssid && !network.saved"
-            class="mt-4 pt-4"
-            style="border-top: 1px solid rgba(65, 185, 195, 0.2)"
-            @click.stop
-          >
-            <div
-              v-if="network.ssid !== dorisHotspotName"
-              class="rounded-lg p-3 mb-3"
-              style="background-color: rgba(255, 153, 55, 0.1); border: 1px solid rgba(255, 153, 55, 0.3)"
-            >
-              <div class="flex items-start gap-2">
-                <AlertCircle class="w-4 h-4 flex-shrink-0 mt-0.5" style="color: #FF9937" />
-                <p class="text-xs" style="color: #FF9937">
-                  <strong>Note:</strong> Once connected to this network, you will lose access to DORIS from the hotspot. You will need to access DORIS from the new network or power cycle DORIS to restore the hotspot.
-                </p>
-              </div>
-            </div>
             <input
               type="password"
               v-model="password"
@@ -344,45 +408,37 @@ const manualConnectDisabled = () => {
               style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.3)"
             />
             <button
-              @click="handleConnect"
-              class="w-full px-4 py-2 text-white rounded-lg transition-all hover:opacity-90"
+              @click="handleConnectFromList"
+              :disabled="!password || isStaPending"
+              class="w-full px-4 py-2 text-white rounded-lg transition-all hover:opacity-90 disabled:opacity-50 flex items-center justify-center gap-2"
               style="background: linear-gradient(135deg, #41B9C3 0%, #187D8B 100%)"
             >
-              Connect
+              <ArrowLeftRight class="w-4 h-4" />
+              Switch DORIS to this network
             </button>
           </div>
 
-          <!-- Connect button for saved, not-connected selected network -->
+          <!-- Switch button for saved selected network (no password needed) -->
           <div
             v-else-if="selectedNetwork?.ssid === network.ssid && network.saved"
             class="mt-4 pt-4"
             style="border-top: 1px solid rgba(65, 185, 195, 0.2)"
             @click.stop
           >
-            <div
-              v-if="network.ssid !== dorisHotspotName"
-              class="rounded-lg p-3 mb-3"
-              style="background-color: rgba(255, 153, 55, 0.1); border: 1px solid rgba(255, 153, 55, 0.3)"
-            >
-              <div class="flex items-start gap-2">
-                <AlertCircle class="w-4 h-4 flex-shrink-0 mt-0.5" style="color: #FF9937" />
-                <p class="text-xs" style="color: #FF9937">
-                  <strong>Note:</strong> Once connected to this network, you will lose access to DORIS from the hotspot. You will need to access DORIS from the new network or power cycle DORIS to restore the hotspot.
-                </p>
-              </div>
-            </div>
             <button
-              @click="handleConnect"
-              class="w-full px-4 py-2 text-white rounded-lg transition-all hover:opacity-90"
+              @click="handleConnectFromList"
+              :disabled="isStaPending"
+              class="w-full px-4 py-2 text-white rounded-lg transition-all hover:opacity-90 disabled:opacity-50 flex items-center justify-center gap-2"
               style="background: linear-gradient(135deg, #41B9C3 0%, #187D8B 100%)"
             >
-              Connect
+              <ArrowLeftRight class="w-4 h-4" />
+              Switch DORIS to this saved network
             </button>
           </div>
         </div>
       </div>
 
-      <!-- Advanced Options -->
+      <!-- ── Advanced Options ──────────────────────────────────── -->
       <div class="pt-6" style="border-top: 1px solid rgba(65, 185, 195, 0.2)">
         <button
           @click="showAdvanced = !showAdvanced"
@@ -400,7 +456,8 @@ const manualConnectDisabled = () => {
           >
             <h3 class="text-white mb-3">Manual Network Entry</h3>
             <p class="text-sm mb-4" style="color: #96EEF2">
-              Enter network details manually if your network isn't detected in the scan.
+              Enter network details manually if your network isn't detected in the scan
+              (e.g., a hidden SSID).
             </p>
             <div class="space-y-3">
               <input
@@ -417,125 +474,75 @@ const manualConnectDisabled = () => {
                 class="w-full px-4 py-2 text-white rounded-lg focus:outline-none"
                 style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.3)"
               />
-
-              <!-- Static IP Configuration -->
-              <div class="pt-3" style="border-top: 1px solid rgba(65, 185, 195, 0.1)">
-                <label class="flex items-center gap-2 mb-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    v-model="useStaticIP"
-                    class="w-4 h-4 rounded"
-                    style="accent-color: #41B9C3"
-                  />
-                  <span class="text-sm" style="color: #96EEF2">Use Static IP Address</span>
-                </label>
-
-                <div v-if="useStaticIP" class="space-y-3 pl-6">
-                  <div>
-                    <label class="block text-xs mb-1" style="color: #96EEF2">IP Address *</label>
-                    <input
-                      type="text"
-                      v-model="staticIPAddress"
-                      placeholder="e.g., 192.168.1.100"
-                      class="w-full px-4 py-2 text-white rounded-lg focus:outline-none"
-                      style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.3)"
-                    />
-                  </div>
-                  <div>
-                    <label class="block text-xs mb-1" style="color: #96EEF2">Subnet Mask *</label>
-                    <input
-                      type="text"
-                      v-model="subnetMask"
-                      placeholder="e.g., 255.255.255.0"
-                      class="w-full px-4 py-2 text-white rounded-lg focus:outline-none"
-                      style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.3)"
-                    />
-                  </div>
-                  <div>
-                    <label class="block text-xs mb-1" style="color: #96EEF2">Gateway *</label>
-                    <input
-                      type="text"
-                      v-model="gateway"
-                      placeholder="e.g., 192.168.1.1"
-                      class="w-full px-4 py-2 text-white rounded-lg focus:outline-none"
-                      style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.3)"
-                    />
-                  </div>
-                  <div>
-                    <label class="block text-xs mb-1" style="color: #96EEF2">DNS Server (Optional)</label>
-                    <input
-                      type="text"
-                      v-model="dnsServer"
-                      placeholder="e.g., 8.8.8.8"
-                      class="w-full px-4 py-2 text-white rounded-lg focus:outline-none"
-                      style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.3)"
-                    />
-                  </div>
-                  <div
-                    class="rounded-lg p-3 mt-2"
-                    style="background-color: rgba(65, 185, 195, 0.1); border: 1px solid rgba(65, 185, 195, 0.2)"
-                  >
-                    <p class="text-xs" style="color: #96EEF2">
-                      <strong>Note:</strong> Ensure the static IP address is within the network's range and not already in use by another device.
-                    </p>
-                  </div>
-                </div>
-              </div>
-
               <button
                 @click="handleManualConnect"
-                class="w-full px-4 py-2 text-white rounded-lg transition-all disabled:opacity-50"
+                :disabled="!manualSSID || isStaPending"
+                class="w-full px-4 py-2 text-white rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
                 style="background: linear-gradient(135deg, #41B9C3 0%, #187D8B 100%)"
-                :disabled="manualConnectDisabled()"
               >
-                Connect to Manual Network
+                <ArrowLeftRight class="w-4 h-4" />
+                Switch DORIS to this network
               </button>
-
-              <div
-                v-if="manualSSID && manualPassword"
-                class="rounded-lg p-3 mt-3"
-                style="background-color: rgba(255, 153, 55, 0.1); border: 1px solid rgba(255, 153, 55, 0.3)"
-              >
-                <div class="flex items-start gap-2">
-                  <AlertCircle class="w-4 h-4 flex-shrink-0 mt-0.5" style="color: #FF9937" />
-                  <p class="text-xs" style="color: #FF9937">
-                    <strong>Note:</strong> Once connected to this network, you will lose access to DORIS from the hotspot. You will need to access DORIS from the new network or power cycle DORIS to restore the hotspot.
-                  </p>
-                </div>
-              </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
 
-          <!-- Direct Connection Mode -->
-          <div
-            class="rounded-lg p-4"
-            style="background-color: rgba(14, 36, 70, 0.5); border: 1px solid rgba(65, 185, 195, 0.2)"
+    <!-- ── Switch Confirmation Modal ─────────────────────────── -->
+    <div
+      v-if="showSwitchConfirm && pendingSwitch"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style="background-color: rgba(0, 0, 0, 0.7)"
+      @click.self="cancelSwitch"
+    >
+      <div
+        class="max-w-md w-full rounded-xl p-6"
+        style="background-color: #0E2446; border: 1px solid rgba(65, 185, 195, 0.4)"
+      >
+        <h2 class="text-white text-lg mb-3 flex items-center gap-2">
+          <ArrowLeftRight class="w-5 h-5" style="color: #FCD869" />
+          Switch DORIS to client mode?
+        </h2>
+        <div
+          class="rounded-lg p-3 mb-3"
+          style="background-color: rgba(255, 153, 55, 0.1); border: 1px solid rgba(255, 153, 55, 0.3)"
+        >
+          <p class="text-sm" style="color: #FF9937">
+            DORIS will leave hotspot mode and try to join
+            <span class="font-mono">{{ pendingSwitch.ssid }}</span>.
+            Anyone connected to the DORIS hotspot will be disconnected immediately.
+          </p>
+        </div>
+        <ul class="text-sm space-y-2 mb-4" style="color: #96EEF2">
+          <li class="flex gap-2">
+            <span style="color: #FCD869">•</span>
+            <span>If the join succeeds, reach DORIS at <span class="font-mono">http://doris.local:8095</span> on the same network.</span>
+          </li>
+          <li class="flex gap-2">
+            <span style="color: #FCD869">•</span>
+            <span>If the join fails, the hotspot will be restarted automatically and you can reconnect here.</span>
+          </li>
+          <li class="flex gap-2">
+            <span style="color: #FCD869">•</span>
+            <span>Power cycling DORIS always restores the hotspot.</span>
+          </li>
+        </ul>
+        <div class="flex gap-3">
+          <button
+            @click="cancelSwitch"
+            class="flex-1 px-4 py-2 text-white rounded-lg transition-all hover:opacity-90"
+            style="background-color: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2)"
           >
-            <h3 class="text-white mb-3 flex items-center gap-2">
-              <Smartphone class="w-5 h-5" style="color: #41B9C3" />
-              Direct Device Connection
-            </h3>
-            <p class="text-sm mb-3" style="color: #96EEF2">
-              Connect directly to DORIS via hotspot mode when no WiFi network is available.
-            </p>
-            <div
-              class="rounded-lg p-3 mb-3"
-              style="background-color: rgba(255, 153, 55, 0.1); border: 1px solid rgba(255, 153, 55, 0.3)"
-            >
-              <div class="flex items-start gap-2">
-                <AlertCircle class="w-4 h-4 flex-shrink-0 mt-0.5" style="color: #FF9937" />
-                <p class="text-xs" style="color: #FF9937">
-                  <strong>Warning:</strong> Enabling hotspot mode will disconnect DORIS from its current network connection. You will need to reconnect your device to the DORIS hotspot ({{ dorisHotspotName }}) to access the interface.
-                </p>
-              </div>
-            </div>
-            <button
-              class="w-full px-4 py-2 text-white rounded-lg transition-all hover:opacity-90"
-              style="background: linear-gradient(135deg, #FCD869 0%, #FF9937 100%)"
-            >
-              Enable DORIS Hotspot
-            </button>
-          </div>
+            Cancel
+          </button>
+          <button
+            @click="confirmSwitch"
+            class="flex-1 px-4 py-2 text-white rounded-lg transition-all hover:opacity-90"
+            style="background: linear-gradient(135deg, #41B9C3 0%, #187D8B 100%)"
+          >
+            Switch now
+          </button>
         </div>
       </div>
     </div>

--- a/extension/frontend/src/composables/useApi.ts
+++ b/extension/frontend/src/composables/useApi.ts
@@ -100,6 +100,29 @@ export interface NetworkFullInfo {
   hotspot_ssid: string | null
 }
 
+/**
+ * AP <-> STA mode switching state for the external WiFi radio.
+ *
+ * The external radio (`uap0`) runs *either* the DORIS hotspot *or* a
+ * client connection to a local WLAN, never both at once. The user
+ * triggers the switch from the Network Setup tab; ``mode`` reflects
+ * the DORIS-side intent and is always force-reset to ``ap`` on every
+ * backend startup so a power cycle reliably restores the hotspot.
+ */
+export interface WlanLastAttempt {
+  ssid: string
+  status: 'success' | 'failed'
+  error: string | null
+  timestamp: string
+}
+
+export interface WlanState {
+  mode: 'ap' | 'sta_pending' | 'sta_connected'
+  target_ssid: string | null
+  ip_address: string | null
+  last_attempt: WlanLastAttempt | null
+}
+
 export interface MissionSummary {
   id: string
   name: string
@@ -479,8 +502,10 @@ export function useWifiNetworks() {
   const connectionStatus = ref<ConnectionStatus | null>(null)
   const serialNumber = ref<string | null>(null)
   const hotspotSsid = ref<string | null>(null)
+  const wlanState = ref<WlanState | null>(null)
   const loading = ref(false)
   const scanning = ref(false)
+  const switching = ref(false)
   const error = ref<string | null>(null)
 
   async function fetchNetworks() {
@@ -558,20 +583,79 @@ export function useWifiNetworks() {
     }
   }
 
+  /**
+   * Read the current AP/STA intent from the backend. Polled by the
+   * Network Setup tab so the UI can show the post-failure banner once
+   * the user reconnects to the hotspot after a busted switch attempt.
+   */
+  async function fetchWlanState() {
+    try {
+      wlanState.value = await fetchApi<WlanState>('/network/wlan/status')
+    } catch (e) {
+      // Backend may be momentarily unreachable while the AP is being
+      // re-asserted after a failed switch — that's expected, don't
+      // surface as an error.
+      void e
+    }
+  }
+
+  /**
+   * Kick off the AP -> STA switch. Returns immediately with the new
+   * ``sta_pending`` state; the caller should expect the AP-side
+   * connection to drop within a few seconds. The actual outcome is
+   * observable via ``fetchWlanState`` once the user is back on a
+   * reachable network.
+   */
+  async function switchToStaMode(ssid: string, password: string): Promise<boolean> {
+    switching.value = true
+    error.value = null
+    try {
+      const result = await postApi<WlanState>('/network/wlan/connect', { ssid, password })
+      wlanState.value = result
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to start WLAN switch'
+      return false
+    } finally {
+      switching.value = false
+    }
+  }
+
+  /** Tear down any STA association and put the external radio back into hotspot mode. */
+  async function switchToApMode(): Promise<boolean> {
+    switching.value = true
+    error.value = null
+    try {
+      const result = await postApi<WlanState>('/network/wlan/disconnect')
+      wlanState.value = result
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to restore hotspot'
+      return false
+    } finally {
+      switching.value = false
+    }
+  }
+
   return {
     networks: readonly(networks),
     connectionStatus: readonly(connectionStatus),
     serialNumber: readonly(serialNumber),
     hotspotSsid: readonly(hotspotSsid),
+    wlanState: readonly(wlanState),
     loading: readonly(loading),
     scanning: readonly(scanning),
+    switching: readonly(switching),
     error: readonly(error),
     fetchNetworks,
     fetchStatus,
+    fetchWlanState,
     scanNetworks,
     connectToNetwork,
     disconnectFromNetwork,
     forgetNetwork,
+    switchToStaMode,
+    switchToApMode,
   }
 }
 

--- a/extension/frontend/yarn.lock
+++ b/extension/frontend/yarn.lock
@@ -167,6 +167,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz#9bdad8176be7811ad148d1f8772359041f46c6c5"
   integrity sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==
 
+"@fontsource/montserrat@^5.1.0":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@fontsource/montserrat/-/montserrat-5.2.8.tgz#4be164061dbab2b81bc803e9ceed47f5bd9c9f88"
+  integrity sha512-xTjLxSbSfCycDB0pwmNsfNvdfWPaDaRQ2LC6yt/ZI7SdvXG52zHnzNYC/09mzuAuWNJyShkteutfCoDgym56hQ==
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"


### PR DESCRIPTION
## Summary

Adds a UI-driven **AP ↔ STA switch** to the Network Setup page so DORIS can
temporarily leave hotspot mode to join a local 2.4 GHz WLAN (for internet
access), with automatic fallback to the hotspot on failure and on every boot.

The AP/hotspot configuration is intentionally **left untouched** — this feature
only layers client-mode switching on top of the existing, working hotspot path
(`wlan0` is never touched; the external `uap0` radio is the only interface
flipped).

## Backend
- `WlanState` / `WlanLastAttempt` models persisted to `DATA_ROOT`
- `begin_switch_to_sta` / `begin_switch_to_ap` run the radio flip as async
  tasks so the HTTP call returns before the AP-side session dies
- AP watchdog gated on intent so it doesn't fight an intentional STA switch
- `reset_wlan_to_ap_on_boot` forces AP intent + explicit disconnect at startup,
  so a power cycle reliably reverts to the hotspot
- New endpoints: `GET/POST /api/v1/network/wlan/{status,connect,disconnect}`
- `NetworkService` is now a process-wide singleton so the in-flight switch lock
  is shared between routes and the watchdog
- **v1 WiFi Manager fallback**: on BlueOS ≤ 1.5.0-beta.37 the v2 endpoints 404,
  so the switch drives `uap0` directly via Commander + `nmcli`, with full
  rollback (restore unmanaged conf, reload NM, re-enable hotspot) on any failure

## Frontend
- `NetworkSetup.vue` rewritten with three mode banners (AP / Switching /
  Connected to WLAN) plus a separate post-failure banner
- Confirmation modal explaining the side effects of leaving hotspot mode
- "Restore DORIS Hotspot" replaces the misleading always-on "Enable Hotspot"
- Polls `/wlan/status` every 3s for prompt UX feedback
- Removed the dead static-IP form; manual entry kept for hidden SSIDs

## Caveats
- WPA2-PSK only (no Enterprise/EAP)
- The failure window can be up to ~60s (`nmcli --wait 30` + 30s DHCP poll)
  before the "Last Attempt Failed" banner appears on hotspot reconnect

## Test plan
- [x] Backend unit tests pass (133 passed), including new WLAN model tests
- [x] Frontend renders locally (Vite dev server) — mode banners + switch UI verified
- [ ] On-vehicle: switch to a 2.4 GHz client network and confirm DORIS is reachable at `doris.local:8095`
- [ ] On-vehicle: failed join rolls back and hotspot restarts automatically
- [ ] On-vehicle: power cycle while in STA mode reverts to hotspot
- [ ] Verify v1 path on BlueOS ≤ 1.5.0-beta.37 and v2 path on newer firmware

🤖 Generated with [Cursor](https://cursor.com)
