### PR TITLE
Fix Artemis tracker tile vanishing: detect by heartbeat recency, not frequency (#55)

### DIFF
--- a/extension/backend/src/doris/services/tracker.py
+++ b/extension/backend/src/doris/services/tracker.py
@@ -68,6 +68,15 @@ TRIGGER_POST_TIMEOUT_S = 15.0  # mavlink2rest POST commonly takes 4-5s
 # truly disconnected tracker visible forever.
 TRACKER_STICKY_GRACE_S = 60.0
 
+# A HEARTBEAT is considered "live" when mavlink2rest last received it
+# within this window.  Detection is gated on message *recency*
+# (status.time.last_update age), NOT on mavlink2rest's per-message
+# frequency estimate: that estimate is a noisy EMA that sits below any
+# fixed threshold for long stretches even while the AGT heartbeats
+# steadily, which dropped the tile despite a live link (issue #55).
+# timesync.py trusts last_update age for the same component; we mirror it.
+HEARTBEAT_MAX_AGE_S = 30.0
+
 
 def _m2r_base() -> str:
     return blueos_services.mavlink2rest
@@ -92,6 +101,27 @@ def _decode_severity(raw_severity) -> int:
     if isinstance(raw_severity, int):
         return raw_severity
     return 6
+
+
+def _message_age_seconds(data: dict) -> float | None:
+    """Age of a mavlink2rest message from its ``status.time.last_update``.
+
+    Returns ``None`` when the timestamp is missing or unparseable.  Both
+    ``last_update`` and ``now`` come from the same host clock, so the
+    returned age is valid even when the absolute system clock is wrong
+    (mirrors the same helper in ``timesync.py``).
+    """
+    last_update = data.get("status", {}).get("time", {}).get("last_update")
+    if not last_update or not isinstance(last_update, str):
+        return None
+    s = last_update.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(tz=timezone.utc) - dt).total_seconds()
 
 
 class _StatusTextBuffer:
@@ -243,7 +273,21 @@ class ArtemisTrackerService:
             return None
 
     async def _get_heartbeat(self) -> dict | None:
-        """Check for a recent HEARTBEAT from the Artemis component."""
+        """Return the AGT HEARTBEAT message if one was received recently.
+
+        Presence is judged by message *recency* (``status.time.last_update``
+        age), NOT by mavlink2rest's per-message frequency estimate.  That
+        estimate is a noisy EMA that sits below any fixed threshold for
+        long stretches even while the AGT heartbeats steadily, which made
+        the tracker tile vanish despite a live link (issue #55).
+        ``timesync.py`` already trusts ``last_update`` age for the same
+        component; we mirror that here.
+
+        A stale cached HEARTBEAT (mavlink2rest keeps the last message
+        forever) is rejected once it ages past ``HEARTBEAT_MAX_AGE_S``.
+        When the timestamp is missing/unparseable we accept the message's
+        presence rather than risk a false negative (the bug being fixed).
+        """
         base = _m2r_base()
         url = f"{base}/mavlink/vehicles/1/components/{ARTEMIS_COMPONENT_ID}/messages/HEARTBEAT"
         try:
@@ -252,14 +296,19 @@ class ArtemisTrackerService:
                 return None
             resp.raise_for_status()
             data = resp.json()
-            time_info = data.get("status", {}).get("time", {})
-            freq = time_info.get("frequency", 0)
-            if freq < 0.05:
-                return None
-            return data.get("message")
         except Exception as e:
             logger.debug("No Artemis heartbeat: %s", e)
             return None
+
+        msg = data.get("message")
+        if not isinstance(msg, dict) or msg.get("type") != "HEARTBEAT":
+            return None
+
+        age = _message_age_seconds(data)
+        if age is not None and age > HEARTBEAT_MAX_AGE_S:
+            logger.debug("Artemis HEARTBEAT is stale (%.0fs old) — ignoring", age)
+            return None
+        return msg
 
     # ── STATUSTEXT subscriber ───────────────────────────────────────
 

--- a/extension/backend/tests/test_tracker.py
+++ b/extension/backend/tests/test_tracker.py
@@ -1,13 +1,22 @@
-"""Tests for Artemis tracker detection stickiness (services/tracker.py).
+"""Tests for Artemis tracker detection (services/tracker.py).
 
-Regression coverage for issue #29: the tracker tile (and the Iridium
-button on it) used to vanish whenever a single HEARTBEAT poll reported a
-low/zero frequency from mavlink2rest.  ``get_modules`` now keeps the
-tracker visible for ``TRACKER_STICKY_GRACE_S`` after the last good
-heartbeat so transient frequency dips don't drop the tile.
+Regression coverage for two issues:
+
+* #29 — the tracker tile (and the Iridium button on it) used to vanish
+  whenever a single HEARTBEAT poll reported a low/zero frequency from
+  mavlink2rest.  ``get_modules`` keeps the tracker visible for
+  ``TRACKER_STICKY_GRACE_S`` after the last good heartbeat so transient
+  dips don't drop the tile.
+* #55 — even with the grace window the tile vanished while the AGT was
+  clearly alive, because ``_get_heartbeat`` gated on mavlink2rest's
+  noisy per-message frequency estimate.  Detection now gates on message
+  *recency* (``status.time.last_update`` age), so a steadily-heartbeating
+  AGT keeps the tile up regardless of the frequency estimate.
 """
 
 from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -37,6 +46,94 @@ def _set_heartbeat(monkeypatch, svc: ArtemisTrackerService, present: bool) -> No
 
 def _set_clock(monkeypatch, value: float) -> None:
     monkeypatch.setattr(tracker_mod.time, "monotonic", lambda: value)
+
+
+# ── recency-gate (issue #55) helpers ────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code: int = 200, payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    """Minimal stand-in for httpx.AsyncClient returning a fixed response."""
+
+    def __init__(self, resp: _FakeResp) -> None:
+        self._resp = resp
+        self.is_closed = False
+
+    async def get(self, _url, *_a, **_k) -> _FakeResp:
+        return self._resp
+
+
+def _hb_payload(age_s: float = 0.0, freq: float = 0.0,
+                mtype: str = "HEARTBEAT") -> dict:
+    last = (datetime.now(timezone.utc) - timedelta(seconds=age_s)).isoformat()
+    return {
+        "message": {"type": mtype},
+        "status": {"time": {"last_update": last, "frequency": freq}},
+    }
+
+
+def _install_client(svc: ArtemisTrackerService, status_code: int = 200,
+                    payload: dict | None = None) -> None:
+    svc._client = _FakeClient(_FakeResp(status_code, payload))
+
+
+async def test_get_heartbeat_fresh_low_frequency_is_present():
+    # The core #55 regression: a fresh heartbeat with frequency well below
+    # the old 0.05 gate must still be detected.
+    s = ArtemisTrackerService()
+    _install_client(s, payload=_hb_payload(age_s=1.0, freq=0.0))
+    assert await s._get_heartbeat() is not None
+
+
+async def test_get_heartbeat_stale_message_ignored():
+    s = ArtemisTrackerService()
+    _install_client(
+        s, payload=_hb_payload(age_s=tracker_mod.HEARTBEAT_MAX_AGE_S + 30.0)
+    )
+    assert await s._get_heartbeat() is None
+
+
+async def test_get_heartbeat_404_returns_none():
+    s = ArtemisTrackerService()
+    _install_client(s, status_code=404)
+    assert await s._get_heartbeat() is None
+
+
+async def test_get_heartbeat_missing_timestamp_accepts_presence():
+    s = ArtemisTrackerService()
+    _install_client(
+        s, payload={"message": {"type": "HEARTBEAT"}, "status": {"time": {}}}
+    )
+    assert await s._get_heartbeat() is not None
+
+
+async def test_get_heartbeat_wrong_message_type_returns_none():
+    s = ArtemisTrackerService()
+    _install_client(s, payload=_hb_payload(mtype="GPS_RAW_INT"))
+    assert await s._get_heartbeat() is None
+
+
+async def test_low_frequency_heartbeat_still_shows_tile(monkeypatch):
+    # End-to-end through get_modules: a live but low-frequency heartbeat
+    # keeps the tracker tile (the field symptom in #55).
+    s = ArtemisTrackerService()
+    monkeypatch.setattr(s, "get_gps_data", _async_return(None))
+    _install_client(s, payload=_hb_payload(age_s=2.0, freq=0.0))
+    modules = await s.get_modules()
+    assert len(modules) == 1
+    assert modules[0].type == "tracker"
 
 
 async def test_present_heartbeat_shows_tracker(svc, monkeypatch):


### PR DESCRIPTION
## Summary
Fixes #55 ? the Artemis tracker tile disappeared from the Sensors page in the field even though the AGT (MAVLink component 191) was clearly alive (HEARTBEAT, GPS_INPUT, and STATUSTEXT all flowing in the dive logs).

Root cause: `ArtemisTrackerService._get_heartbeat()` gated tile presence on mavlink2rest's per-message **frequency** estimate (`freq < 0.05`). That estimate is a noisy EMA that sits below any fixed threshold for long stretches even with a steady ~1 Hz heartbeat, so the #29 60 s sticky grace never got *seeded* and the tile dropped despite a live link.

## Changes
- Detection now gates on message **recency** (`status.time.last_update` age), mirroring `timesync.py` for the same component:
  - accept any non-404 HEARTBEAT seen within `HEARTBEAT_MAX_AGE_S` (30 s),
  - reject a stale cached message past that window,
  - accept presence when the timestamp is missing/unparseable rather than risk a false negative.
- The 60 s sticky grace from #29 stays as a secondary cushion for transient mavlink2rest read failures.
- Added a `_message_age_seconds` helper (same approach as `timesync.py`).

## Test plan
- [x] `pytest tests/test_tracker.py` ? 11 passed (5 existing sticky-grace + 6 new recency-gate tests, incl. fresh-but-low-frequency keeps the tile, stale message drops it, 404 / wrong-type / missing-timestamp handling, and an end-to-end `get_modules` check).
- [x] Full backend suite: 169 passed.
- [ ] Hardware: confirm the tracker tile stays visible on the Sensors page throughout a deployment while component 191 is heartbeating.

Closes #55
