### PR TITLE
refactor(power): rename hotel load to base load

### DIFF
--- a/extension/backend/src/doris/services/power_model.py
+++ b/extension/backend/src/doris/services/power_model.py
@@ -13,7 +13,7 @@ log (recorder_20260528_165058.mcap) by joining MAVLink ``BATTERY_STATUS``
 * LED: measured pack-current rise at 1700 us was 1.28 A vs the bench table's
   1.24 A (3% agreement), so the bench curve is trustworthy and the LED draws
   on the monitored pack rail.
-* Hotel (everything except the LED, lights off, idle): ~0.49 A ≈ 7-8 W.
+* Base (everything except the LED, lights off, idle): ~0.49 A ≈ 7-8 W.
 * Camera recording adds only ~1.5 W over idle (descent/bottom/ascent
   lights-off baseline rose from ~0.49 A to ~0.59 A).
 * Release/burn-wire relay showed no measurable current step at activation,
@@ -22,7 +22,7 @@ log (recorder_20260528_165058.mcap) by joining MAVLink ``BATTERY_STATUS``
 NOTE: these figures reflect whatever is on the autopilot's monitored power
 rail. The LED is definitely on it (delta matches the bench curve). If the
 Pi5/RadCAM are ever moved to a separate unmonitored converter, revisit
-``HOTEL_W`` / ``CAMERA_RECORDING_W``.
+``BASE_W`` / ``CAMERA_RECORDING_W``.
 """
 
 from __future__ import annotations
@@ -47,15 +47,15 @@ BATTERY_CAPACITY_WH = BATTERY_TOTAL_AH * BATTERY_NOMINAL_V    # 296 Wh
 BATTERY_RESERVE_PCT = 15.0
 
 # ── Component loads (empirical, see module docstring) ────────────────
-# Hotel = Raspberry Pi 5 + autopilot + sensors, everything but the LED.
-HOTEL_W = 8.0
+# Base = Raspberry Pi 5 + autopilot + sensors, everything but the LED.
+BASE_W = 8.0
 # Extra draw while the camera pipeline is actively recording video.
 CAMERA_RECORDING_W = 1.5
 # Burn-wire / drop-weight release: no measurable draw in the logs.
 RELEASE_W = 0.0
 # Surface recovery draw (terminal RECOVERY state, disarmed on the surface):
-# measured ~9.2 W in-log = hotel electronics + recovery beacon/strobe.
-RECOVERY_HOTEL_W = 9.2
+# measured ~9.2 W in-log = base electronics + recovery beacon/strobe.
+RECOVERY_BASE_W = 9.2
 # Whole-dive average draw measured in-log (~26 Wh over 140 min). Used as
 # the live time-remaining fallback when no instantaneous current is read.
 TYPICAL_DIVE_LOAD_W = 11.0
@@ -167,10 +167,10 @@ def phase_average_power_w(
     camera_duty_fraction: float = 0.0,
     voltage: float = BATTERY_NOMINAL_V,
 ) -> float:
-    """Average power (W) for a dive phase = hotel + LED + camera."""
+    """Average power (W) for a dive phase = base + LED + camera."""
     led = led_power_w(light_brightness_pct, voltage) * _clamp(light_duty_fraction, 0.0, 1.0)
     cam = CAMERA_RECORDING_W * _clamp(camera_duty_fraction, 0.0, 1.0)
-    return HOTEL_W + led + cam
+    return BASE_W + led + cam
 
 
 def usable_capacity_wh(reserve_pct: float = BATTERY_RESERVE_PCT) -> float:
@@ -264,17 +264,17 @@ def phase_breakdown(
     """Per-component energy (Wh) for one phase of a given duration."""
     ld = effective_light_duty(cfg)
     cd = effective_camera_duty(cfg)
-    hotel_wh = HOTEL_W * hours
+    base_wh = BASE_W * hours
     light_wh = led_power_w(cfg.brightness_pct, voltage) * ld * hours
     camera_wh = CAMERA_RECORDING_W * cd * hours
-    total_wh = hotel_wh + light_wh + camera_wh
+    total_wh = base_wh + light_wh + camera_wh
     return {
         "name": name,
         "hours": hours,
         "brightness_pct": cfg.brightness_pct,
         "light_duty": ld,
         "camera_duty": cd,
-        "hotel_wh": hotel_wh,
+        "base_wh": base_wh,
         "light_wh": light_wh,
         "camera_wh": camera_wh,
         "total_wh": total_wh,
@@ -329,7 +329,7 @@ def estimate_dive(
     p_asc = phases[2]["average_w"]
 
     energy_wh = sum(p["total_wh"] for p in phases)
-    hotel_wh = sum(p["hotel_wh"] for p in phases)
+    base_wh = sum(p["base_wh"] for p in phases)
     light_wh = sum(p["light_wh"] for p in phases)
     camera_wh = sum(p["camera_wh"] for p in phases)
     total_h = descent_h + bottom_h + ascent_h
@@ -341,10 +341,10 @@ def estimate_dive(
     remaining_after_dive_wh = BATTERY_CAPACITY_WH - energy_wh
     battery_life_h = BATTERY_CAPACITY_WH / avg_w if avg_w > 0 else 0.0
     # Time the vehicle can loiter on the surface in RECOVERY on whatever
-    # energy is left after the dive, running only the recovery hotel load.
+    # energy is left after the dive, running only the recovery base load.
     recovery_hours = (
-        max(0.0, remaining_after_dive_wh) / RECOVERY_HOTEL_W
-        if RECOVERY_HOTEL_W > 0
+        max(0.0, remaining_after_dive_wh) / RECOVERY_BASE_W
+        if RECOVERY_BASE_W > 0
         else 0.0
     )
 
@@ -365,10 +365,10 @@ def estimate_dive(
         "usable_wh": usable_wh,
         "remaining_after_dive_wh": remaining_after_dive_wh,
         "fits_within_reserve": remaining_after_dive_wh >= reserve_wh_val,
-        "recovery_hotel_w": RECOVERY_HOTEL_W,
+        "recovery_base_w": RECOVERY_BASE_W,
         "recovery_hours": recovery_hours,
         "phases": phases,
-        "hotel_wh": hotel_wh,
+        "base_wh": base_wh,
         "light_wh": light_wh,
         "camera_wh": camera_wh,
     }

--- a/extension/backend/tests/test_power_model.py
+++ b/extension/backend/tests/test_power_model.py
@@ -81,9 +81,9 @@ def test_camera_duty_modes():
 
 
 # ── Phase + dive estimation ──────────────────────────────────────────
-def test_phase_power_hotel_only():
+def test_phase_power_base_only():
     cfg = pm.PhaseConfig()  # everything off
-    assert pm.phase_power(cfg) == pytest.approx(pm.HOTEL_W)
+    assert pm.phase_power(cfg) == pytest.approx(pm.BASE_W)
 
 
 def test_phase_power_full_light_and_camera():
@@ -93,7 +93,7 @@ def test_phase_power_full_light_and_camera():
         camera_on=True,
         camera_type="continuous-video",
     )
-    expected = pm.HOTEL_W + pm.led_power_w(100) + pm.CAMERA_RECORDING_W
+    expected = pm.BASE_W + pm.led_power_w(100) + pm.CAMERA_RECORDING_W
     assert pm.phase_power(cfg) == pytest.approx(expected)
 
 
@@ -112,7 +112,7 @@ def test_estimate_dive_durations():
     assert est["total_hours"] == pytest.approx(4.75)
 
 
-def test_estimate_dive_hotel_only_energy():
+def test_estimate_dive_base_only_energy():
     est = pm.estimate_dive(
         depth_m=0,
         bottom_time_hours=10.0,
@@ -121,9 +121,9 @@ def test_estimate_dive_hotel_only_energy():
         ascent=pm.PhaseConfig(),
     )
     # depth 0 -> descent 0 h, ascent = 0.75 h burn, bottom 10 h
-    expected_wh = pm.HOTEL_W * (10.0 + 0.75)
+    expected_wh = pm.BASE_W * (10.0 + 0.75)
     assert est["energy_wh"] == pytest.approx(expected_wh)
-    assert est["average_power_w"] == pytest.approx(pm.HOTEL_W)
+    assert est["average_power_w"] == pytest.approx(pm.BASE_W)
 
 
 def test_estimate_dive_brightness_affects_usage():
@@ -193,11 +193,11 @@ def test_phase_breakdown_components_sum():
         light_on=True, brightness_pct=100, camera_on=True, camera_type="continuous-video"
     )
     b = pm.phase_breakdown("Bottom", cfg, hours=2.0)
-    assert b["hotel_wh"] == pytest.approx(pm.HOTEL_W * 2.0)
+    assert b["base_wh"] == pytest.approx(pm.BASE_W * 2.0)
     assert b["light_wh"] == pytest.approx(pm.led_power_w(100) * 2.0)
     assert b["camera_wh"] == pytest.approx(pm.CAMERA_RECORDING_W * 2.0)
     assert b["total_wh"] == pytest.approx(
-        b["hotel_wh"] + b["light_wh"] + b["camera_wh"]
+        b["base_wh"] + b["light_wh"] + b["camera_wh"]
     )
 
 
@@ -212,7 +212,7 @@ def test_estimate_dive_breakdown_totals_match():
     assert len(est["phases"]) == 3
     assert [p["name"] for p in est["phases"]] == ["Descent", "On Bottom", "Ascent"]
     # Component totals reconcile with overall energy.
-    assert est["hotel_wh"] + est["light_wh"] + est["camera_wh"] == pytest.approx(
+    assert est["base_wh"] + est["light_wh"] + est["camera_wh"] == pytest.approx(
         est["energy_wh"]
     )
     assert sum(p["total_wh"] for p in est["phases"]) == pytest.approx(est["energy_wh"])
@@ -308,8 +308,8 @@ def test_recovery_hours_from_remaining_energy():
         bottom=pm.PhaseConfig(),
         ascent=pm.PhaseConfig(),
     )
-    assert est["recovery_hotel_w"] == pytest.approx(pm.RECOVERY_HOTEL_W)
-    expected = est["remaining_after_dive_wh"] / pm.RECOVERY_HOTEL_W
+    assert est["recovery_base_w"] == pytest.approx(pm.RECOVERY_BASE_W)
+    expected = est["remaining_after_dive_wh"] / pm.RECOVERY_BASE_W
     assert est["recovery_hours"] == pytest.approx(expected)
     # More energy consumed => less surface recovery time.
     heavy = pm.estimate_dive(

--- a/extension/frontend/src/components/MissionProgramming.vue
+++ b/extension/frontend/src/components/MissionProgramming.vue
@@ -6,7 +6,7 @@ import { useConfigurations } from '../composables/useApi'
 import type { DeploymentConfiguration } from '../composables/useApi'
 import {
   estimateDive,
-  HOTEL_W,
+  BASE_W,
   CAMERA_RECORDING_W,
   BATTERY_CAPACITY_WH,
   ASCENT_BURN_MINUTES,
@@ -15,7 +15,7 @@ import {
   type LightMode,
 } from '../lib/powerModel'
 
-const POWER = { HOTEL_W, CAMERA_RECORDING_W, BATTERY_CAPACITY_WH, ASCENT_BURN_MINUTES }
+const POWER = { BASE_W, CAMERA_RECORDING_W, BATTERY_CAPACITY_WH, ASCENT_BURN_MINUTES }
 
 const props = withDefaults(defineProps<{
   releaseWeightBy: 'datetime' | 'elapsed'
@@ -1869,7 +1869,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
               <span style="color: #96EEF2">Surface recovery time</span>
               <span class="text-white">
                 {{ batteryData.estimate.recoveryHours.toFixed(1) }} h
-                <span style="color: rgba(150, 238, 242, 0.6)">({{ batteryData.estimate.remainingAfterDiveWh.toFixed(0) }} Wh left ÷ {{ batteryData.estimate.recoveryHotelW.toFixed(1) }} W hotel)</span>
+                <span style="color: rgba(150, 238, 242, 0.6)">({{ batteryData.estimate.remainingAfterDiveWh.toFixed(0) }} Wh left ÷ {{ batteryData.estimate.recoveryBaseW.toFixed(1) }} W base)</span>
               </span>
             </div>
 
@@ -1887,7 +1887,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
 
             <div v-if="showBatteryBreakdown" class="mt-3 text-xs" style="color: #96EEF2">
               <p class="mb-2" style="color: rgba(150, 238, 242, 0.75)">
-                Energy per phase = (Hotel {{ POWER.HOTEL_W }} W + LED×brightness×duty + Camera {{ POWER.CAMERA_RECORDING_W }} W×duty) × phase&nbsp;hours.
+                Energy per phase = (Base {{ POWER.BASE_W }} W + LED×brightness×duty + Camera {{ POWER.CAMERA_RECORDING_W }} W×duty) × phase&nbsp;hours.
                 Usage % = total energy ÷ {{ POWER.BATTERY_CAPACITY_WH.toFixed(0) }} Wh pack.
                 Durations: descent = depth ÷ 1 m/s, bottom = release-weight time, ascent = {{ POWER.ASCENT_BURN_MINUTES }} min burn + depth ÷ 1 m/s.
               </p>
@@ -1897,7 +1897,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
                     <tr style="color: rgba(150, 238, 242, 0.9)">
                       <th class="py-1 pr-3">Phase</th>
                       <th class="py-1 pr-3">Dur (h)</th>
-                      <th class="py-1 pr-3">Hotel</th>
+                      <th class="py-1 pr-3">Base</th>
                       <th class="py-1 pr-3">Lights</th>
                       <th class="py-1 pr-3">Camera</th>
                       <th class="py-1">Total (Wh)</th>
@@ -1916,7 +1916,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
                         </span>
                       </td>
                       <td class="py-1 pr-3">{{ phase.hours.toFixed(2) }}</td>
-                      <td class="py-1 pr-3">{{ phase.hotelWh.toFixed(1) }}</td>
+                      <td class="py-1 pr-3">{{ phase.baseWh.toFixed(1) }}</td>
                       <td class="py-1 pr-3">{{ phase.lightWh.toFixed(1) }}</td>
                       <td class="py-1 pr-3">{{ phase.cameraWh.toFixed(1) }}</td>
                       <td class="py-1 text-white">{{ phase.totalWh.toFixed(1) }}</td>
@@ -1924,7 +1924,7 @@ const phaseStyle = "background-color: rgba(14, 36, 70, 0.3); border: 1px solid r
                     <tr style="border-top: 1px solid rgba(65, 185, 195, 0.4)">
                       <td class="py-1 pr-3 text-white">Total</td>
                       <td class="py-1 pr-3 text-white">{{ batteryData.estimate.totalHours.toFixed(2) }}</td>
-                      <td class="py-1 pr-3 text-white">{{ batteryData.estimate.hotelWh.toFixed(1) }}</td>
+                      <td class="py-1 pr-3 text-white">{{ batteryData.estimate.baseWh.toFixed(1) }}</td>
                       <td class="py-1 pr-3 text-white">{{ batteryData.estimate.lightWh.toFixed(1) }}</td>
                       <td class="py-1 pr-3 text-white">{{ batteryData.estimate.cameraWh.toFixed(1) }}</td>
                       <td class="py-1 text-white">{{ batteryData.estimate.energyWh.toFixed(1) }}</td>

--- a/extension/frontend/src/lib/powerModel.ts
+++ b/extension/frontend/src/lib/powerModel.ts
@@ -7,7 +7,7 @@
  * Constants were validated against a real 140 min / 791 m dive log
  * (recorder_20260528_165058.mcap):
  *  - LED: measured pack-current rise at 1700 us = 1.28 A vs bench 1.24 A.
- *  - Hotel (Pi5 + autopilot + sensors, lights off): ~8 W.
+ *  - Base (Pi5 + autopilot + sensors, lights off): ~8 W.
  *  - Camera recording adder: ~1.5 W.
  *  - Release/burn-wire relay: no measurable draw.
  */
@@ -25,12 +25,12 @@ export const BATTERY_CAPACITY_WH = BATTERY_TOTAL_AH * BATTERY_NOMINAL_V // 296 W
 export const BATTERY_RESERVE_PCT = 15.0
 
 // ── Component loads (empirical) ──────────────────────────────────────
-export const HOTEL_W = 8.0
+export const BASE_W = 8.0
 export const CAMERA_RECORDING_W = 1.5
 export const RELEASE_W = 0.0
 // Surface recovery draw (terminal RECOVERY state, disarmed): measured
-// ~9.2 W in-log = hotel electronics + recovery beacon/strobe.
-export const RECOVERY_HOTEL_W = 9.2
+// ~9.2 W in-log = base electronics + recovery beacon/strobe.
+export const RECOVERY_BASE_W = 9.2
 export const TYPICAL_DIVE_LOAD_W = 11.0
 
 // ── LED (single) ─────────────────────────────────────────────────────
@@ -175,7 +175,7 @@ export function phaseAveragePowerW(opts: {
   const v = opts.voltage ?? BATTERY_NOMINAL_V
   const led = ledPowerW(opts.brightnessPct ?? 0, v) * clamp(opts.lightDutyFraction ?? 0, 0, 1)
   const cam = CAMERA_RECORDING_W * clamp(opts.cameraDutyFraction ?? 0, 0, 1)
-  return HOTEL_W + led + cam
+  return BASE_W + led + cam
 }
 
 export function phasePower(cfg: PhaseConfig, voltage = BATTERY_NOMINAL_V): number {
@@ -262,7 +262,7 @@ export interface PhaseBreakdown {
   brightnessPct: number
   lightDuty: number
   cameraDuty: number
-  hotelWh: number
+  baseWh: number
   lightWh: number
   cameraWh: number
   totalWh: number
@@ -278,17 +278,17 @@ export function phaseBreakdown(
 ): PhaseBreakdown {
   const ld = effectiveLightDuty(cfg)
   const cd = effectiveCameraDuty(cfg)
-  const hotelWh = HOTEL_W * hours
+  const baseWh = BASE_W * hours
   const lightWh = ledPowerW(cfg.brightnessPct ?? 0, voltage) * ld * hours
   const cameraWh = CAMERA_RECORDING_W * cd * hours
-  const totalWh = hotelWh + lightWh + cameraWh
+  const totalWh = baseWh + lightWh + cameraWh
   return {
     name,
     hours,
     brightnessPct: cfg.brightnessPct ?? 0,
     lightDuty: ld,
     cameraDuty: cd,
-    hotelWh,
+    baseWh,
     lightWh,
     cameraWh,
     totalWh,
@@ -313,10 +313,10 @@ export interface DiveEstimate {
   usableWh: number
   remainingAfterDiveWh: number
   fitsWithinReserve: boolean
-  recoveryHotelW: number
+  recoveryBaseW: number
   recoveryHours: number
   phases: PhaseBreakdown[]
-  hotelWh: number
+  baseWh: number
   lightWh: number
   cameraWh: number
 }
@@ -358,7 +358,7 @@ export function estimateDive(opts: {
   const ascentPowerW = phases[2].averageW
 
   const energyWh = phases.reduce((s, p) => s + p.totalWh, 0)
-  const hotelWh = phases.reduce((s, p) => s + p.hotelWh, 0)
+  const baseWh = phases.reduce((s, p) => s + p.baseWh, 0)
   const lightWh = phases.reduce((s, p) => s + p.lightWh, 0)
   const cameraWh = phases.reduce((s, p) => s + p.cameraWh, 0)
   const totalHours = descentHours + bottomHours + ascentHours
@@ -369,7 +369,7 @@ export function estimateDive(opts: {
   const usableWh = Math.max(0, BATTERY_CAPACITY_WH - reserveWh)
   const remainingAfterDiveWh = BATTERY_CAPACITY_WH - energyWh
   const recoveryHours =
-    RECOVERY_HOTEL_W > 0 ? Math.max(0, remainingAfterDiveWh) / RECOVERY_HOTEL_W : 0
+    RECOVERY_BASE_W > 0 ? Math.max(0, remainingAfterDiveWh) / RECOVERY_BASE_W : 0
 
   return {
     descentHours,
@@ -388,10 +388,10 @@ export function estimateDive(opts: {
     usableWh,
     remainingAfterDiveWh,
     fitsWithinReserve: remainingAfterDiveWh >= reserveWh,
-    recoveryHotelW: RECOVERY_HOTEL_W,
+    recoveryBaseW: RECOVERY_BASE_W,
     recoveryHours,
     phases,
-    hotelWh,
+    baseWh,
     lightWh,
     cameraWh,
   }


### PR DESCRIPTION
## Summary

Renames the always-on electronics load from "hotel" (marine jargon) to the plainer **"base"** load — the Raspberry Pi 5 + autopilot + sensors, i.e. everything except the LED. Pure terminology change; no values or behavior change.

- Backend `power_model.py`: `HOTEL_W → BASE_W`, `RECOVERY_HOTEL_W → RECOVERY_BASE_W`, dict keys `hotel_wh → base_wh`, `recovery_hotel_w → recovery_base_w`.
- Frontend `powerModel.ts` (mirror): `BASE_W`, `RECOVERY_BASE_W`, `baseWh`, `recoveryBaseW`.
- `MissionProgramming.vue`: breakdown table "Base" column, formula text, and recovery-line wording.
- Tests updated to match.

## Test plan

- [x] Backend unit tests pass (`pytest tests/test_power_model.py`, 30 passing).
- [x] `ruff` clean; no remaining `hotel` references anywhere in `extension/`.
- [x] Frontend type-checks via `vue-tsc` in the Docker build.
- [x] Verified locally in SITL: planner shows the "Base" column and "W base" recovery line.
