### PR TITLE
fix(dive): gate continuous-mode bottom light on real frames

### DIFF
--- a/extension/backend/scripts/doris.lua
+++ b/extension/backend/scripts/doris.lua
@@ -1250,7 +1250,22 @@ function update()
         --                  + post-roll windows around each snapshot
         --                  (driven by tl_strobe_active below)
         local bottom_lgt_eff = cfg.btm_lgt
-        if ipcam_cfg.btm_cmod == 2 then
+        if ipcam_cfg.btm_cmod == 1 and ipcam_cfg.rec_en then
+            -- CONTINUOUS: the operator wants the light on cfg.btm_dly_ms
+            -- (light delay) after *video recording actually starts*, not
+            -- after bottom detection.  The RTSP connect + first-frame
+            -- latency (plus the one-time GStreamer init on the first dive
+            -- recording) can push real frames several seconds past bottom
+            -- detection, so we gate the light-delay clock on first-frame
+            -- just like INTERVAL mode.  cycle_start_ms is held at 0 until
+            -- the recorder confirms frames are on disk (set in the bottom
+            -- camera dispatcher below), so the light stays off through the
+            -- connect window and then lights cfg.btm_dly_ms later.
+            bottom_lgt_eff = cfg.btm_lgt
+                and not ipcam_state.cycle_awaiting_frames
+                and ipcam_state.cycle_start_ms > 0
+                and (now_ms - ipcam_state.cycle_start_ms) >= cfg.btm_dly_ms
+        elseif ipcam_cfg.btm_cmod == 2 then
             -- INTERVAL: the camera starts each cycle, the light comes on
             -- cfg.btm_dly_ms (light delay) after the record clock starts,
             -- and both turn off together when the record window ends.  The
@@ -1270,10 +1285,13 @@ function update()
             bottom_lgt_eff = cfg.btm_lgt and (pre_active or post_active)
         end
 
-        if ipcam_cfg.btm_cmod == 2 then
-            -- INTERVAL owns its light timing per-cycle (above).  The
-            -- one-time bottom settling delay is replaced by the camera
-            -- settle (cam_delay_done), which gates the first cycle.
+        if ipcam_cfg.btm_cmod == 2
+           or (ipcam_cfg.btm_cmod == 1 and ipcam_cfg.rec_en) then
+            -- INTERVAL and CONTINUOUS-recording own their light timing via
+            -- the first-frame-anchored bottom_lgt_eff above.  The one-time
+            -- bottom settling delay (bottom_delay_done, measured from
+            -- bottom detection) is replaced by the recording-start anchor
+            -- so the light tracks the camera, not the detection instant.
             update_lights(bottom_lgt_eff, now_ms)
         elseif not bottom_delay_done then
             update_lights(false, now_ms)
@@ -1295,10 +1313,49 @@ function update()
         elseif ipcam_cfg.btm_cmod == 1 then
             -- CONTINUOUS: start once after camera delay, keep running.
             -- seg=300 -> splitmuxsink rotates every 5 minutes so the
-            -- finalize step can produce on_bottom_chunkNN.mp4 files.
-            if cam_delay_done and not ipcam_recording then
-                ipcam_begin_phase(true, "on_bottom", 300)
-                ipcam_btm_started = ipcam_recording
+            -- finalize step can produce on_bottom_chunkNN.mp4 files.  The
+            -- recorder may already be live here (the zero-gap start fired
+            -- at bottom detection when there was no camera delay) or not
+            -- (a camera delay stopped descent recording); either way we
+            -- run a first-frame wait so the bottom light's delay clock
+            -- (cycle_start_ms) is anchored to real frames on disk rather
+            -- than bottom detection.
+            if ipcam_cfg.rec_en and cam_delay_done then
+                if not ipcam_state.cycle_started then
+                    ipcam_state.cycle_started         = true
+                    ipcam_state.cycle_awaiting_frames = true
+                    ipcam_state.cycle_wait_start_ms   = now_ms
+                    ipcam_state.cycle_start_ms        = 0
+                    if not ipcam_recording then
+                        ipcam_begin_phase(true, "on_bottom", 300)
+                    end
+                    ipcam_btm_started = ipcam_recording
+                elseif ipcam_state.cycle_awaiting_frames then
+                    -- Hold the light-delay clock until frames are confirmed
+                    -- on disk (or the safety timeout fires).  Recording is
+                    -- already running; we only gate the light here.
+                    local ff = ipcam_frames_flowing()
+                    local waited = now_ms - ipcam_state.cycle_wait_start_ms
+                    if ff == true then
+                        ipcam_state.cycle_awaiting_frames = false
+                        ipcam_state.cycle_start_ms        = now_ms
+                        reset_light_cycle(now_ms)
+                        gcs:send_text(MAV_SEVERITY.INFO,
+                            string.format(
+                                "DIVE: IPcam frames flowing after %.1fs, lights +%ds",
+                                waited / 1000.0,
+                                math.floor(cfg.btm_dly_ms / 1000)))
+                    elseif waited >= IPCAM_FIRST_FRAME_TIMEOUT_MS then
+                        ipcam_state.cycle_awaiting_frames = false
+                        ipcam_state.cycle_start_ms        = now_ms
+                        reset_light_cycle(now_ms)
+                        gcs:send_text(MAV_SEVERITY.WARNING,
+                            string.format(
+                                "DIVE: IPcam first-frame wait timed out (%.0fs), "
+                                .. "starting light clock anyway",
+                                waited / 1000.0))
+                    end
+                end
             end
         elseif ipcam_cfg.btm_cmod == 2 then
             -- VIDEO_INTERVAL: duty-cycle record for btm_rec_ms, pause

--- a/extension/backend/src/doris/main.py
+++ b/extension/backend/src/doris/main.py
@@ -27,6 +27,7 @@ from .routes import (
     register_sensor_routes,
     register_system_routes,
 )
+from .services import ip_camera_recorder
 from .services.external_storage import start_external_storage_setup
 from .services.storage import DATA_ROOT
 from .services.usb_storage import start_usb_storage_probe
@@ -202,6 +203,16 @@ def create_app() -> Robyn:
 
         timesync_service.start_background_sync()
         start_dmesg_capture()
+
+        # Pre-warm GStreamer so the first dive recording doesn't pay the
+        # one-time ~4 s Gst.init() plugin-registry scan at bottom
+        # detection.  Run off the event loop (init blocks) and don't await
+        # it -- startup shouldn't wait on it, and recording falls back to
+        # lazy init if this hasn't finished yet.
+        try:
+            asyncio.get_event_loop().run_in_executor(None, ip_camera_recorder.prewarm)
+        except Exception as e:
+            logger.warning("GStreamer prewarm scheduling skipped: %s", e)
 
         logger.info("DORIS backend startup complete")
         asyncio.get_event_loop().create_task(_restart_autopilot(logger))

--- a/extension/backend/src/doris/services/ip_camera_recorder.py
+++ b/extension/backend/src/doris/services/ip_camera_recorder.py
@@ -130,6 +130,26 @@ def _ensure_gst_init() -> None:
             )
 
 
+def prewarm() -> None:
+    """Initialise GStreamer ahead of the first recording.
+
+    ``Gst.init`` scans the plugin registry the first time it runs, which
+    measured ~4 s on the Pi during a real dive (see the gap between
+    ``RECORD /start called`` and ``GStreamer initialized`` in doris.log).
+    Because init was previously triggered lazily inside the first
+    ``start_recording`` call, that one-time cost landed squarely on the
+    critical path at bottom detection -- delaying the moment real frames
+    hit disk and, with it, the bottom light.  Calling this at extension
+    startup moves the cost off the dive path.  Idempotent and best-effort:
+    any failure is logged and swallowed so a GStreamer hiccup can never
+    block backend startup (recording will simply re-attempt init lazily).
+    """
+    try:
+        _ensure_gst_init()
+    except Exception:
+        logger.exception("GStreamer prewarm failed (will retry lazily on first record)")
+
+
 # ── module state ───────────────────────────────────────────────────────────────
 
 _state_lock = asyncio.Lock()


### PR DESCRIPTION
## Summary

Fixes two issues reported from a field test of a continuous-video DORIS dive (run from master @ #46):

1. **Lights came on ~1 s after bottom detection instead of ~1 s after video recording actually started.**
2. **~10 s delay before recording started in continuous mode.**

Both trace to a single root cause: continuous bottom mode (`DORIS_BTM_CMOD=1`) measured the bottom-light delay (`DORIS_BTM_DLY`) from *bottom detection*, while real video doesn't start landing on disk until the RTSP connect + first-frame latency (and, on the first dive recording of a boot, a one-time ~4 s `Gst.init()` plugin-registry scan) have elapsed.

### Evidence (from the shared dive `dive_20260609_204636`)

| Time | Event | Source |
|---|---|---|
| ~20:46:36 | Bottom detected -> Lua fires `POST /rec/start` | `doris.log` |
| 20:46:40 | First-ever `Gst.init()` finishes (~4 s) + session start | `doris.log` |
| 20:46:42 | First H.264 frame on disk (`first_frame latency_s: 2.141`) | `stream_log.jsonl` |

Lights (1 s delay) lit at ~20:46:37 — about 5 s before video was actually capturing.

## Changes

- **`doris.lua`** — In continuous bottom mode, anchor the light-delay clock to *frames flowing* (held at 0 until the recorder confirms frames on disk, or a 30 s safety timeout), mirroring the first-frame gating that VIDEO_INTERVAL already uses. INTERVAL and TIMELAPSE were already correct; this brings CONTINUOUS to parity.
- **`ip_camera_recorder.py` / `main.py`** — Add `prewarm()` and call it off the event loop at startup so the first dive recording no longer pays the ~4 s `Gst.init()` cost at bottom detection. Reduces recording-start latency for all modes (remaining ~2 s is unavoidable RTSP connect/jitter).

## Notes

- The light-timing bug was **continuous-mode-only**; interval/timelapse already gated on `frames_flowing`.
- Lua param table unchanged (still 38); only block-scoped locals added, matching the existing interval branch.

## Test plan

- [ ] SITL/bench continuous-mode dive: confirm the new `DIVE: IPcam frames flowing after Xs, lights +Ys` GCS line, and that lights energize `DORIS_BTM_DLY` after that message (not after bottom detection).
- [ ] Confirm `GStreamer initialized` appears in `doris.log` at extension startup (prewarm) rather than at the first `/rec/start`.
- [ ] Regression check interval + timelapse bottom modes behave as before.
